### PR TITLE
Add age-based retention purge for raw interactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,9 @@ DAILY_REPLY_LIMIT_PER_USER=50
 # Start a fresh Claude session past either cap (context/injection hygiene).
 SESSION_MAX_TURNS=30
 SESSION_MAX_AGE_HOURS=24
+# Age-based purge of raw `interactions` (privacy/retention). Unset/0 = disabled.
+# Must be 0 or >= 7 if set. knowledge/admin_audit/sessions are never touched.
+INTERACTION_RETENTION_DAYS=
 # Log level: trace|debug|info|warn|error
 LOG_LEVEL=info
 # Set to "true" to pretty-print logs (dev only).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -46,6 +46,10 @@ Set at least: `CLAUDE_CODE_OAUTH_TOKEN`, `DISCORD_BOT_TOKEN`,
 default — after startup, message the bot as a super admin and use
 `add_member` / `grant_admin` to onboard people.
 
+Consider also setting `INTERACTION_RETENTION_DAYS` (e.g. `90`) to
+automatically age-purge raw message content per your privacy policy — it's
+disabled by default so existing deployments see no behaviour change.
+
 ## 5. Run migrations
 ```bash
 cd /opt/community-agent

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -105,8 +105,15 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
   AI assistant logs interactions (Discord/WhatsApp etiquette + NZ Privacy Act
   2020 expectations).
 - Provide a deletion path: delete rows from `interactions` (and `knowledge`)
-  by `user_id` on request. Consider a retention policy (e.g. purge raw
-  `interactions` older than N months while keeping aggregate `knowledge`).
+  by `user_id` on request (`forget_me` / `purge_user_data`).
+- **Retention policy**: set `INTERACTION_RETENTION_DAYS` to age-purge raw
+  `interactions` (default unset = disabled, no behaviour change on upgrade).
+  A daily in-process timer (`src/index.ts`) deletes rows older than the
+  configured window and logs the count purged. Must be `0` or **at least 7
+  days** (enforced at startup) so a low value can't silently gut memory
+  recall for users still mid-conversation. `knowledge` (curated, durable
+  facts), `admin_audit` (accountability trail), and `sessions` (governed by
+  `SESSION_MAX_TURNS`/`_AGE_HOURS`) are never touched by this purge.
 
 ## Platform-specific notes
 
@@ -198,5 +205,6 @@ number could reach an unrelated person).
 - [ ] Postgres is not exposed to the network.
 - [ ] Bot has minimal Discord permissions.
 - [ ] Community is informed that interactions are logged.
-- [ ] A retention/deletion policy is defined.
+- [ ] A retention/deletion policy is defined (`forget_me`/`purge_user_data`
+      for per-user requests; `INTERACTION_RETENTION_DAYS` for age-based purge).
 - [ ] `journalctl -u community-agent` reviewed for redaction leaks.

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,12 +59,21 @@ const EnvSchema = z.object({
   // Session hygiene: start a fresh Claude session past either cap.
   SESSION_MAX_TURNS: z.coerce.number().int().positive().default(30),
   SESSION_MAX_AGE_HOURS: z.coerce.number().positive().default(24),
+  // Age-based purge of raw `interactions` content. Unset/0 = disabled (no
+  // behaviour change on upgrade). knowledge/admin_audit/sessions are never
+  // touched by this — see storage/repository.ts:purgeOldInteractions.
+  INTERACTION_RETENTION_DAYS: z.coerce.number().int().nonnegative().default(0),
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
   LOG_PRETTY: z
     .string()
     .optional()
     .transform((v) => v === 'true'),
 });
+
+// Retention must stay well clear of the active-conversation window
+// (SESSION_MAX_AGE_HOURS) so a low value can't silently gut memory recall
+// for users still mid-conversation.
+const MIN_INTERACTION_RETENTION_DAYS = 7;
 
 const EnvSchemaChecked = EnvSchema.refine(
   (e) =>
@@ -79,7 +88,10 @@ const EnvSchemaChecked = EnvSchema.refine(
       'WHATSAPP_CLOUD_VERIFY_TOKEN, and WHATSAPP_CLOUD_APP_SECRET',
     path: ['WHATSAPP_PROVIDER'],
   },
-);
+).refine((e) => e.INTERACTION_RETENTION_DAYS === 0 || e.INTERACTION_RETENTION_DAYS >= MIN_INTERACTION_RETENTION_DAYS, {
+  message: `INTERACTION_RETENTION_DAYS must be 0 (disabled) or at least ${MIN_INTERACTION_RETENTION_DAYS}`,
+  path: ['INTERACTION_RETENTION_DAYS'],
+});
 
 const parsed = EnvSchemaChecked.safeParse(process.env);
 if (!parsed.success) {
@@ -138,6 +150,7 @@ export const config = {
     dailyReplyLimitPerUser: env.DAILY_REPLY_LIMIT_PER_USER,
     sessionMaxTurns: env.SESSION_MAX_TURNS,
     sessionMaxAgeHours: env.SESSION_MAX_AGE_HOURS,
+    interactionRetentionDays: env.INTERACTION_RETENTION_DAYS,
   },
   log: {
     level: env.LOG_LEVEL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,32 @@ import { logger } from './logger.js';
 import { configureSubscriptionAuth } from './agent/auth.js';
 import { Router } from './router.js';
 import { closeDb, healthcheck } from './storage/db.js';
-import { verifyEmbeddingDim } from './storage/repository.js';
+import { purgeOldInteractions, verifyEmbeddingDim } from './storage/repository.js';
 import type { PlatformAdapter } from './platforms/types.js';
 import { DiscordAdapter } from './platforms/discord/adapter.js';
 import { BaileysAdapter } from './platforms/whatsapp/baileysAdapter.js';
 import { WhatsAppCloudAdapter } from './platforms/whatsapp/cloudAdapter.js';
+
+const DAY_MS = 24 * 60 * 60_000;
+
+/**
+ * Age-based purge of raw `interactions` (SECURITY.md retention policy). Off
+ * unless INTERACTION_RETENTION_DAYS is set. Runs once immediately (so
+ * operators see it working without waiting a day) and then daily.
+ */
+function startRetentionPurge(): ReturnType<typeof setInterval> | null {
+  const days = config.behaviour.interactionRetentionDays;
+  if (days <= 0) return null;
+  const run = () => {
+    purgeOldInteractions(days)
+      .then((count) => logger.info({ days, count }, 'Purged old interactions (retention policy)'))
+      .catch((err) => logger.error({ err }, 'Interaction retention purge failed'));
+  };
+  run();
+  const timer = setInterval(run, DAY_MS);
+  timer.unref();
+  return timer;
+}
 
 async function main(): Promise<void> {
   logger.info('Starting Community Agent');
@@ -43,9 +64,13 @@ async function main(): Promise<void> {
   await Promise.all(adapters.map((a) => a.start()));
   logger.info({ platforms: adapters.map((a) => a.platform) }, 'Community Agent running');
 
+  // 4b. Optional age-based retention purge (disabled unless configured).
+  const retentionTimer = startRetentionPurge();
+
   // 5. Graceful shutdown.
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutting down');
+    if (retentionTimer) clearInterval(retentionTimer);
     await Promise.allSettled(adapters.map((a) => a.stop()));
     await closeDb();
     process.exit(0);

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -527,6 +527,21 @@ export async function purgeUserData(platform: Platform, userId: string): Promise
   return (messages ?? 0) + (knowledge ?? 0);
 }
 
+/**
+ * Age-based retention: delete raw `interactions` older than `days`. Never
+ * touches `knowledge` (curated facts are meant to be durable), `sessions`
+ * (governed separately by SESSION_MAX_TURNS/_AGE_HOURS), or `admin_audit`
+ * (accountability trail, retained deliberately — see SECURITY.md). Returns
+ * the number of rows deleted, for operator-visible logging.
+ */
+export async function purgeOldInteractions(days: number): Promise<number> {
+  const { rowCount } = await pool.query(
+    `DELETE FROM interactions WHERE created_at < now() - ($1::text || ' days')::interval`,
+    [days],
+  );
+  return rowCount ?? 0;
+}
+
 // --- Super-admin views ---------------------------------------------------------
 
 export async function recentAuditEntries(limit = 20): Promise<


### PR DESCRIPTION
Closes #9

## Summary

`docs/SECURITY.md` flagged this as an open item twice ("consider a retention policy" / "a retention/deletion policy is defined" unchecked). Raw `interactions` had no age-based cleanup — only the per-user `forget_me`/`purge_user_data` paths existed, so every deployment's raw message footprint grew indefinitely unless an individual explicitly asked to be purged.

- **`src/config.ts`** — new `INTERACTION_RETENTION_DAYS` (optional, default `0` = disabled, so upgrading an existing deployment changes nothing unless explicitly configured). Enforced at startup via a `zod` refine: must be `0` or **at least 7 days** — a hard floor so a low value can't silently gut memory recall for users still mid-conversation (`SESSION_MAX_AGE_HOURS` defaults to 24h; 7 days gives real headroom above that).
- **`src/storage/repository.ts`** — `purgeOldInteractions(days)`: a single parameterised `DELETE FROM interactions WHERE created_at < now() - interval`. Deliberately never touches `knowledge` (curated, durable facts — the whole point of promoting something via `save_knowledge`), `admin_audit` (accountability trail, retained deliberately per existing SECURITY.md residual-risk notes), or `sessions` (governed separately by `SESSION_MAX_TURNS`/`_AGE_HOURS`).
- **`src/index.ts`** — a lightweight in-process daily timer (`setInterval`, `.unref()`'d, cleared on graceful shutdown), matching the project's existing "single long-running Node service" shape rather than adding a job-scheduling dependency. Runs once immediately at startup (so operators see it working without waiting a day) and logs the purged row count each run at `info` level. No timer/purge activity at all when the env var is unset — this is purely additive.
- **Docs** — `docs/SECURITY.md`'s two open retention-policy items are resolved (§6 Data protection, the operational checklist), and `docs/DEPLOYMENT.md`/`.env.example` document the new var.

Went with the in-process-timer approach over the "external cron + purge CLI script" alternative raised in the proposal: it's zero-touch once the env var is set (no separate system cron to wire up), consistent with how `SESSION_MAX_TURNS`/session hygiene and the router's own sweep timer already work in this codebase.

## Security impact

- Net **reduces** the stored PII footprint over time — directly addresses the privacy gap the project's own docs flagged; no new data exposure.
- No new RBAC surface — this is a config-driven background timer with no user-facing tool, so nothing to gate with `assertAtLeast`/audit (unlike `forget_me`/`purge_user_data`, which remain the on-demand, audited paths).
- The purge query is a single fixed, parameterised interval delete — no user-controllable input, no injection surface.
- The 7-day minimum floor is enforced at config-parse time (fails fast at startup with a readable error), not left as an unchecked raw int, addressing the proposal's explicit call-out that this needed a guard.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 53/53 passing, no regressions.
- `npm run build` — clean.
- **Exercised against a local Postgres 16 + pgvector** (per CLAUDE.md):
  - Confirmed the config guard: `INTERACTION_RETENTION_DAYS=3` fails startup with `INTERACTION_RETENTION_DAYS must be 0 (disabled) or at least 7`; unset (default `0`) and `30` both parse cleanly.
  - Manually drove `purgeOldInteractions` via the built `dist/`: inserted one recent interaction and one backdated 100-days-old interaction plus a 100-day-old `knowledge` entry, ran `purgeOldInteractions(30)`, and confirmed exactly the old interaction was deleted, the recent one survived, and the `knowledge` row was completely untouched despite being older than the retention window. Also confirmed a purge call with a far-future cutoff deletes nothing (no false positives).
- Did not exercise the `setInterval`-driven daily scheduling itself end-to-end (would require running the full service for 24h+); the scheduling logic is a thin wrapper calling the already-verified `purgeOldInteractions`, matching the existing router sweep-timer pattern (`router.ts`) already running unverified-by-test in production today.
- No automated DB-integration test added to `tests/*.test.ts` — CI has no Postgres service and no existing test in the repo touches the DB; matches the convention established in the two prior PRs (#8, #10) for this same reason.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbSqwjMCuFL6rRnzCC14Qw)_