### PR TITLE
Fix setup-labels workflow: restore contents:read for checkout

### DIFF
--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read # required by actions/checkout on a private repo
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

The "Setup pipeline labels" workflow failed at the **checkout** step, not the label step:

```
remote: Repository not found.
fatal: repository '.../community-agent/' not found  (exit 128)
```

**Cause:** an explicit `permissions:` block *replaces* the default token scope. The workflow listed only `issues: write`, which dropped `contents: read`, so `actions/checkout` couldn't clone this private repo (GitHub returns 404 for private repos when the token lacks read) and the job died before running `scripts/setup-labels.sh`.

**Fix:** add `contents: read` back alongside `issues: write`.

```yaml
permissions:
  contents: read   # required by actions/checkout on a private repo
  issues: write
```

(The "Node 20 deprecated" line in the log is an unrelated cosmetic warning on the checkout action wrapper — not the failure.)

## After merge
Re-run **Actions → "Setup pipeline labels" → Run workflow**; it should create the seven labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_