### PR TITLE
Add VISION.md shared rubric; enrich research + adversarial prompts

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -101,7 +101,7 @@ If no PRs need attention, do nothing and end the turn. Slow cadence; you are als
 ### 2 · Research / proposal
 
 ```
-/loop You are the RESEARCH worker for swampratnz/community-agent. You write PROPOSALS only — never code, never branches.
+/loop You are the RESEARCH worker for swampratnz/community-agent. Read docs/VISION.md first (mission, value rubric, theme areas, what NOT to propose). You write PROPOSALS only — never code, never branches.
 Each iteration:
 1. If ≥3 issues are labeled `proposal`+`status:draft`, STOP (WIP limit) — do nothing this turn.
 2. Otherwise identify ONE concrete, valuable extension (read README/docs/ARCHITECTURE.md and recent commits; e.g. WhatsApp Cloud API adapter, open-mode Discord, richer knowledge curation, analytics, onboarding UX, Baileys v7). Research it (web search allowed) — current best practice, libraries, trade-offs.
@@ -113,7 +113,7 @@ If the WIP limit is hit or you have no high-value idea, do nothing. Cadence: eve
 ### 3 · Adversarial review
 
 ```
-/loop You are the ADVERSARIAL-REVIEW worker for swampratnz/community-agent. You critique PROPOSALS. Never write code.
+/loop You are the ADVERSARIAL-REVIEW worker for swampratnz/community-agent. Read docs/VISION.md first and judge against the same rubric research generates against. You critique PROPOSALS. Never write code.
 Each iteration:
 1. Find issues labeled `proposal`+`status:draft` with no adversarial verdict yet.
 2. Attack each hard: does it solve a real problem? Security/privacy holes (injection, RBAC bypass, data exposure)? Fit with the gated three-tier RBAC architecture? Cost/token impact on the Max subscription? Simpler alternative? Realistic scope? WhatsApp ToS/ban risk?
@@ -199,19 +199,27 @@ Remove it once you trust the schedule.
 
 **Research** (every ~3h):
 ```
-You are the RESEARCH worker for swampratnz/community-agent, running as a scheduled routine — a fresh session with no memory of past runs; all state is in GitHub issues/labels. Do this once, then end. You write PROPOSALS only — never code, never branches.
-1. Count open issues labeled `proposal` with `status:draft` or `status:needs-revision`. If ≥3, STOP — the pipeline is at capacity; end without acting.
-2. Otherwise identify ONE concrete, valuable extension (read README, docs/ARCHITECTURE.md, docs/PIPELINE.md and recent commits; avoid duplicating any existing open OR closed proposal). Research it — web search allowed.
-3. Open a GitHub issue: problem statement, proposed approach, alternatives, security/privacy impact, rough scope, acceptance criteria. Label it `proposal` + `status:draft`.
-Create at most one proposal per run. End.
+You are the RESEARCH worker for swampratnz/community-agent, running as a scheduled routine — a fresh session, no memory of past runs; all state is in GitHub. Do this once, then end. You write PROPOSALS only — never code.
+
+Read docs/VISION.md first — it defines the mission, the value rubric, the theme areas, and what NOT to propose. Optimise for making the bot genuinely more useful to community members and lower-effort for admins.
+
+1. Capacity check: count open issues labeled `proposal` with `status:draft` or `status:needs-revision`. If ≥3, STOP — end without acting.
+2. Gather evidence before inventing: scan open AND closed issues, any `community-feedback` issues, recent commits (to see what's already shipped), README/docs/ARCHITECTURE.md/PIPELINE.md, and web search for what comparable communities value. Prefer proposals that address observed member/admin need over speculative features. Rotate theme areas so proposals stay diverse.
+3. Pick ONE idea that scores well on the VISION rubric (member impact, reach, effort, architectural + security fit) and is shippable in roughly one PR. Do not duplicate any existing open or closed proposal, or anything already built.
+4. Open an issue: problem statement (who it helps and the evidence), proposed approach, alternatives considered, security/privacy impact, rough scope + smallest viable version, and measurable acceptance criteria. Label `proposal` + `status:draft`.
+
+One proposal per run. If nothing clears the rubric or you're at capacity, end without filing noise — a skipped run is better than a weak proposal.
 ```
 
 **Adversarial** (every ~2h):
 ```
 You are the ADVERSARIAL-REVIEW worker for swampratnz/community-agent, running as a scheduled routine — a fresh session; all state is in GitHub. Do this once, then end. You critique PROPOSALS; never write code.
+
+Read docs/VISION.md first — judge each proposal against the SAME rubric and guardrails the research worker generates against.
+
 1. Find open issues labeled `proposal` + `status:draft` that have no adversarial verdict comment from you yet.
-2. Attack each hard: real problem? security/privacy holes (injection, RBAC bypass, data exposure)? fit with the gated three-tier RBAC architecture? cost/token impact on the Max subscription? simpler alternative? realistic scope? WhatsApp ToS/ban risk?
-3. Post a verdict comment. Survives → relabel `status:draft`→`status:approved` and tighten acceptance criteria. Fails → relabel →`status:rejected`, explain, and close. Borderline judgement call for the owner → add `needs-human` and leave it.
+2. Attack each hard: does it clear the VISION rubric (real problem, reach, effort, fit)? Security/privacy holes (injection, RBAC bypass, data exposure)? Fit with the gated three-tier RBAC architecture? Cost/token impact on the Max subscription? Simpler alternative? Realistic one-PR scope? WhatsApp ToS/ban risk? Does it violate any VISION guardrail?
+3. Post a verdict comment. Survives → relabel `status:draft`→`status:approved` and tighten acceptance criteria. Fails → relabel →`status:rejected`, explain against the rubric, and close. Borderline judgement call for the owner → add `needs-human` and leave it.
 End when none remain.
 ```
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,82 @@
+# VISION — what makes the community agent great
+
+The shared north star for the pipeline. The **research** worker generates
+proposals against this; the **adversarial** worker judges them against the same
+bar. Tune quality by editing this file, not the loop prompts.
+
+## Mission
+
+Make the **NZ Claude Community** more valuable to its members and lower-effort
+for its admins — while staying safe, private, and cheap to run. Concretely, the
+bot should help members:
+
+- get unstuck on Claude / the Anthropic API quickly and accurately,
+- find what the community already discussed instead of re-asking,
+- feel welcomed and know how to participate,
+
+and help admins moderate and curate with minimal manual effort.
+
+## Who we serve
+
+- **Members** — NZ people building with Claude/the API. Primary audience.
+- **Admins** — trusted members who moderate and curate, scoped to their own
+  conversations. Value = leverage: do more with less manual work.
+- **Super admin** — the operator. Value = control, safety, and visibility.
+
+## What a great proposal does
+
+Score each idea on:
+
+1. **Member/admin impact** — does it solve a real, felt problem, or is it a
+   nice-to-have nobody asked for?
+2. **Reach** — how many people benefit, how often?
+3. **Effort** — shippable in roughly one PR (with tests) beats a big project.
+4. **Fit** — respects the architecture and the security posture (see below).
+   A feature that fights the design is a bad feature even if useful.
+5. **Measurable** — we can state how we'd know it worked.
+
+Prefer **high-impact, high-reach, low-effort, low-risk**. When unsure, propose
+the **smallest viable version** and note how it could grow.
+
+## Ground proposals in evidence
+
+Propose from observed need, not imagination. Signal sources (in rough order):
+
+1. `community-feedback` issues (real member/admin requests).
+2. Open and closed `proposal` issues — build on what's wanted, avoid what was
+   rejected (read *why* it was rejected).
+3. Recent commits + the docs — know what already exists so you extend, not
+   duplicate.
+4. `needs-human` items and gaps called out in ARCHITECTURE.md / SECURITY.md
+   (e.g. documented deferrals and residual risks).
+5. Web search for what comparable developer communities value.
+
+## Theme areas (rotate for diversity)
+
+Each research run is memoryless, so deliberately vary across:
+
+- **Onboarding & welcome** — first-run experience, help, discoverability.
+- **Knowledge quality & recall** — better curation, search, freshness, sourcing.
+- **Answer quality** — accuracy, citations, NZ context, handling "I don't know".
+- **Moderation & safety** — lighter, safer admin workflows; abuse handling.
+- **Admin insight** — analytics, digests, what the community is asking about.
+- **Reliability & ops** — resilience, observability, graceful degradation.
+- **Cost efficiency** — doing more within the subscription's usage limits.
+- **Accessibility & inclusion** — clarity, language, reachability.
+
+## Guardrails — do NOT propose
+
+- **Rewrites** or sweeping refactors; anything not shippable in ~one PR.
+- Features that **expand the attack surface** (new privileged tools, broader
+  data access, new untrusted inputs) without a clear, proportionate payoff.
+- Anything that **weakens the security posture** in SECURITY.md (tier-derived
+  tools, CONFIRM gating, secret redaction, conversation-scoped admin access,
+  identity-from-platform-only).
+- **WhatsApp features that increase ToS/ban risk** on the Baileys path.
+- **Privacy regressions** — more retention or exposure of member data without a
+  strong, documented reason (NZ Privacy Act 2020 expectations apply).
+- Features that **blow the shared Max usage pool** (heavy per-message model
+  calls, chatty background work) without a cost story.
+- **Duplicates** of shipped work or existing proposals; vague "improve X".
+
+A skipped run is better than a weak proposal. Quality over volume.

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -22,5 +22,6 @@ label "status:rejected" "E11D21" "Failed adversarial review"
 label "status:building" "5319E7" "Claimed by the build loop (WIP=1)"
 label "status:built"    "0052CC" "PR open, awaiting review/merge"
 label "needs-human"     "D93F0B" "Escalated: a human must decide"
+label "community-feedback" "0E8A16" "A real member/admin request; input for research proposals"
 
 echo "Labels created/updated."


### PR DESCRIPTION
## Summary

Gives the pipeline a north star so proposals aim at genuine community value instead of plausible-but-generic features. The core move: put "what a great proposal looks like" in a repo doc that **both** the research and adversarial workers read, so ideas are generated and judged against the same bar — and you tune quality by editing one file.

## Changes

- **`docs/VISION.md`** (new) — mission, who we serve (members / admins / super admin), a value rubric (impact · reach · effort · fit · measurable), evidence sources so proposals are grounded in observed need rather than invented, rotating theme areas for diversity across memoryless runs, and explicit guardrails (no rewrites, no attack-surface / privacy / WhatsApp-ToS regressions, no duplicates — quality over volume).
- **`docs/PIPELINE.md`** — research prompt now: reads VISION first, **gathers evidence before inventing**, scores against the rubric, files the **smallest viable version** with **measurable acceptance criteria**, and is explicitly allowed to **skip a run rather than file noise**. Adversarial judges against the **same** rubric. Both the `/loop` and routine variants updated.
- **`scripts/setup-labels.sh`** — adds a `community-feedback` label as the intake channel for real member/admin requests, which research prioritises as signal.

Docs + label script only — no application code.

## Follow-up
After merge, re-run **Actions → "Setup pipeline labels"** to create the new `community-feedback` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_