### PR TITLE
Add proactive onboarding: Discord welcome message + access-request queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ DISCORD_BOT_TOKEN=
 DISCORD_GUILD_ID=
 # Optional: only respond in these channel IDs (comma-separated). Empty = all.
 DISCORD_ALLOWED_CHANNEL_IDS=
+# Send a static welcome DM to new server joiners. Off by default.
+DISCORD_WELCOME_ENABLED=false
+# Fallback text channel to post the welcome in if the DM fails (DMs closed).
+DISCORD_WELCOME_CHANNEL_ID=
 
 # --- WhatsApp (Baileys provider) ------------------------------------------
 WHATSAPP_PROVIDER=baileys

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,7 +89,9 @@ Tiers: **super_admin > admin > member > guest**.
 - **member** — granted by an admin (`add_member`); stored in `community_users`.
 - **guest** — everyone else. In **gated** mode (`ACCESS_MODE_*=gated`, the
   default) guests get a "ask an admin to add you" pointer and their message
-  content is **not stored**. In `open` mode guests get member-level tools.
+  content is **not stored** — only that they asked (identity + count, in
+  `access_requests`; see "Onboarding" below). In `open` mode guests get
+  member-level tools.
 
 The router resolves the tier (env + DB — never message content), and the agent
 core passes `toolsForRole(tier)` as `allowedTools`, so lower tiers are
@@ -106,6 +108,7 @@ and every privileged action is audited and alerted to super admins by DM.
 | Memory/history across conversations | ❌ | ❌ | ✅ *their conversations* | ✅ all |
 | `moderate` / `announce` | ❌ | ❌ | ✅ *their conversations*, confirm-gated | ✅ anywhere |
 | `save_knowledge` / `list_knowledge` / `update_knowledge` / `delete_knowledge` | ❌ | ❌ | ✅, delete confirm-gated | ✅ |
+| `list_access_requests` | ❌ | ❌ | ✅ *(not conversation-scoped — see below)* | ✅ |
 | `add_member` / `remove_member` | ❌ | ❌ | ✅ (member tier only) | ✅ |
 | Web search & summarise (`WebSearch`; `WebFetch` never) | ❌ | ❌ | ✅ | ✅ |
 | `grant_admin` / `revoke_admin`, `purge_user_data`, `audit_view`, `usage_stats`, `pause_bot`, `set_policy` | ❌ | ❌ | ❌ | ✅ |
@@ -114,6 +117,24 @@ Behaviour guardrails on top: per-user daily reply budget
 (`DAILY_REPLY_LIMIT_PER_USER`), session caps (`SESSION_MAX_TURNS`/`_AGE_HOURS`),
 and an outbound filter on every reply — secret redaction plus the
 `code_answers` policy (`off`/`snippets`/`full`, set via `set_policy`).
+
+## Onboarding (gated mode)
+
+Two pieces make the default gated experience less friction-y without
+weakening it:
+
+1. **Welcome message** (Discord only — WhatsApp has no equivalent "join"
+   event). Off unless `DISCORD_WELCOME_ENABLED=true`. On join, `DiscordAdapter`
+   sends a static, non-agent DM (no LLM call, no cost) pointing the new member
+   at an admin; if their DMs are closed, it falls back to posting in
+   `DISCORD_WELCOME_CHANNEL_ID` if configured.
+2. **Pending-access queue**. When a gated guest addresses the bot,
+   `router.ts` upserts a row into `access_requests` (platform, user id/name,
+   first/last-requested timestamps, request count) — deliberately *never*
+   their message content, preserving the existing no-storage invariant for
+   guests. Admins call `list_access_requests` to see who's waiting instead of
+   relying on informal pings; `add_member` clears the row for that user once
+   actioned.
 
 ## Concurrency model
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -164,7 +164,11 @@ the supported path.
   up to that window.
 - **Guests in gated mode are invisible**: their messages are not stored, which
   also means no audit trail of what strangers sent the WhatsApp number. Trade
-  chosen deliberately (privacy > forensics for non-members).
+  chosen deliberately (privacy > forensics for non-members). The one exception
+  is `access_requests` (the pending-access queue): it stores identity
+  (platform, user id/name) and a request count/timestamps for guests who
+  addressed the bot, but never their message content — an admin-only,
+  `list_access_requests`-gated read, not a new content-storage surface.
 - **forget_me/purge scope**: deletes the user's messages, replies to them, and
   knowledge entries *sourced from* them. Membership rows and the admin audit
   log are retained deliberately (accountability).

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -5,10 +5,12 @@ import { assertAtLeast, type CallerContext } from '../auth/rbac.js';
 import { isSuperAdmin, superAdminIds } from '../auth/roles.js';
 import { logger } from '../logger.js';
 import {
+  clearAccessRequest,
   deleteKnowledge,
   demoteAdmin,
   isKnownConversation,
   isKnownUser,
+  listAccessRequests,
   listKnowledge,
   purgeUserData,
   recentAuditEntries,
@@ -452,6 +454,26 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     },
   );
 
+  const listAccessRequestsTool = tool(
+    'list_access_requests',
+    'List gated guests who have asked the bot for access — identity and request count only, never message content. Admin only.',
+    { limit: z.number().optional().describe('Max entries (default 50)') },
+    async (args) => {
+      assertAtLeast(caller.role, 'admin', 'list_access_requests');
+      const rows = await listAccessRequests(args.limit ?? 50);
+      if (rows.length === 0) return text('No pending access requests.');
+      return text(
+        rows
+          .map(
+            (r) =>
+              `${r.platform} ${r.userName ?? r.userId} (${r.userId}) — ${r.requestCount} request(s), last ${r.lastRequestedAt.toISOString()}`,
+          )
+          .join('\n'),
+      );
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
   const addMember = tool(
     'add_member',
     'Register a user as a community member so the bot will talk to them (gated mode). Admin only; grants member tier only.',
@@ -461,9 +483,10 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'add_member');
+      const userId = args.userId.trim();
       const finalRole = await upsertMember({
         platform: caller.platform,
-        userId: args.userId.trim(),
+        userId,
         role: 'member',
         addedBy: caller.userId,
         displayName: args.displayName,
@@ -474,6 +497,9 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
         params: { displayName: args.displayName },
         run: async () => `registered as ${finalRole}`,
       });
+      await clearAccessRequest(caller.platform, userId).catch((err) =>
+        logger.warn({ err, userId }, 'Failed to clear access request'),
+      );
       return text(`Added ${args.displayName ?? args.userId} as ${finalRole} on ${caller.platform}.`);
     },
   );
@@ -681,6 +707,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
       listKnowledgeTool,
       updateKnowledgeTool,
       deleteKnowledgeTool,
+      listAccessRequestsTool,
       addMember,
       removeMemberTool,
       grantAdmin,

--- a/src/auth/rbac.ts
+++ b/src/auth/rbac.ts
@@ -56,6 +56,7 @@ export const ADMIN_TOOLS = [
   'mcp__community__list_knowledge',
   'mcp__community__update_knowledge',
   'mcp__community__delete_knowledge',
+  'mcp__community__list_access_requests',
   'mcp__community__add_member',
   'mcp__community__remove_member',
 ] as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,13 @@ const EnvSchema = z.object({
   DISCORD_BOT_TOKEN: z.string().min(1),
   DISCORD_GUILD_ID: z.string().min(1),
   DISCORD_ALLOWED_CHANNEL_IDS: z.string().optional(),
+  // Welcome message for new server joiners; off unless explicitly enabled.
+  DISCORD_WELCOME_ENABLED: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
+  // Fallback text channel to post the welcome in if the DM fails (e.g. DMs closed).
+  DISCORD_WELCOME_CHANNEL_ID: z.string().optional(),
 
   // WhatsApp
   WHATSAPP_PROVIDER: z.enum(['baileys', 'cloud', 'disabled']).default('baileys'),
@@ -96,6 +103,10 @@ export const config = {
     botToken: env.DISCORD_BOT_TOKEN,
     guildId: env.DISCORD_GUILD_ID,
     allowedChannelIds: csv(env.DISCORD_ALLOWED_CHANNEL_IDS),
+    welcome: {
+      enabled: env.DISCORD_WELCOME_ENABLED ?? false,
+      channelId: env.DISCORD_WELCOME_CHANNEL_ID,
+    },
   },
   whatsapp: {
     provider: env.WHATSAPP_PROVIDER,

--- a/src/platforms/discord/adapter.ts
+++ b/src/platforms/discord/adapter.ts
@@ -3,6 +3,7 @@ import {
   Events,
   GatewayIntentBits,
   Partials,
+  type GuildMember,
   type Message,
   ChannelType,
 } from 'discord.js';
@@ -21,6 +22,11 @@ import type {
 
 const MAX_DISCORD_LEN = 2000;
 const MEMBERSHIP_CACHE_TTL_MS = 60_000;
+
+const WELCOME_MESSAGE =
+  "Kia ora, welcome! 👋 This server's bot answers Claude/Anthropic questions and remembers context, " +
+  "but it only replies to registered members. Ask an admin to add you, or just say hi to the bot here " +
+  'and an admin will see your request.';
 
 export class DiscordAdapter implements PlatformAdapter {
   readonly platform = 'discord' as const;
@@ -50,6 +56,10 @@ export class DiscordAdapter implements PlatformAdapter {
   async start(): Promise<void> {
     this.client.on(Events.MessageCreate, (message) => {
       this.onDiscordMessage(message).catch((err) => logger.error({ err }, 'Discord message handling failed'));
+    });
+
+    this.client.on(Events.GuildMemberAdd, (member) => {
+      this.onGuildMemberAdd(member).catch((err) => logger.error({ err }, 'Welcome message failed'));
     });
 
     this.client.once(Events.ClientReady, (c) => {
@@ -112,6 +122,37 @@ export class DiscordAdapter implements PlatformAdapter {
     if (!refId) return false;
     const ref = await message.channel.messages.fetch(refId);
     return ref.author.id === this.client.user?.id;
+  }
+
+  /**
+   * Static, non-agent welcome for new joiners — no LLM call, same cost
+   * profile as the gated notice. Off unless DISCORD_WELCOME_ENABLED=true, so
+   * existing deployments are unaffected. DM-first; falls back to the
+   * configured channel if the member has DMs closed.
+   */
+  private async onGuildMemberAdd(member: GuildMember): Promise<void> {
+    if (!config.discord.welcome.enabled) return;
+    if (member.guild.id !== config.discord.guildId) return;
+
+    try {
+      await member.send({ content: WELCOME_MESSAGE, allowedMentions: { parse: [] } });
+      return;
+    } catch (err) {
+      logger.warn({ err, userId: member.id }, 'Welcome DM failed; trying channel fallback');
+    }
+
+    const channelId = config.discord.welcome.channelId;
+    if (!channelId) return;
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !channel.isTextBased() || !('send' in channel)) return;
+      await channel.send({
+        content: `Welcome <@${member.id}>! ${WELCOME_MESSAGE}`,
+        allowedMentions: { users: [member.id] },
+      });
+    } catch (err) {
+      logger.warn({ err, userId: member.id, channelId }, 'Welcome channel fallback failed');
+    }
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,7 +12,7 @@ import {
   takePendingAction,
 } from './agent/pendingActions.js';
 import { isPaused } from './storage/policies.js';
-import { countRepliesToUser, recordInteraction } from './storage/repository.js';
+import { countRepliesToUser, recordAccessRequest, recordInteraction } from './storage/repository.js';
 
 const GATED_NOTICE =
   'Kia ora! This assistant is member-only. Ask a community admin to add you as a member and I can help.';
@@ -93,10 +93,14 @@ export class Router {
     const gated = config.rbac.accessMode[msg.platform] === 'gated';
 
     // Gated mode: guests are not part of the community — do not store their
-    // content; if they address the bot, point them at an admin (rate-limited).
+    // content; if they address the bot, point them at an admin (rate-limited)
+    // and record the request (identity + count only) so admins have a queue.
     if (gated && role === 'guest') {
       if ((msg.addressedToBot || msg.isDirect) && msg.text.trim()) {
         const userKey = `${msg.platform}:${msg.userId}`;
+        recordAccessRequest({ platform: msg.platform, userId: msg.userId, userName: msg.userName }).catch((err) =>
+          logger.warn({ err }, 'Failed to record access request'),
+        );
         if (!this.rateLimited(userKey)) {
           await this.send(adapter, msg.conversationId, GATED_NOTICE).catch((err) =>
             logger.warn({ err }, 'Failed to send gated notice'),

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -617,3 +617,58 @@ export async function recordAdminAction(input: {
     ],
   );
 }
+
+// --- Access requests (gated-mode pending queue) -----------------------------
+
+/**
+ * Record that a gated guest addressed the bot. Identity + counts only — the
+ * caller must never pass message content. Upserts so repeat pings from the
+ * same user dedup into one row instead of growing unbounded.
+ */
+export async function recordAccessRequest(input: {
+  platform: Platform;
+  userId: string;
+  userName?: string;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO access_requests (platform, user_id, user_name)
+     VALUES ($1,$2,$3)
+     ON CONFLICT (platform, user_id) DO UPDATE
+       SET last_requested_at = now(),
+           request_count = access_requests.request_count + 1,
+           user_name = COALESCE(EXCLUDED.user_name, access_requests.user_name)`,
+    [input.platform, input.userId, input.userName ?? null],
+  );
+}
+
+export interface AccessRequest {
+  platform: Platform;
+  userId: string;
+  userName: string | null;
+  firstRequestedAt: Date;
+  lastRequestedAt: Date;
+  requestCount: number;
+}
+
+export async function listAccessRequests(limit = 50): Promise<AccessRequest[]> {
+  const { rows } = await pool.query(
+    `SELECT platform, user_id, user_name, first_requested_at, last_requested_at, request_count
+       FROM access_requests
+      ORDER BY last_requested_at DESC
+      LIMIT $1`,
+    [limit],
+  );
+  return rows.map((r) => ({
+    platform: r.platform,
+    userId: r.user_id,
+    userName: r.user_name,
+    firstRequestedAt: r.first_requested_at,
+    lastRequestedAt: r.last_requested_at,
+    requestCount: Number(r.request_count),
+  }));
+}
+
+/** Clear a resolved access request (e.g. after add_member succeeds for that user). */
+export async function clearAccessRequest(platform: Platform, userId: string): Promise<void> {
+  await pool.query(`DELETE FROM access_requests WHERE platform = $1 AND user_id = $2`, [platform, userId]);
+}

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -139,3 +139,23 @@ CREATE TABLE IF NOT EXISTS admin_audit (
 
 CREATE INDEX IF NOT EXISTS admin_audit_actor_idx
   ON admin_audit (platform, actor_user_id, created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- Gated-mode guests who have addressed the bot, so admins have a queue of
+-- who to add without relaying pings out of band. Identity + counts only —
+-- never message content (mirrors the "gated guest content is not stored"
+-- invariant in router.ts).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS access_requests (
+  id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  platform           TEXT        NOT NULL,
+  user_id            TEXT        NOT NULL,
+  user_name          TEXT,
+  first_requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_requested_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  request_count      INT         NOT NULL DEFAULT 1,
+  UNIQUE (platform, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS access_requests_last_requested_idx
+  ON access_requests (last_requested_at DESC);


### PR DESCRIPTION
Closes #7

## Summary

Onboarding in gated mode (the default) was purely reactive: new Discord joiners got no welcome at all, and every guest ping to the bot was handled independently and forgotten — admins had no visibility into who'd actually asked to be added short of an out-of-band ping.

Two additive, low-risk pieces:

1. **Welcome message on join** (`src/platforms/discord/adapter.ts`) — a `GuildMemberAdd` listener sends a static, non-agent DM (no LLM call, same cost profile as the existing `GATED_NOTICE`) explaining what the bot is and that they should ask an admin. Off unless `DISCORD_WELCOME_ENABLED=true`, so existing deployments are unaffected. DM-first; falls back to posting in `DISCORD_WELCOME_CHANNEL_ID` if the member's DMs are closed. Discord-only — WhatsApp has no equivalent "join" event, noted explicitly rather than faked.
2. **Pending-access queue** — a new `access_requests` table (`src/storage/schema.sql`) storing `platform`, `user_id`, `user_name`, `first_requested_at`, `last_requested_at`, `request_count`. `router.ts` upserts a row whenever a gated guest addresses the bot, alongside (not instead of) the existing rate-limited `GATED_NOTICE` — deliberately **never** their message content, preserving the existing "gated guest content is not stored" invariant. New `list_access_requests` tool (`src/agent/tools.ts`, admin-gated) lets an admin ask "who's waiting to be added" and get a real list. `add_member` clears a user's row once they're actioned.

## Security impact

- `access_requests` stores identity + request metadata only, **no message content** — verified in the manual smoke test below (no `content`/`text` field on the returned rows).
- `list_access_requests` is `admin`+-gated via `assertAtLeast`, same pattern as `usage_stats`/`audit_view`. Per the proposal's explicit call-out: **unlike other admin data-access tools, this one is not scoped to "conversations the admin participates in"** — a guest's access request isn't tied to a conversation the admin is a member of the same way (they're pre-membership by definition), so there's nothing to scope against. No new data exposure beyond what `add_member` already implies admins can see (that a user id/name exists and wants access).
- The welcome DM is a static, non-agent message — no prompt-injection surface (never calls the model), no cost.
- Row growth is bounded: upsert-on-repeat-request (not one row per ping), and `add_member` clears resolved rows.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 53/53 passing, no regressions. RBAC tests iterate `ADMIN_TOOLS`, so `list_access_requests`'s gating (members/guests denied, admins/super-admins allowed) is automatically covered.
- `npm run build` — clean.
- **Exercised against a local Postgres 16 + pgvector** (per CLAUDE.md): ran `npm run migrate` to apply the new `access_requests` table, then manually drove `recordAccessRequest` → `listAccessRequests` → `clearAccessRequest` end-to-end via the built `dist/`, confirming:
  - A repeat request from the same `(platform, user_id)` dedups into one row with `request_count` incremented and `last_requested_at` bumped past `first_requested_at`, rather than growing unbounded.
  - Requests from different users/platforms stay as separate rows.
  - The returned row objects have no `content`/`text` field — confirms no message content path exists.
  - `clearAccessRequest` removes only the targeted user's row, leaving others untouched.
- Did not exercise the Discord `GuildMemberAdd` listener or DM-fallback path against a live Discord gateway (would require a real bot token + guild) — reviewed against `discord.js` docs and the existing `sendDirectMessage`/`performAdminAction` patterns already used elsewhere in the same adapter for message-sending conventions (chunking, `allowedMentions: { parse: [] }`).
- No automated DB-integration tests added to `tests/*.test.ts` — CI has no Postgres service and no existing test in the repo touches the DB; this matches the existing convention (see the knowledge-curation-tools PR for the same reasoning).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbSqwjMCuFL6rRnzCC14Qw)_