### PR TITLE
Add Postgres+pgvector CI service and repository-level integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: community_agent_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      # Dummy values so config.ts's zod schema is satisfied — nothing in
+      # this job talks to Claude or Discord, only DATABASE_URL is real.
+      CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
+      DISCORD_BOT_TOKEN: ci-dummy-token
+      DISCORD_GUILD_ID: ci-dummy-guild
+      WHATSAPP_PROVIDER: disabled
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -16,5 +38,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run typecheck
+      - run: npm run migrate
       - run: npm test
       - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,13 @@ with `README.md`, then `docs/ARCHITECTURE.md` and `docs/SECURITY.md`.
   here (tool gating, confirm flow, secret redaction, WhatsApp wire helpers) —
   when you touch those areas, extend the tests.
 - `npm run build` — tsc + copies `schema.sql` into `dist/`.
-- DB-touching changes: exercise against a local Postgres 16 + pgvector.
+- DB-touching changes: CI runs `tests/repository.test.ts` against a real
+  `pgvector/pgvector:pg16` service container (see `.github/workflows/ci.yml`),
+  so this is enforced, not just a manual reminder. Do it locally too for the
+  tight loop: run `npm run migrate` against a local Postgres 16 + pgvector
+  with `DATABASE_URL` set, then `npm test` — DB-touching tests skip cleanly
+  (not fail) when `DATABASE_URL` is unset, so a contributor without local
+  Postgres isn't blocked.
 - Run all three (typecheck, test, build) green before opening/updating a PR.
 
 ## Security posture (do not regress)

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -1,0 +1,235 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+// config.ts validates env at import time — provide a dummy environment
+// before importing anything that (transitively) loads it, matching the
+// convention in tests/agentOptions.test.ts.
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+
+const skip = hasDb ? false : 'DATABASE_URL not set — skipping DB-integration tests (CLAUDE.md: exercise against a local Postgres 16 + pgvector)';
+
+const { pool, closeDb } = await import('../src/storage/db.js');
+const {
+  recordInteraction,
+  userMessages,
+  purgeOldInteractions,
+  purgeUserData,
+  saveKnowledge,
+  searchKnowledge,
+  updateKnowledge,
+  deleteKnowledge,
+  recordAdminAction,
+} = await import('../src/storage/repository.js');
+
+// Unique per test-run tag so fixtures never collide across runs and can be
+// cleaned up precisely, whether this runs against a throwaway CI Postgres or
+// a developer's real local instance.
+const RUN = `t${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+
+after(async () => {
+  await closeDb();
+});
+
+test(
+  'repository: purgeOldInteractions deletes only rows past the cutoff, never knowledge/admin_audit',
+  { skip },
+  async () => {
+    const userId = `${RUN}-purge`;
+    const conversationId = `${RUN}-c-purge`;
+
+    // Use an extreme age (~100 years) rather than a realistic retention
+    // window: this makes the boundary assertions correct regardless of what
+    // else lives in the table (real interactions can't predate the schema),
+    // so this test is safe to run against a populated local dev DB too.
+    const HUNDRED_YEARS_DAYS = 36_525;
+
+    await recordInteraction({
+      platform: 'discord',
+      conversationId,
+      userId,
+      role: 'member',
+      direction: 'inbound',
+      content: 'recent — must survive',
+    });
+    await pool.query(
+      `INSERT INTO interactions (platform, conversation_id, user_id, role, direction, content, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6, now() - interval '${HUNDRED_YEARS_DAYS - 1} days')`,
+      ['discord', conversationId, userId, 'member', 'inbound', 'just under the cutoff — must survive'],
+    );
+    await pool.query(
+      `INSERT INTO interactions (platform, conversation_id, user_id, role, direction, content, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6, now() - interval '${HUNDRED_YEARS_DAYS + 1} days')`,
+      ['discord', conversationId, userId, 'member', 'inbound', 'just over the cutoff — must be purged'],
+    );
+
+    const kId = await saveKnowledge({ content: 'durable fact', title: 'K', scope: 'global', sourceUserId: userId });
+    await pool.query(
+      `UPDATE knowledge SET created_at = now() - interval '${HUNDRED_YEARS_DAYS + 1} days',
+                            updated_at = now() - interval '${HUNDRED_YEARS_DAYS + 1} days'
+        WHERE id = $1`,
+      [kId],
+    );
+    await recordAdminAction({
+      platform: 'discord',
+      actorUserId: `${RUN}-actor`,
+      actionKind: 'test_fixture',
+      targetUserId: userId,
+      success: true,
+    });
+
+    const deleted = await purgeOldInteractions(HUNDRED_YEARS_DAYS);
+    assert.ok(deleted >= 1, 'at least our over-the-cutoff fixture was deleted');
+
+    const remaining = await pool.query(
+      `SELECT content FROM interactions WHERE user_id = $1 ORDER BY created_at`,
+      [userId],
+    );
+    assert.deepEqual(
+      remaining.rows.map((r) => r.content).sort(),
+      ['just under the cutoff — must survive', 'recent — must survive'].sort(),
+      'only the row older than the cutoff is removed',
+    );
+
+    const knowledgeRow = await pool.query(`SELECT id FROM knowledge WHERE id = $1`, [kId]);
+    assert.equal(knowledgeRow.rows.length, 1, 'knowledge is never touched by purgeOldInteractions regardless of age');
+
+    const auditRow = await pool.query(`SELECT id FROM admin_audit WHERE target_user_id = $1`, [userId]);
+    assert.equal(auditRow.rows.length, 1, 'admin_audit is never touched by purgeOldInteractions');
+
+    // Cleanup.
+    await pool.query(`DELETE FROM interactions WHERE user_id = $1`, [userId]);
+    await pool.query(`DELETE FROM knowledge WHERE id = $1`, [kId]);
+    await pool.query(`DELETE FROM admin_audit WHERE target_user_id = $1`, [userId]);
+  },
+);
+
+test('repository: purgeUserData deletes only the target user (interactions + sourced knowledge)', { skip }, async () => {
+  const targetUser = `${RUN}-target`;
+  const otherUser = `${RUN}-other`;
+  const conversationId = `${RUN}-c-purge-user`;
+
+  await recordInteraction({
+    platform: 'discord',
+    conversationId,
+    userId: targetUser,
+    role: 'member',
+    direction: 'inbound',
+    content: 'target message',
+  });
+  await recordInteraction({
+    platform: 'discord',
+    conversationId,
+    userId: otherUser,
+    role: 'member',
+    direction: 'inbound',
+    content: 'other user message',
+  });
+  const targetKnowledgeId = await saveKnowledge({ content: 'from target', sourceUserId: targetUser, scope: 'global' });
+  const otherKnowledgeId = await saveKnowledge({ content: 'from other', sourceUserId: otherUser, scope: 'global' });
+  await recordAdminAction({
+    platform: 'discord',
+    actorUserId: `${RUN}-actor2`,
+    actionKind: 'test_fixture',
+    targetUserId: targetUser,
+    success: true,
+  });
+
+  const purged = await purgeUserData('discord', targetUser);
+  assert.ok(purged >= 2, 'purged count covers the target interaction + knowledge row');
+
+  const targetRows = await pool.query(`SELECT 1 FROM interactions WHERE user_id = $1`, [targetUser]);
+  assert.equal(targetRows.rows.length, 0, 'target user interactions are gone');
+
+  const otherRows = await pool.query(`SELECT content FROM interactions WHERE user_id = $1`, [otherUser]);
+  assert.equal(otherRows.rows.length, 1, 'other user interactions are untouched');
+
+  const targetKnowledge = await pool.query(`SELECT 1 FROM knowledge WHERE id = $1`, [targetKnowledgeId]);
+  assert.equal(targetKnowledge.rows.length, 0, 'knowledge sourced from the target user is gone');
+
+  const otherKnowledge = await pool.query(`SELECT 1 FROM knowledge WHERE id = $1`, [otherKnowledgeId]);
+  assert.equal(otherKnowledge.rows.length, 1, "other user's knowledge is untouched");
+
+  const auditRow = await pool.query(`SELECT 1 FROM admin_audit WHERE target_user_id = $1`, [targetUser]);
+  assert.equal(auditRow.rows.length, 1, 'admin_audit (accountability trail) is retained deliberately, not purged');
+
+  // Cleanup.
+  await pool.query(`DELETE FROM interactions WHERE user_id = $1`, [otherUser]);
+  await pool.query(`DELETE FROM knowledge WHERE id = $1`, [otherKnowledgeId]);
+  await pool.query(`DELETE FROM admin_audit WHERE target_user_id = $1`, [targetUser]);
+});
+
+test('repository: knowledge CRUD — insert, search finds it, update re-embeds and bumps updated_at, delete removes it', { skip }, async () => {
+  const id = await saveKnowledge({ title: 'Meetup schedule', content: 'We meet monthly on the first Tuesday.', scope: `${RUN}-scope` });
+
+  const foundBefore = await searchKnowledge('monthly meetup schedule', 20);
+  assert.ok(foundBefore.some((h) => h.content.includes('first Tuesday')), 'search finds the freshly-saved entry');
+
+  const beforeRow = await pool.query(`SELECT updated_at FROM knowledge WHERE id = $1`, [id]);
+  const updated = await updateKnowledge({ id, content: 'We meet monthly on the SECOND Tuesday now.' });
+  assert.equal(updated, true);
+
+  const afterRow = await pool.query(`SELECT title, content, updated_at FROM knowledge WHERE id = $1`, [id]);
+  assert.equal(afterRow.rows[0].title, 'Meetup schedule', 'unspecified field (title) is preserved');
+  assert.equal(afterRow.rows[0].content, 'We meet monthly on the SECOND Tuesday now.');
+  assert.ok(
+    new Date(afterRow.rows[0].updated_at).getTime() > new Date(beforeRow.rows[0].updated_at).getTime(),
+    'updated_at is bumped',
+  );
+
+  const foundAfterUpdate = await searchKnowledge('second Tuesday meetup', 20);
+  assert.ok(
+    foundAfterUpdate.some((h) => h.content.includes('SECOND Tuesday')),
+    're-embedding means search finds the new content',
+  );
+
+  const deleted = await deleteKnowledge(id);
+  assert.equal(deleted, true);
+
+  const goneRow = await pool.query(`SELECT 1 FROM knowledge WHERE id = $1`, [id]);
+  assert.equal(goneRow.rows.length, 0);
+
+  const deletedAgain = await deleteKnowledge(id);
+  assert.equal(deletedAgain, false, 'deleting a nonexistent id returns false, not an error');
+});
+
+test('SECURITY: repository: admin conversation scoping excludes conversations outside the given list', { skip }, async () => {
+  const userId = `${RUN}-scoped-user`;
+  const inScopeConvo = `${RUN}-c-in-scope`;
+  const outOfScopeConvo = `${RUN}-c-out-of-scope`;
+
+  await recordInteraction({
+    platform: 'discord',
+    conversationId: inScopeConvo,
+    userId,
+    role: 'member',
+    direction: 'inbound',
+    content: 'visible to the scoped admin',
+  });
+  await recordInteraction({
+    platform: 'discord',
+    conversationId: outOfScopeConvo,
+    userId,
+    role: 'member',
+    direction: 'inbound',
+    content: 'must NOT be visible — admin is not in this conversation',
+  });
+
+  const unscoped = await userMessages('discord', userId, 20);
+  assert.equal(unscoped.length, 2, 'without a scope filter, both conversations are visible (super-admin/no-filter path)');
+
+  const scoped = await userMessages('discord', userId, 20, [inScopeConvo]);
+  assert.equal(scoped.length, 1, 'the admin-scoped query returns only the in-scope conversation');
+  assert.equal(scoped[0].conversationId, inScopeConvo);
+  assert.ok(
+    !scoped.some((r) => r.conversationId === outOfScopeConvo),
+    'SECURITY: a conversation outside the scope filter must never be returned',
+  );
+
+  await pool.query(`DELETE FROM interactions WHERE user_id = $1`, [userId]);
+});


### PR DESCRIPTION
Closes #13

## Summary

`src/storage/repository.ts` had grown into the most load-bearing, security-relevant file in the project — knowledge CRUD, the `purgeOldInteractions` DELETE that runs on a schedule in production, `access_requests`, and the admin cross-conversation scoping filter CLAUDE.md names by name as a security invariant — with **zero** CI coverage. Every existing test in `tests/` is pure logic with no database.

- **`.github/workflows/ci.yml`** — added a `pgvector/pgvector:pg16` service container (matches `docs/DEPLOYMENT.md`'s recommended version), health-checked via `pg_isready`, exposed on `5432`. The job now sets dummy `CLAUDE_CODE_OAUTH_TOKEN`/`DISCORD_BOT_TOKEN`/`DISCORD_GUILD_ID` (required by `config.ts`'s zod schema regardless of what a given test needs) plus a real `DATABASE_URL` pointing at the service container, runs `npm run migrate` before `npm test`.
- **`tests/repository.test.ts`** (new) covers the four highest-risk paths the proposal called out:
  - `purgeOldInteractions` deletes only rows older than the cutoff; `knowledge` and `admin_audit` are never touched regardless of age.
  - `purgeUserData` cascade only affects the target user's `interactions` + knowledge sourced from them; another user's data and the audit trail are untouched.
  - `knowledge` CRUD: insert → `searchKnowledge` finds it; `updateKnowledge` re-embeds (verified via search on the new content) and bumps `updated_at` while preserving unspecified fields; `deleteKnowledge` removes it and returns `false` (not an error) on a second call.
  - **`SECURITY:`** the admin cross-conversation scoping filter (`userMessages`'s `conversationIds` param, backing the `user_history` tool) actually excludes a conversation outside the given scope — this is the invariant CLAUDE.md calls out by name that previously had no automated regression test at the SQL layer.
- **Local dev parity**: DB-touching tests check `Boolean(process.env.DATABASE_URL)` and pass `{ skip }` to `test()` when it's unset, so `npm test` still passes cleanly (skipped, not failed) for a contributor without local Postgres — matching the existing `tests/agentOptions.test.ts` convention for stubbing `config.ts`'s required env vars before import.
- **`CLAUDE.md`** — updated the "Build / test / verify" section: DB-touching changes are now enforced by CI, not just a manual reminder, with the local-dev-parity instructions.

One deliberate safety choice: `purgeOldInteractions` is an **un-scoped, whole-table** delete by design (that's its actual production behavior). To make the test safe to run against a populated local dev Postgres (not just the throwaway CI container), the test backdates its fixtures to ~100 years old (`36,525`/`36,526` days) rather than a realistic retention window like 30 days, and asserts the exact boundary (`created_at` just under vs. just over the cutoff). Since no real interaction can predate the schema itself, this makes the test's destructive `DELETE` provably incapable of touching legitimate recent data, while still exercising the exact SQL comparison the function performs.

## Security impact

- **Improves** the security posture: closes the gap CLAUDE.md already names ("Admin data access is scoped in SQL to conversations the admin is in") but had no automated test proving — a future change could silently widen that scope and CI would have stayed green.
- No new production surface — CI-only infrastructure (a service container) plus test files. The CI Postgres uses throwaway, non-secret local credentials (`postgres`/`postgres`) that never touch real data.
- Test fixtures are synthetic, tagged with a per-run unique id, and fully cleaned up at the end of each test (verified manually — see below) — no risk of leftover data accumulating in a real Postgres a contributor points `DATABASE_URL` at locally.

## Verification

- `npm run typecheck` — clean.
- `npm test` **without** `DATABASE_URL` set — 62 pass, 0 fail, **4 skipped** (the new DB tests), confirming the local-dev-parity acceptance criterion (a contributor without local Postgres isn't blocked).
- `npm test` **with** `DATABASE_URL` set against a real local Postgres 16 + pgvector (per CLAUDE.md) — **66/66 pass, 0 skipped**, including all 4 new repository tests running for real against live SQL.
- `npm run build` — clean.
- Manually confirmed via `psql` that after the full test run, `interactions`, `knowledge`, and `admin_audit` all have **0 rows** — every fixture the new tests create is cleaned up, leaving no residue in the test database.
- Manually sanity-checked `.github/workflows/ci.yml`'s YAML is well-formed (`yaml.safe_load`).
- Did not run this against the actual GitHub Actions runner (would require pushing and watching the Actions tab) — the local verification above exercises the identical `npm run migrate && npm test` sequence the workflow runs, against the same `pgvector/pgvector:pg16`-equivalent local setup (Postgres 16 + the `vector` extension installed), so I'm confident it'll behave the same in CI; will confirm once this PR's own CI run completes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbSqwjMCuFL6rRnzCC14Qw)_