### PR TITLE
Add knowledge curation tools: list, update, delete

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,10 @@ memory**:
    (never the system prompt — see SECURITY.md on prompt injection).
 3. The `remember_search` / `knowledge_search` tools let the model query memory
    on demand mid-turn. Cross-conversation search is admin-only.
-4. Admins can promote durable facts into `knowledge` via `save_knowledge`.
+4. Admins can promote durable facts into `knowledge` via `save_knowledge`, and
+   curate existing entries with `list_knowledge` (browse by scope),
+   `update_knowledge` (correct + re-embed), and `delete_knowledge` (retire,
+   CONFIRM-gated).
 
 Conversation continuity uses the Agent SDK's session resume: the Claude
 `session_id` for each `(platform, conversation)` is stored in `sessions` and
@@ -102,6 +105,7 @@ and every privileged action is audited and alerted to super admins by DM.
 | Search memory (own conversation), knowledge, `forget_me` | ❌ | ✅ | ✅ | ✅ |
 | Memory/history across conversations | ❌ | ❌ | ✅ *their conversations* | ✅ all |
 | `moderate` / `announce` | ❌ | ❌ | ✅ *their conversations*, confirm-gated | ✅ anywhere |
+| `save_knowledge` / `list_knowledge` / `update_knowledge` / `delete_knowledge` | ❌ | ❌ | ✅, delete confirm-gated | ✅ |
 | `add_member` / `remove_member` | ❌ | ❌ | ✅ (member tier only) | ✅ |
 | Web search & summarise (`WebSearch`; `WebFetch` never) | ❌ | ❌ | ✅ | ✅ |
 | `grant_admin` / `revoke_admin`, `purge_user_data`, `audit_view`, `usage_stats`, `pause_bot`, `set_policy` | ❌ | ❌ | ❌ | ✅ |

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -5,9 +5,11 @@ import { assertAtLeast, type CallerContext } from '../auth/rbac.js';
 import { isSuperAdmin, superAdminIds } from '../auth/roles.js';
 import { logger } from '../logger.js';
 import {
+  deleteKnowledge,
   demoteAdmin,
   isKnownConversation,
   isKnownUser,
+  listKnowledge,
   purgeUserData,
   recentAuditEntries,
   recordAdminAction,
@@ -15,6 +17,7 @@ import {
   saveKnowledge,
   searchKnowledge,
   searchMemory,
+  updateKnowledge,
   upsertMember,
   usageStats,
   userMessages,
@@ -372,6 +375,83 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     },
   );
 
+  const listKnowledgeTool = tool(
+    'list_knowledge',
+    'Browse curated community knowledge entries directly (not semantic search) — for finding an entry to correct or retire. Admin only.',
+    {
+      scope: z.string().optional().describe('Filter to a scope (e.g. "global", a platform, or a conversation id)'),
+      limit: z.number().optional().describe('Max entries (default 20)'),
+      offset: z.number().optional().describe('Pagination offset (default 0)'),
+    },
+    async (args) => {
+      assertAtLeast(caller.role, 'admin', 'list_knowledge');
+      const entries = await listKnowledge({ scope: args.scope, limit: args.limit, offset: args.offset });
+      if (entries.length === 0) return text('No knowledge entries found.');
+      return text(
+        untrusted(
+          'Knowledge entries',
+          entries
+            .map(
+              (e) =>
+                `#${e.id} [${e.scope}] ${e.title ? `${e.title}: ` : ''}${e.content.slice(0, 200)} (updated ${e.updatedAt.toISOString()})`,
+            )
+            .join('\n'),
+        ),
+      );
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const updateKnowledgeTool = tool(
+    'update_knowledge',
+    'Correct an existing knowledge entry (title/content/scope). Re-embeds the content. Admin only.',
+    {
+      id: z.number().describe('Knowledge entry id (from list_knowledge or knowledge_search)'),
+      title: z.string().optional().describe('New title; omit to leave unchanged'),
+      content: z.string().optional().describe('New content; omit to leave unchanged'),
+      scope: z.string().optional().describe('New scope; omit to leave unchanged'),
+    },
+    async (args) => {
+      assertAtLeast(caller.role, 'admin', 'update_knowledge');
+      const { success, result } = await audited({
+        actionKind: 'update_knowledge',
+        params: { id: args.id, title: args.title, content: args.content, scope: args.scope },
+        run: async () => {
+          const updated = await updateKnowledge({
+            id: args.id,
+            title: args.title,
+            content: args.content,
+            scope: args.scope,
+          });
+          if (!updated) throw new Error(`No knowledge entry with id ${args.id}.`);
+          return 'updated';
+        },
+      });
+      return text(success ? `Updated knowledge entry #${args.id}.` : `Failed: ${result}`, !success);
+    },
+  );
+
+  const deleteKnowledgeTool = tool(
+    'delete_knowledge',
+    'Retire (permanently delete) a knowledge entry that is no longer accurate. Requires confirmation. Admin only.',
+    { id: z.number().describe('Knowledge entry id (from list_knowledge or knowledge_search)') },
+    async (args) => {
+      assertAtLeast(caller.role, 'admin', 'delete_knowledge');
+      return requireConfirm(`delete knowledge entry #${args.id}`, 'admin', async () => {
+        const { success, result } = await audited({
+          actionKind: 'delete_knowledge',
+          params: { id: args.id },
+          run: async () => {
+            const deleted = await deleteKnowledge(args.id);
+            if (!deleted) throw new Error(`No knowledge entry with id ${args.id}.`);
+            return 'deleted';
+          },
+        });
+        return success ? `Deleted knowledge entry #${args.id}.` : `Failed: ${result}`;
+      });
+    },
+  );
+
   const addMember = tool(
     'add_member',
     'Register a user as a community member so the bot will talk to them (gated mode). Admin only; grants member tier only.',
@@ -598,6 +678,9 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
       moderate,
       announce,
       saveKnowledgeTool,
+      listKnowledgeTool,
+      updateKnowledgeTool,
+      deleteKnowledgeTool,
       addMember,
       removeMemberTool,
       grantAdmin,

--- a/src/auth/rbac.ts
+++ b/src/auth/rbac.ts
@@ -53,6 +53,9 @@ export const ADMIN_TOOLS = [
   'mcp__community__moderate',
   'mcp__community__announce',
   'mcp__community__save_knowledge',
+  'mcp__community__list_knowledge',
+  'mcp__community__update_knowledge',
+  'mcp__community__delete_knowledge',
   'mcp__community__add_member',
   'mcp__community__remove_member',
 ] as const;

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -332,6 +332,84 @@ export async function searchKnowledge(query: string, topK = 5): Promise<Array<{ 
   return rows.map((r) => ({ title: r.title, content: r.content, similarity: Number(r.similarity) }));
 }
 
+export interface KnowledgeEntry {
+  id: number;
+  scope: string;
+  title: string | null;
+  content: string;
+  createdByRole: string;
+  updatedAt: Date;
+}
+
+/** Browse knowledge entries directly (as opposed to semantic search), optionally filtered by scope. */
+export async function listKnowledge(input: { scope?: string; limit?: number; offset?: number } = {}): Promise<
+  KnowledgeEntry[]
+> {
+  const params: unknown[] = [];
+  let scopeClause = '';
+  if (input.scope) {
+    params.push(input.scope);
+    scopeClause = `WHERE scope = $${params.length}`;
+  }
+  params.push(input.limit ?? 20);
+  const limitParam = params.length;
+  params.push(input.offset ?? 0);
+  const { rows } = await pool.query(
+    `SELECT id, scope, title, content, created_by_role, updated_at
+       FROM knowledge
+       ${scopeClause}
+      ORDER BY updated_at DESC
+      LIMIT $${limitParam} OFFSET $${params.length}`,
+    params,
+  );
+  return rows.map((r) => ({
+    id: Number(r.id),
+    scope: r.scope,
+    title: r.title,
+    content: r.content,
+    createdByRole: r.created_by_role,
+    updatedAt: r.updated_at,
+  }));
+}
+
+/** Update a knowledge entry's title/content/scope and re-embed. Returns false if no row matched. */
+export async function updateKnowledge(input: {
+  id: number;
+  title?: string;
+  content?: string;
+  scope?: string;
+}): Promise<boolean> {
+  const { rows: existingRows } = await pool.query(
+    `SELECT title, content FROM knowledge WHERE id = $1`,
+    [input.id],
+  );
+  if (existingRows.length === 0) return false;
+
+  const title = input.title !== undefined ? input.title : existingRows[0].title;
+  const content = input.content !== undefined ? input.content : existingRows[0].content;
+
+  let embedding: number[] | null = null;
+  try {
+    embedding = await embed(title ? `${title}\n${content}` : content);
+  } catch (err) {
+    logger.warn({ err }, 'Embedding failed for knowledge update');
+  }
+
+  const { rowCount } = await pool.query(
+    `UPDATE knowledge
+        SET title = $2, content = $3, scope = COALESCE($4, scope), embedding = COALESCE($5, embedding)
+      WHERE id = $1`,
+    [input.id, title ?? null, content, input.scope ?? null, embedding ? pgvector.toSql(embedding) : null],
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+/** Delete a knowledge entry by id. Returns false if no row matched. */
+export async function deleteKnowledge(id: number): Promise<boolean> {
+  const { rowCount } = await pool.query(`DELETE FROM knowledge WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+}
+
 // --- Membership (three-tier RBAC) -------------------------------------------
 
 export type StoredRole = 'admin' | 'member';


### PR DESCRIPTION
Closes #5

## Summary

Rounds out the knowledge lifecycle. Previously `save_knowledge` could only *add* an entry and `knowledge_search` could semantically search it — there was no way to browse, correct, or retire an entry without going around the bot and running raw SQL against production Postgres.

- **`listKnowledge` / `updateKnowledge` / `deleteKnowledge`** (`src/storage/repository.ts`) — new repository functions:
  - `listKnowledge({ scope?, limit?, offset? })` — paginated, `ORDER BY updated_at DESC`, optional scope filter. Lets an admin see everything stored, including entries semantic search might not surface for a given query.
  - `updateKnowledge({ id, title?, content?, scope? })` — partial update (each field optional, unspecified fields keep their current value), re-embeds using the same `title\ncontent` convention as `saveKnowledge`, and relies on the schema's existing `updated_at` trigger (previously dead code — nothing ever updated a row before this).
  - `deleteKnowledge(id)` — straightforward delete by id; returns `false` if nothing matched so callers can report a clear "not found" instead of a silent no-op.
- **Three new tools** (`src/agent/tools.ts`): `list_knowledge`, `update_knowledge`, `delete_knowledge`. All `assertAtLeast(caller.role, 'admin', ...)`, matching `save_knowledge`. `update_knowledge` and `delete_knowledge` route through the existing `audited()` wrapper, so they get the same `admin_audit` row + super-admin DM alert as every other privileged mutation. `delete_knowledge` is additionally CONFIRM-gated via `requireConfirm` (irreversible and affects what the bot tells every future asker — same reasoning as `delete_message`/`kick_user`), with `assertAtLeast` checked eagerly (before queuing), matching the `grant_admin`/`purge_user_data` pattern.
- **RBAC** (`src/auth/rbac.ts`): added the three new tool names to `ADMIN_TOOLS`. No new tier or scoping model — `toolsForRole`'s structural gating and the existing RBAC tests (which iterate `ADMIN_TOOLS`) cover them automatically.
- **Docs**: updated `docs/ARCHITECTURE.md`'s memory section and RBAC capability table.
- No schema migration — the `knowledge` table already had everything needed (the `updated_at` trigger existed but was unused).

## Security impact

- All three tools are admin+-gated only, identical surface to `save_knowledge` — no new role or tool-gating model.
- `update_knowledge`/`delete_knowledge` are audited (DB row + super-admin DM), matching CLAUDE.md's "everything privileged is audited + alerted" invariant.
- `delete_knowledge` requires an out-of-band CONFIRM reply, handled deterministically by the router/pendingActions machinery — never executed by the model directly.
- `list_knowledge` returning content to the model is no wider than `knowledge_search` already returning content — it just makes full enumeration easier (the intended change), not new data exposure.
- No user-supplied message content is trusted as instructions — inputs are `id`/`scope` filters from an already role-checked caller, and recalled content returned to the model goes through the existing `untrusted()` framing.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 53/53 passing (no regressions; RBAC tests iterate `ADMIN_TOOLS`/`SUPER_ADMIN_TOOLS` so the three new tool names are automatically covered by the existing gating tests — members/guests never get them, admins do, super-admins do).
- `npm run build` — clean.
- **Exercised against a local Postgres 16 + pgvector** (per CLAUDE.md): ran `npm run migrate` against a fresh local DB, then manually drove `saveKnowledge` → `listKnowledge` → `updateKnowledge` → `deleteKnowledge` → `listKnowledge` end-to-end via the built `dist/`, confirming:
  - `listKnowledge` returns entries newest-first and the `scope` filter only returns matching rows.
  - `updateKnowledge` preserves unspecified fields (title unchanged when only `content` is passed), the content actually changes, `updated_at` is bumped, and the new content is found by `searchKnowledge` (proving re-embedding happened).
  - `updateKnowledge`/`deleteKnowledge` on a nonexistent id return `false` rather than throwing.
  - Deleting one entry removes it from `listKnowledge` while leaving an unrelated entry untouched.
- No automated DB-integration tests were added to `tests/*.test.ts` — CI (`ci.yml`) has no Postgres service and no existing test in the repo touches the DB (all existing tests exercise pure helpers or in-memory RBAC/pendingActions logic); adding one here would break `npm test` for anyone without a local Postgres. This matches the existing repo convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbSqwjMCuFL6rRnzCC14Qw)_