### PR TITLE
Implement WhatsAppCloudAdapter against the official Meta Cloud API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,10 +41,11 @@ SUPER_ADMIN_WHATSAPP_NUMBERS=
 ACCESS_MODE_DISCORD=gated
 ACCESS_MODE_WHATSAPP=gated
 
-# --- WhatsApp Cloud API (only if WHATSAPP_PROVIDER=cloud) ------------------
+# --- WhatsApp Cloud API (required if WHATSAPP_PROVIDER=cloud) --------------
 WHATSAPP_CLOUD_PHONE_NUMBER_ID=
 WHATSAPP_CLOUD_ACCESS_TOKEN=
 WHATSAPP_CLOUD_VERIFY_TOKEN=
+WHATSAPP_CLOUD_APP_SECRET=
 WHATSAPP_CLOUD_WEBHOOK_PORT=8080
 
 # --- Database (PostgreSQL + pgvector) -------------------------------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ authenticated with a **Claude subscription** (no per-token API billing).
 | Runtime | TypeScript on Node 22+ (Node 24 LTS in production) |
 | Agent | `@anthropic-ai/claude-agent-sdk` (subscription auth) |
 | Discord | `discord.js` v14 |
-| WhatsApp | Baileys (dedicated number) — Cloud API adapter stubbed |
+| WhatsApp | Baileys (dedicated number) or the official Meta Cloud API |
 | Memory | PostgreSQL + `pgvector`, local embeddings (`transformers.js`) |
 | Service | systemd on Ubuntu |
 
@@ -65,9 +65,10 @@ basic questions. See **[docs/SECURITY.md](docs/SECURITY.md)** and
 ## Important caveats
 - **Subscription auth** is a grey area in Anthropic's SDK terms (see SECURITY.md).
   The auth layer is isolated so you can switch to an API key easily.
-- **Baileys WhatsApp** uses the unofficial protocol and violates WhatsApp ToS —
-  the number can be banned. Use a number you can afford to lose, or implement
-  the Cloud API adapter.
+- **Baileys WhatsApp** (the default) uses the unofficial protocol and violates
+  WhatsApp ToS — the number can be banned. Use a number you can afford to
+  lose, or set `WHATSAPP_PROVIDER=cloud` to use the official Meta Cloud API
+  adapter instead (see docs/ARCHITECTURE.md "Switching WhatsApp providers").
 - **Privacy**: all interactions are logged. Tell your community, and define a
   retention/deletion policy (NZ Privacy Act 2020).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ Claude-powered agent, with a Postgres-backed memory for learning.
 | `src/platforms/types.ts` | `PlatformAdapter` interface + normalised `IncomingMessage`. The seam that decouples the agent from any specific chat platform. |
 | `src/platforms/discord/adapter.ts` | discord.js client; normalises messages, resolves roles, performs moderation actions. |
 | `src/platforms/whatsapp/baileysAdapter.ts` | WhatsApp via Baileys (linked-device protocol, dedicated number). |
-| `src/platforms/whatsapp/cloudAdapter.ts` | Stub for the official Meta Cloud API — the documented upgrade path. |
+| `src/platforms/whatsapp/cloudAdapter.ts` | The official Meta Cloud API adapter — webhook intake + Graph API send, the documented upgrade path from Baileys. |
 | `src/auth/rbac.ts` | Role resolution (`admin`/`user`) + the per-role allowed-tool lists. |
 | `src/agent/core.ts` | Runs one agent turn: memory recall → prompt → `query()` → reply. |
 | `src/agent/tools.ts` | In-process MCP tools (search memory/knowledge, moderate, announce, …). |
@@ -132,10 +132,27 @@ conversation.
 ## Switching WhatsApp providers
 
 The Baileys adapter is the default (immediate, free, dedicated number, but
-against WhatsApp ToS — ban risk). To move to the official Meta **Cloud API**:
+against WhatsApp ToS — ban risk). The official Meta **Cloud API** is
+implemented as `WhatsAppCloudAdapter` and is the recommended path for any
+bot expected to run continuously:
 
-1. Implement `WhatsAppCloudAdapter` (webhook intake + Graph API send).
-2. Set `WHATSAPP_PROVIDER=cloud` and the `WHATSAPP_CLOUD_*` env vars.
+1. Set `WHATSAPP_PROVIDER=cloud` and `WHATSAPP_CLOUD_PHONE_NUMBER_ID`,
+   `WHATSAPP_CLOUD_ACCESS_TOKEN`, `WHATSAPP_CLOUD_VERIFY_TOKEN`,
+   `WHATSAPP_CLOUD_APP_SECRET`, and optionally `WHATSAPP_CLOUD_WEBHOOK_PORT`
+   (default `8080`).
+2. Point your Meta app's webhook subscription at
+   `http://<host>:<port>/` (any path — the adapter listens on all paths) with
+   the same verify token, and expose it over HTTPS via a reverse proxy (see
+   `docs/DEPLOYMENT.md`).
+
+The adapter verifies every inbound webhook's `X-Hub-Signature-256` HMAC
+against `WHATSAPP_CLOUD_APP_SECRET` before parsing the body. Because the
+Cloud API is 1:1-only (no groups), `adminCapabilities` only advertises
+`warn_user`; other moderation actions report as unsupported. Free-form
+outbound replies are only sent within Meta's 24h customer-service window
+(tracked in-process from the timestamp of the sender's last inbound
+message); sends outside that window fail with a clear error rather than
+being attempted.
 
 Nothing in `router.ts`, `agent/*`, or `storage/*` changes — they only depend on
 the `PlatformAdapter` interface.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,5 +154,10 @@ outbound replies are only sent within Meta's 24h customer-service window
 message); sends outside that window fail with a clear error rather than
 being attempted.
 
+`WHATSAPP_ALLOWED_JIDS` is shared between both adapters but each entry can be
+either a bare phone-number digit string or a full Baileys-style JID
+(`64211234567@s.whatsapp.net`) — the Cloud adapter matches against the part
+before `@`, so the same list works for either adapter without reformatting.
+
 Nothing in `router.ts`, `agent/*`, or `storage/*` changes — they only depend on
 the `PlatformAdapter` interface.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,6 +61,34 @@ A QR code prints in the terminal. On the dedicated phone:
 Wait for `WhatsApp connected`, then Ctrl-C. Credentials are saved in
 `whatsapp-auth/` and reused by the service.
 
+## 6b. (Alternative) Configure the WhatsApp Cloud API instead of Baileys
+Skip step 6 and use the official, ToS-compliant Meta Cloud API instead:
+
+1. In [Meta for Developers](https://developers.facebook.com/), create an app
+   with the **WhatsApp** product added, and note the **Phone number ID**,
+   a **temporary or permanent access token**, and the app's **App secret**
+   (App settings → Basic).
+2. In `.env`, set `WHATSAPP_PROVIDER=cloud` and fill in
+   `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`,
+   `WHATSAPP_CLOUD_APP_SECRET`, and a `WHATSAPP_CLOUD_VERIFY_TOKEN` of your
+   choosing (any random string — you'll enter the same value in Meta's
+   dashboard). `WHATSAPP_CLOUD_WEBHOOK_PORT` defaults to `8080`.
+3. Expose that port over HTTPS — Meta requires TLS for webhooks and will not
+   deliver to plain HTTP. Put a reverse proxy (nginx/Caddy) in front with a
+   real certificate, forwarding to `127.0.0.1:$WHATSAPP_CLOUD_WEBHOOK_PORT`.
+4. In the Meta app's WhatsApp → Configuration page, set the **Callback URL**
+   to your public HTTPS URL and the **Verify token** to the same
+   `WHATSAPP_CLOUD_VERIFY_TOKEN` value, then subscribe to the `messages`
+   webhook field. Meta will GET the URL to verify it — the service must
+   already be running (start it, or run step 8 first, then return here).
+5. No `whatsapp:link` step, no QR code, and no `whatsapp-auth/` directory —
+   the Cloud API is stateless on this side.
+
+Note: the Cloud API only allows free-form replies within the 24h window after
+a user messages the bot; outside that window only pre-approved message
+templates can be sent (not implemented here — the adapter fails clearly
+instead of attempting an unsupported send).
+
 ## 7. Invite the Discord bot
 In the Developer Portal, generate an OAuth2 URL with the `bot` scope and
 permissions: *Read Messages/View Channels, Send Messages, Read Message History,
@@ -95,6 +123,13 @@ tar czf whatsapp-auth-$(date +%F).tgz -C /opt/community-agent whatsapp-auth
 - **`Invalid environment configuration`** — a required env var is missing; the
   log lists which.
 - **WhatsApp keeps showing a QR / `logged out`** — re-run step 6.
+- **Meta webhook verification fails (Cloud API)** — confirm the service is
+  reachable over HTTPS at the exact Callback URL configured, and that
+  `WHATSAPP_CLOUD_VERIFY_TOKEN` matches the "Verify token" field in the Meta
+  dashboard exactly.
+- **Cloud API messages silently do nothing / 401 in logs** — the webhook's
+  `X-Hub-Signature-256` didn't match `WHATSAPP_CLOUD_APP_SECRET`; double-check
+  you copied the App secret (not the access token) from Meta's Basic settings.
 - **Discord bot silent or login fails** — check the `MessageContent` **and**
   `GuildMembers` privileged intents are on,
   the bot can see the channel, and (if set) `DISCORD_ALLOWED_CHANNEL_IDS`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -114,9 +114,23 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
 Baileys uses the unofficial WhatsApp Web protocol. This **violates WhatsApp's
 Terms of Service** and the number can be **banned** at any time, and the
 protocol can break. Mitigations: use a dedicated number you can afford to lose,
-keep volume human-like, and keep the `WhatsAppCloudAdapter` path ready to
-migrate to the official API. This is a deliberate, accepted trade-off for
-immediate, free operation — revisit it before scaling.
+keep volume human-like, or switch to `WhatsAppCloudAdapter`
+(`WHATSAPP_PROVIDER=cloud`), the official, ToS-compliant Meta Cloud API — see
+"Switching WhatsApp providers" in `docs/ARCHITECTURE.md`. Running Baileys is a
+deliberate, accepted trade-off for immediate, free operation; revisit it
+before scaling.
+
+### WhatsApp Cloud API webhook
+`WhatsAppCloudAdapter` exposes a public HTTP listener
+(`WHATSAPP_CLOUD_WEBHOOK_PORT`) that must sit behind TLS termination (see
+`docs/DEPLOYMENT.md`). Every inbound `POST` is rejected unless its
+`X-Hub-Signature-256` header verifies against `WHATSAPP_CLOUD_APP_SECRET`
+(HMAC-SHA256 over the raw body, timing-safe compare) — the body is never
+parsed before that check passes. `WHATSAPP_CLOUD_ACCESS_TOKEN` and
+`WHATSAPP_CLOUD_APP_SECRET` are secrets and must go through the same
+`.env`-only, git-ignored handling as other tokens. Message content and
+delivery metadata for Cloud API traffic are additionally retained by Meta
+per their own terms, on top of this project's own storage.
 
 ### Discord
 - Enable only the gateway intents the bot needs (Guilds, GuildMessages,

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ const EnvSchema = z.object({
   WHATSAPP_CLOUD_PHONE_NUMBER_ID: z.string().optional(),
   WHATSAPP_CLOUD_ACCESS_TOKEN: z.string().optional(),
   WHATSAPP_CLOUD_VERIFY_TOKEN: z.string().optional(),
+  WHATSAPP_CLOUD_APP_SECRET: z.string().optional(),
   WHATSAPP_CLOUD_WEBHOOK_PORT: z.coerce.number().int().positive().default(8080),
 
   // Database
@@ -58,11 +59,20 @@ const EnvSchema = z.object({
     .transform((v) => v === 'true'),
 });
 
-const EnvSchemaChecked = EnvSchema.refine((e) => e.WHATSAPP_PROVIDER !== 'cloud', {
-  message:
-    "WHATSAPP_PROVIDER=cloud is not implemented yet — use 'baileys' or 'disabled' (see src/platforms/whatsapp/cloudAdapter.ts for the upgrade path)",
-  path: ['WHATSAPP_PROVIDER'],
-});
+const EnvSchemaChecked = EnvSchema.refine(
+  (e) =>
+    e.WHATSAPP_PROVIDER !== 'cloud' ||
+    (e.WHATSAPP_CLOUD_PHONE_NUMBER_ID &&
+      e.WHATSAPP_CLOUD_ACCESS_TOKEN &&
+      e.WHATSAPP_CLOUD_VERIFY_TOKEN &&
+      e.WHATSAPP_CLOUD_APP_SECRET),
+  {
+    message:
+      'WHATSAPP_PROVIDER=cloud requires WHATSAPP_CLOUD_PHONE_NUMBER_ID, WHATSAPP_CLOUD_ACCESS_TOKEN, ' +
+      'WHATSAPP_CLOUD_VERIFY_TOKEN, and WHATSAPP_CLOUD_APP_SECRET',
+    path: ['WHATSAPP_PROVIDER'],
+  },
+);
 
 const parsed = EnvSchemaChecked.safeParse(process.env);
 if (!parsed.success) {
@@ -95,6 +105,7 @@ export const config = {
       phoneNumberId: env.WHATSAPP_CLOUD_PHONE_NUMBER_ID,
       accessToken: env.WHATSAPP_CLOUD_ACCESS_TOKEN,
       verifyToken: env.WHATSAPP_CLOUD_VERIFY_TOKEN,
+      appSecret: env.WHATSAPP_CLOUD_APP_SECRET,
       webhookPort: env.WHATSAPP_CLOUD_WEBHOOK_PORT,
     },
   },

--- a/src/platforms/whatsapp/cloudAdapter.ts
+++ b/src/platforms/whatsapp/cloudAdapter.ts
@@ -1,52 +1,248 @@
+import { createServer, type IncomingMessage as HttpRequest, type Server, type ServerResponse } from 'node:http';
+import { config } from '../../config.js';
+import { logger } from '../../logger.js';
+import { filterOutbound } from '../../agent/outbound.js';
+import { runtimeSecrets } from '../../agent/secrets.js';
+import { getCodeAnswersPolicy } from '../../storage/policies.js';
+import { extractMessages, parseVerificationRequest, verifySignature, type CloudInboundMessage } from './cloudWire.js';
 import type {
   AdminAction,
+  IncomingMessage,
   MessageHandler,
   OutgoingMessage,
   PlatformAdapter,
 } from '../types.js';
 
+const GRAPH_API_VERSION = 'v21.0';
+/** Meta webhook payloads are small JSON; this bounds memory use per request. */
+const MAX_BODY_BYTES = 1_000_000;
+/** Free-form replies are only allowed within Meta's 24h customer-service window. */
+const CUSTOMER_SERVICE_WINDOW_MS = 24 * 60 * 60_000;
+
 /**
- * Stub for the official WhatsApp Business Cloud API (Meta).
+ * WhatsApp via the official Meta Business Cloud API. ToS-compliant
+ * alternative to {@link BaileysAdapter}: no linked-device session to ban,
+ * webhook-driven, 1:1 messaging only (no group/moderation surface).
  *
- * This is intentionally unimplemented: it documents the seam so the project
- * can move off Baileys to the official, ToS-compliant API without touching the
- * agent core or router. To implement:
- *  1. Stand up an HTTPS webhook endpoint (verify with WHATSAPP_CLOUD_VERIFY_TOKEN).
- *  2. On inbound `messages` webhooks, normalise to IncomingMessage and call the handler.
- *  3. sendMessage -> POST https://graph.facebook.com/v21.0/{PHONE_NUMBER_ID}/messages.
- *  4. Map admin actions (the Cloud API has no group moderation; most will be unsupported).
- *
- * See docs/ARCHITECTURE.md "Switching WhatsApp providers".
+ * Requires WHATSAPP_CLOUD_PHONE_NUMBER_ID, _ACCESS_TOKEN, _VERIFY_TOKEN, and
+ * _APP_SECRET (see config.ts). Set WHATSAPP_PROVIDER=cloud to select it.
  */
 export class WhatsAppCloudAdapter implements PlatformAdapter {
   readonly platform = 'whatsapp' as const;
-  readonly adminCapabilities = new Set<string>([]);
+  readonly adminCapabilities = new Set(['warn_user']);
 
-  onMessage(_handler: MessageHandler): void {
-    throw new Error('WhatsAppCloudAdapter is not implemented yet. Set WHATSAPP_PROVIDER=baileys.');
+  private handler: MessageHandler | null = null;
+  private server: Server | null = null;
+  /**
+   * Last time each user sent an inbound message, tracked in-process to
+   * enforce Meta's 24h free-form messaging window. Resets on restart — a
+   * known limitation of not persisting this; see docs/DEPLOYMENT.md.
+   */
+  private readonly lastInboundAt = new Map<string, number>();
+
+  onMessage(handler: MessageHandler): void {
+    this.handler = handler;
   }
 
   async start(): Promise<void> {
-    throw new Error('WhatsAppCloudAdapter is not implemented yet. Set WHATSAPP_PROVIDER=baileys.');
+    const { phoneNumberId, accessToken, verifyToken, appSecret, webhookPort } = config.whatsapp.cloud;
+    if (!phoneNumberId || !accessToken || !verifyToken || !appSecret) {
+      throw new Error(
+        'WhatsAppCloudAdapter requires WHATSAPP_CLOUD_PHONE_NUMBER_ID, _ACCESS_TOKEN, _VERIFY_TOKEN, and _APP_SECRET',
+      );
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        this.handleRequest(req, res).catch((err) => {
+          logger.error({ err }, 'WhatsApp Cloud webhook handler failed');
+          if (!res.headersSent) res.writeHead(500).end();
+        });
+      });
+      server.once('error', reject);
+      server.listen(webhookPort, () => {
+        server.off('error', reject);
+        resolve();
+      });
+      this.server = server;
+    });
+    logger.info({ port: webhookPort }, 'WhatsApp Cloud webhook listening');
   }
 
   async stop(): Promise<void> {
-    /* nothing to do */
+    const server = this.server;
+    this.server = null;
+    if (!server) return;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 
-  async sendMessage(_out: OutgoingMessage): Promise<void> {
-    throw new Error('WhatsAppCloudAdapter.sendMessage not implemented.');
+  private async handleRequest(req: HttpRequest, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    if (req.method === 'GET') {
+      this.handleVerification(url, res);
+      return;
+    }
+    if (req.method === 'POST') {
+      await this.handleWebhook(req, res);
+      return;
+    }
+    res.writeHead(405).end();
   }
 
-  async sendDirectMessage(_userId: string, _text: string): Promise<void> {
-    throw new Error('WhatsAppCloudAdapter.sendDirectMessage not implemented.');
+  private handleVerification(url: URL, res: ServerResponse): void {
+    const verification = parseVerificationRequest(url);
+    const { verifyToken } = config.whatsapp.cloud;
+    if (verification && verification.mode === 'subscribe' && verification.token === verifyToken) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' }).end(verification.challenge);
+      return;
+    }
+    logger.warn('Rejected WhatsApp Cloud webhook verification request');
+    res.writeHead(403).end();
   }
 
-  async conversationsForUser(_userId: string): Promise<string[]> {
-    throw new Error('WhatsAppCloudAdapter.conversationsForUser not implemented.');
+  private async handleWebhook(req: HttpRequest, res: ServerResponse): Promise<void> {
+    let rawBody: Buffer;
+    try {
+      rawBody = await readBody(req);
+    } catch (err) {
+      logger.warn({ err }, 'WhatsApp Cloud webhook: failed to read body');
+      res.writeHead(413).end();
+      return;
+    }
+
+    const { appSecret } = config.whatsapp.cloud;
+    const signature = req.headers['x-hub-signature-256'];
+    if (!verifySignature(rawBody, typeof signature === 'string' ? signature : undefined, appSecret ?? '')) {
+      logger.warn('Rejected WhatsApp Cloud webhook: signature verification failed');
+      res.writeHead(401).end();
+      return;
+    }
+
+    // Ack immediately — Meta requires a <5s response or it retries/disables
+    // the subscription; message handling continues asynchronously below.
+    res.writeHead(200).end();
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody.toString('utf8'));
+    } catch (err) {
+      logger.warn({ err }, 'WhatsApp Cloud webhook: invalid JSON body');
+      return;
+    }
+
+    for (const msg of extractMessages(payload)) {
+      await this.onCloudMessage(msg).catch((err) =>
+        logger.error({ err }, 'WhatsApp Cloud message handling failed'),
+      );
+    }
   }
 
-  async performAdminAction(_action: AdminAction): Promise<string> {
-    throw new Error('WhatsAppCloudAdapter.performAdminAction not implemented.');
+  private async onCloudMessage(msg: CloudInboundMessage): Promise<void> {
+    this.lastInboundAt.set(msg.from, Date.now());
+    if (!this.handler) return;
+    if (config.whatsapp.allowedJids.length > 0 && !config.whatsapp.allowedJids.includes(msg.from)) {
+      return;
+    }
+
+    const normalised: IncomingMessage = {
+      platform: 'whatsapp',
+      conversationId: msg.from,
+      userId: msg.from,
+      userName: msg.name || msg.from,
+      text: msg.text,
+      isDirect: true,
+      addressedToBot: true,
+      timestamp: msg.timestampMs,
+      raw: msg,
+    };
+    await this.handler(normalised);
   }
+
+  /**
+   * Every outbound path is filtered HERE (secret redaction + code policy) so
+   * no caller — router reply, announce, warn, super-admin alert — can forget.
+   */
+  private async filtered(text: string): Promise<string> {
+    return filterOutbound(text, await getCodeAnswersPolicy(), runtimeSecrets());
+  }
+
+  async sendMessage(out: OutgoingMessage): Promise<void> {
+    await this.sendText(out.conversationId, out.text);
+  }
+
+  async sendDirectMessage(userId: string, text: string): Promise<void> {
+    await this.sendText(userId, text);
+  }
+
+  private async sendText(to: string, text: string): Promise<void> {
+    const { phoneNumberId, accessToken } = config.whatsapp.cloud;
+    if (!phoneNumberId || !accessToken) throw new Error('WhatsApp Cloud adapter not configured');
+
+    const lastInbound = this.lastInboundAt.get(to);
+    const withinWindow = lastInbound !== undefined && Date.now() - lastInbound < CUSTOMER_SERVICE_WINDOW_MS;
+    if (!withinWindow) {
+      throw new Error(
+        `Cannot send free-form WhatsApp message to ${to}: outside the 24h customer-service window ` +
+          '(no recent inbound message from this user). Only pre-approved message templates can be sent here.',
+      );
+    }
+
+    const body = await this.filtered(text);
+    const res = await fetch(`https://graph.facebook.com/${GRAPH_API_VERSION}/${phoneNumberId}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to,
+        type: 'text',
+        text: { body },
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`WhatsApp Cloud send failed: ${res.status} ${detail}`);
+    }
+  }
+
+  /** No groups on the Cloud API — a user's only conversation is their 1:1 with the bot. */
+  async conversationsForUser(userId: string): Promise<string[]> {
+    return [userId];
+  }
+
+  async performAdminAction(action: AdminAction): Promise<string> {
+    switch (action.kind) {
+      case 'warn_user': {
+        await this.sendDirectMessage(
+          action.targetUserId ?? '',
+          `⚠️ Warning from NZ Claude Community: ${action.params?.reason ?? ''}`,
+        );
+        return `Warned ${action.targetUserId}.`;
+      }
+      default:
+        throw new Error(
+          `Unsupported WhatsApp Cloud action: ${action.kind} (the Cloud API has no group/moderation surface).`,
+        );
+    }
+  }
+}
+
+function readBody(req: HttpRequest): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('WhatsApp Cloud webhook body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
 }

--- a/src/platforms/whatsapp/cloudAdapter.ts
+++ b/src/platforms/whatsapp/cloudAdapter.ts
@@ -4,7 +4,13 @@ import { logger } from '../../logger.js';
 import { filterOutbound } from '../../agent/outbound.js';
 import { runtimeSecrets } from '../../agent/secrets.js';
 import { getCodeAnswersPolicy } from '../../storage/policies.js';
-import { extractMessages, parseVerificationRequest, verifySignature, type CloudInboundMessage } from './cloudWire.js';
+import {
+  extractMessages,
+  isAllowedSender,
+  parseVerificationRequest,
+  verifySignature,
+  type CloudInboundMessage,
+} from './cloudWire.js';
 import type {
   AdminAction,
   IncomingMessage,
@@ -18,6 +24,8 @@ const GRAPH_API_VERSION = 'v21.0';
 const MAX_BODY_BYTES = 1_000_000;
 /** Free-form replies are only allowed within Meta's 24h customer-service window. */
 const CUSTOMER_SERVICE_WINDOW_MS = 24 * 60 * 60_000;
+/** How often to prune `lastInboundAt` entries older than the window, so long-running processes don't grow it forever. */
+const LAST_INBOUND_SWEEP_MS = 60 * 60_000;
 
 /**
  * WhatsApp via the official Meta Business Cloud API. ToS-compliant
@@ -33,10 +41,13 @@ export class WhatsAppCloudAdapter implements PlatformAdapter {
 
   private handler: MessageHandler | null = null;
   private server: Server | null = null;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
   /**
    * Last time each user sent an inbound message, tracked in-process to
    * enforce Meta's 24h free-form messaging window. Resets on restart — a
-   * known limitation of not persisting this; see docs/DEPLOYMENT.md.
+   * known limitation of not persisting this; see docs/DEPLOYMENT.md. Swept
+   * periodically (see `sweepTimer`) so a busy, long-running deployment
+   * doesn't grow this map forever.
    */
   private readonly lastInboundAt = new Map<string, number>();
 
@@ -66,14 +77,28 @@ export class WhatsAppCloudAdapter implements PlatformAdapter {
       });
       this.server = server;
     });
+    this.sweepTimer = setInterval(() => this.sweepLastInboundAt(), LAST_INBOUND_SWEEP_MS);
+    this.sweepTimer.unref?.();
     logger.info({ port: webhookPort }, 'WhatsApp Cloud webhook listening');
   }
 
   async stop(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
     const server = this.server;
     this.server = null;
     if (!server) return;
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  /** Drop tracked senders whose last inbound message has aged out of the 24h window. */
+  private sweepLastInboundAt(): void {
+    const cutoff = Date.now() - CUSTOMER_SERVICE_WINDOW_MS;
+    for (const [from, lastInbound] of this.lastInboundAt) {
+      if (lastInbound < cutoff) this.lastInboundAt.delete(from);
+    }
   }
 
   private async handleRequest(req: HttpRequest, res: ServerResponse): Promise<void> {
@@ -140,9 +165,7 @@ export class WhatsAppCloudAdapter implements PlatformAdapter {
   private async onCloudMessage(msg: CloudInboundMessage): Promise<void> {
     this.lastInboundAt.set(msg.from, Date.now());
     if (!this.handler) return;
-    if (config.whatsapp.allowedJids.length > 0 && !config.whatsapp.allowedJids.includes(msg.from)) {
-      return;
-    }
+    if (!isAllowedSender(msg.from, config.whatsapp.allowedJids)) return;
 
     const normalised: IncomingMessage = {
       platform: 'whatsapp',

--- a/src/platforms/whatsapp/cloudWire.ts
+++ b/src/platforms/whatsapp/cloudWire.ts
@@ -1,0 +1,114 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Pure helpers for the WhatsApp Business Cloud API webhook wire format
+ * (signature verification, verification handshake, inbound payload
+ * normalisation). Kept free of config/HTTP imports so they are unit-testable.
+ */
+
+/**
+ * Verify Meta's `X-Hub-Signature-256` header against the raw request body.
+ * MUST be checked before the body is parsed or acted on in any way — this is
+ * the Cloud API's substitute for Baileys' transport trust.
+ */
+export function verifySignature(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  appSecret: string,
+): boolean {
+  if (!signatureHeader || !appSecret) return false;
+  const prefix = 'sha256=';
+  if (!signatureHeader.startsWith(prefix)) return false;
+  const expectedHex = signatureHeader.slice(prefix.length);
+  if (!/^[0-9a-f]+$/i.test(expectedHex)) return false;
+
+  const computed = createHmac('sha256', appSecret).update(rawBody).digest();
+  const expected = Buffer.from(expectedHex, 'hex');
+  if (expected.length !== computed.length) return false;
+  return timingSafeEqual(expected, computed);
+}
+
+export interface WebhookVerification {
+  mode: string;
+  token: string;
+  challenge: string;
+}
+
+/** Parse the `hub.mode`/`hub.verify_token`/`hub.challenge` GET handshake. */
+export function parseVerificationRequest(url: URL): WebhookVerification | null {
+  const mode = url.searchParams.get('hub.mode');
+  const token = url.searchParams.get('hub.verify_token');
+  const challenge = url.searchParams.get('hub.challenge');
+  if (!mode || !token || !challenge) return null;
+  return { mode, token, challenge };
+}
+
+export interface CloudInboundMessage {
+  /** Sender's phone number (E.164 digits, no '+'). */
+  from: string;
+  id: string;
+  timestampMs: number;
+  text: string;
+  name: string;
+}
+
+interface MetaContact {
+  profile?: { name?: string };
+  wa_id?: string;
+}
+interface MetaMessage {
+  from?: string;
+  id?: string;
+  timestamp?: string;
+  type?: string;
+  text?: { body?: string };
+}
+interface MetaValue {
+  contacts?: MetaContact[];
+  messages?: MetaMessage[];
+}
+interface MetaChange {
+  value?: MetaValue;
+}
+interface MetaEntry {
+  changes?: MetaChange[];
+}
+interface MetaPayload {
+  object?: string;
+  entry?: MetaEntry[];
+}
+
+/**
+ * Normalise a Meta `messages` webhook payload into inbound text messages.
+ * Non-text message types (image/audio/status/etc.) and malformed entries are
+ * silently skipped — only well-formed text messages are actionable here.
+ */
+export function extractMessages(payload: unknown): CloudInboundMessage[] {
+  const out: CloudInboundMessage[] = [];
+  const body = payload as MetaPayload;
+  if (body?.object !== 'whatsapp_business_account' || !Array.isArray(body.entry)) return out;
+
+  for (const entry of body.entry) {
+    for (const change of entry.changes ?? []) {
+      const value = change.value;
+      if (!value || !Array.isArray(value.messages)) continue;
+
+      const nameByWaId = new Map<string, string>();
+      for (const contact of value.contacts ?? []) {
+        if (contact.wa_id) nameByWaId.set(contact.wa_id, contact.profile?.name ?? '');
+      }
+
+      for (const msg of value.messages) {
+        if (msg.type !== 'text' || !msg.from || !msg.id || typeof msg.text?.body !== 'string') continue;
+        out.push({
+          from: msg.from,
+          id: msg.id,
+          timestampMs: Number(msg.timestamp ?? 0) * 1000,
+          text: msg.text.body,
+          name: nameByWaId.get(msg.from) ?? '',
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/src/platforms/whatsapp/cloudWire.ts
+++ b/src/platforms/whatsapp/cloudWire.ts
@@ -43,6 +43,18 @@ export function parseVerificationRequest(url: URL): WebhookVerification | null {
   return { mode, token, challenge };
 }
 
+/**
+ * Check a bare phone-number digit string (a Cloud API sender id) against
+ * `WHATSAPP_ALLOWED_JIDS`. That list is shared with BaileysAdapter, whose
+ * entries are full JIDs ('64211234567@s.whatsapp.net', '...@g.us') rather
+ * than bare digits — normalise by stripping everything from '@' onward so
+ * either format works, instead of silently never matching.
+ */
+export function isAllowedSender(from: string, allowedJids: readonly string[]): boolean {
+  if (allowedJids.length === 0) return true;
+  return allowedJids.some((entry) => entry.split('@')[0] === from);
+}
+
 export interface CloudInboundMessage {
   /** Sender's phone number (E.164 digits, no '+'). */
   from: string;

--- a/tests/whatsappCloudWire.test.ts
+++ b/tests/whatsappCloudWire.test.ts
@@ -1,7 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHmac } from 'node:crypto';
-import { extractMessages, parseVerificationRequest, verifySignature } from '../src/platforms/whatsapp/cloudWire.js';
+import {
+  extractMessages,
+  isAllowedSender,
+  parseVerificationRequest,
+  verifySignature,
+} from '../src/platforms/whatsapp/cloudWire.js';
 
 function sign(body: string, secret: string): string {
   return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
@@ -106,6 +111,25 @@ test('extractMessages: missing contact profile falls back to empty name', () => 
   assert.deepEqual(extractMessages(payload), [
     { from: '64211234567', id: 'wamid.1', timestampMs: 1700000000000, text: 'hi', name: '' },
   ]);
+});
+
+test('isAllowedSender: empty allowlist admits everyone', () => {
+  assert.equal(isAllowedSender('64211234567', []), true);
+});
+
+test('isAllowedSender: matches a bare-digit entry', () => {
+  assert.equal(isAllowedSender('64211234567', ['64211234567']), true);
+  assert.equal(isAllowedSender('64299999999', ['64211234567']), false);
+});
+
+test('SECURITY: isAllowedSender matches a full Baileys-style JID entry (shared WHATSAPP_ALLOWED_JIDS config)', () => {
+  // The allowlist is shared with BaileysAdapter, whose entries are full JIDs
+  // ('...@s.whatsapp.net', '...@g.us') rather than bare digits — an operator
+  // reusing the same list for the Cloud adapter must not be silently locked
+  // out because the formats don't match.
+  assert.equal(isAllowedSender('64211234567', ['64211234567@s.whatsapp.net']), true);
+  assert.equal(isAllowedSender('64211234567', ['999@g.us', '64211234567@s.whatsapp.net']), true);
+  assert.equal(isAllowedSender('64299999999', ['64211234567@s.whatsapp.net']), false);
 });
 
 test('extractMessages: malformed or unrelated payloads yield an empty array', () => {

--- a/tests/whatsappCloudWire.test.ts
+++ b/tests/whatsappCloudWire.test.ts
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { extractMessages, parseVerificationRequest, verifySignature } from '../src/platforms/whatsapp/cloudWire.js';
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+test('verifySignature: valid signature over the exact raw body', () => {
+  const body = Buffer.from('{"object":"whatsapp_business_account"}');
+  const secret = 'app-secret';
+  assert.equal(verifySignature(body, sign(body.toString(), secret), secret), true);
+});
+
+test('SECURITY: verifySignature rejects a mismatched signature', () => {
+  const body = Buffer.from('{"a":1}');
+  const secret = 'app-secret';
+  const wrongSig = sign('{"a":2}', secret);
+  assert.equal(verifySignature(body, wrongSig, secret), false);
+});
+
+test('SECURITY: verifySignature rejects a signature computed with the wrong secret', () => {
+  const body = Buffer.from('{"a":1}');
+  assert.equal(verifySignature(body, sign('{"a":1}', 'wrong-secret'), 'app-secret'), false);
+});
+
+test('SECURITY: verifySignature rejects missing header, missing secret, and malformed prefixes', () => {
+  const body = Buffer.from('{"a":1}');
+  assert.equal(verifySignature(body, undefined, 'app-secret'), false);
+  assert.equal(verifySignature(body, sign('{"a":1}', 'app-secret'), ''), false);
+  assert.equal(verifySignature(body, 'not-a-real-signature', 'app-secret'), false);
+  assert.equal(verifySignature(body, 'sha256=not-hex!!', 'app-secret'), false);
+});
+
+test('SECURITY: verifySignature rejects a hex signature of the wrong length', () => {
+  const body = Buffer.from('{"a":1}');
+  assert.equal(verifySignature(body, 'sha256=deadbeef', 'app-secret'), false);
+});
+
+test('parseVerificationRequest: valid Meta handshake', () => {
+  const url = new URL('http://localhost/webhook?hub.mode=subscribe&hub.verify_token=tok&hub.challenge=1234');
+  assert.deepEqual(parseVerificationRequest(url), { mode: 'subscribe', token: 'tok', challenge: '1234' });
+});
+
+test('parseVerificationRequest: missing params yields null', () => {
+  assert.equal(parseVerificationRequest(new URL('http://localhost/webhook?hub.mode=subscribe')), null);
+  assert.equal(parseVerificationRequest(new URL('http://localhost/webhook')), null);
+});
+
+test('extractMessages: normalises a well-formed text message', () => {
+  const payload = {
+    object: 'whatsapp_business_account',
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              contacts: [{ profile: { name: 'Jamie' }, wa_id: '64211234567' }],
+              messages: [
+                { from: '64211234567', id: 'wamid.1', timestamp: '1700000000', type: 'text', text: { body: 'kia ora' } },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(extractMessages(payload), [
+    { from: '64211234567', id: 'wamid.1', timestampMs: 1700000000000, text: 'kia ora', name: 'Jamie' },
+  ]);
+});
+
+test('extractMessages: ignores non-text message types (image, status updates, etc)', () => {
+  const payload = {
+    object: 'whatsapp_business_account',
+    entry: [
+      {
+        changes: [
+          { value: { messages: [{ from: '64211234567', id: 'wamid.1', type: 'image', timestamp: '1' }] } },
+          { value: { statuses: [{ id: 'wamid.2', status: 'delivered' }] } },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(extractMessages(payload), []);
+});
+
+test('extractMessages: missing contact profile falls back to empty name', () => {
+  const payload = {
+    object: 'whatsapp_business_account',
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              messages: [
+                { from: '64211234567', id: 'wamid.1', timestamp: '1700000000', type: 'text', text: { body: 'hi' } },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(extractMessages(payload), [
+    { from: '64211234567', id: 'wamid.1', timestampMs: 1700000000000, text: 'hi', name: '' },
+  ]);
+});
+
+test('extractMessages: malformed or unrelated payloads yield an empty array', () => {
+  assert.deepEqual(extractMessages(null), []);
+  assert.deepEqual(extractMessages({}), []);
+  assert.deepEqual(extractMessages({ object: 'page' }), []);
+  assert.deepEqual(extractMessages({ object: 'whatsapp_business_account' }), []);
+  assert.deepEqual(extractMessages({ object: 'whatsapp_business_account', entry: 'not-an-array' }), []);
+});


### PR DESCRIPTION
Closes #4

## Summary

Replaces the `WhatsAppCloudAdapter` stub (`src/platforms/whatsapp/cloudAdapter.ts`) with a real implementation against the official WhatsApp Business Cloud API, giving self-hosters a ToS-compliant alternative to `BaileysAdapter` (which uses the unofficial linked-device protocol and risks a number ban).

- **Webhook intake** via a `node:http` server (no new dependency needed — Node 22's built-in `fetch`/`http`/`crypto` cover everything):
  - `GET` — verification handshake (`hub.mode`/`hub.verify_token`/`hub.challenge`) against `WHATSAPP_CLOUD_VERIFY_TOKEN`.
  - `POST` — verifies `X-Hub-Signature-256` (HMAC-SHA256 over the raw body) against `WHATSAPP_CLOUD_APP_SECRET` **before** parsing anything, then acks `200` immediately (Meta requires <5s) and normalises text messages into the same `IncomingMessage` shape Baileys produces, handed to the same router/agent path unmodified.
  - Pure parsing/verification logic lives in a new `src/platforms/whatsapp/cloudWire.ts` (mirrors the existing `wire.ts` pattern), kept free of HTTP/config imports so it's directly unit-testable.
- **Outbound** — `sendMessage`/`sendDirectMessage` POST to the Graph API (`v21.0`), routed through the same `filterOutbound` secret-redaction/code-policy path every other adapter uses. Free-form sends are only attempted within Meta's 24h customer-service window, tracked in-process from each sender's last inbound message; outside that window the send fails immediately with a clear error instead of attempting (and getting rejected by) an unsupported free-form message.
- **Admin actions** — the Cloud API has no group/moderation concept, so `adminCapabilities` only advertises `warn_user` (DM-based). `performAdminAction` throws a clear "unsupported" error for anything else, and the existing `moderate` tool already gates on `adminCapabilities.has(...)` before ever calling it, so an admin gets a clean "not supported on this platform" message rather than a throw.
- **Config** — added `WHATSAPP_CLOUD_APP_SECRET` (needed for webhook signature verification, previously missing from the schema) and removed the hard block on `WHATSAPP_PROVIDER=cloud`, replacing it with a `zod` refine requiring all four `WHATSAPP_CLOUD_*` vars when `cloud` is selected. No changes to `router.ts`, `agent/*`, or `storage/*` — purely additive behind the existing `PlatformAdapter` interface, matching the design already documented in `docs/ARCHITECTURE.md`.
- **Docs** — updated `README.md`, `docs/ARCHITECTURE.md` ("Switching WhatsApp providers"), `docs/SECURITY.md` (new webhook-security subsection), `docs/DEPLOYMENT.md` (new "Configure the WhatsApp Cloud API instead of Baileys" section + troubleshooting entries), and `.env.example`.

## Security impact

- New public HTTP surface (the webhook listener) is scoped tightly: every `POST` is rejected with `401` unless its HMAC-SHA256 signature verifies against `WHATSAPP_CLOUD_APP_SECRET`, checked before the body is ever parsed. The GET handshake requires an exact `WHATSAPP_CLOUD_VERIFY_TOKEN` match or returns `403`.
- No RBAC, memory, or outbound-filtering changes — inbound Cloud API messages normalise into the same `IncomingMessage` the router already gates/audits/rate-limits; outbound sends go through the same `filterOutbound` (secret redaction + code policy) as Baileys/Discord.
- `WHATSAPP_CLOUD_ACCESS_TOKEN` and `WHATSAPP_CLOUD_APP_SECRET` are new secrets, handled the same `.env`-only, git-ignored way as existing tokens (documented in `docs/SECURITY.md`).
- Admin data scoping is unaffected: `conversationsForUser` returns only the caller's own 1:1 (no groups exist on this API), so admin actions can't be scoped to conversations they don't participate in.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 50/50 passing, including a new `tests/whatsappCloudWire.test.ts` covering: valid/invalid/missing webhook signatures (wrong signature, wrong secret, malformed prefix, wrong-length hex — all `SECURITY:`-prefixed), the verification handshake, and payload normalisation (well-formed text messages, non-text/status payloads ignored, malformed payloads yield `[]`).
- `npm run build` — clean.
- Manual smoke test of the live HTTP server (via `dist/`, not just unit tests): verified the `GET` handshake returns `200` + echoes the challenge on a correct token and `403` on a wrong one; a signed `POST` webhook is normalised and delivered to the message handler correctly; an unsigned/badly-signed `POST` is rejected `401` before parsing; `sendMessage` to a recently-messaged user correctly attempts the real Graph API call; `sendMessage` to a user outside the 24h window fails immediately with a clear error instead of attempting the send.
- Not exercised against a live Meta Business account/real webhook subscription (would require Meta app credentials); the above smoke test exercises the full request/response path against a mocked payload with a real HMAC signature.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbSqwjMCuFL6rRnzCC14Qw)_