### PR TITLE
Add question_digest admin tool for recurring-question discovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,10 @@ memory**:
 4. Admins can promote durable facts into `knowledge` via `save_knowledge`, and
    curate existing entries with `list_knowledge` (browse by scope),
    `update_knowledge` (correct + re-embed), and `delete_knowledge` (retire,
-   CONFIRM-gated).
+   CONFIRM-gated). `question_digest` closes the discovery gap: it greedily
+   clusters recent addressed-to-bot messages by embedding similarity (reusing
+   the same vectors, no new embedding calls) to surface "N people asked this"
+   patterns worth turning into a knowledge entry.
 
 Conversation continuity uses the Agent SDK's session resume: the Claude
 `session_id` for each `(platform, conversation)` is stored in `sessions` and
@@ -110,6 +113,7 @@ and every privileged action is audited and alerted to super admins by DM.
 | `moderate` / `announce` | ❌ | ❌ | ✅ *their conversations*, confirm-gated | ✅ anywhere |
 | `save_knowledge` / `list_knowledge` / `update_knowledge` / `delete_knowledge` | ❌ | ❌ | ✅, delete confirm-gated | ✅ |
 | `list_access_requests` | ❌ | ❌ | ✅ *(not conversation-scoped — see below)* | ✅ |
+| `question_digest` (recurring-question clusters) | ❌ | ❌ | ✅ *their conversations* | ✅ all |
 | `add_member` / `remove_member` | ❌ | ❌ | ✅ (member tier only) | ✅ |
 | Web search & summarise (`WebSearch`; `WebFetch` never) | ❌ | ❌ | ✅ | ✅ |
 | `grant_admin` / `revoke_admin`, `purge_user_data`, `audit_view`, `usage_stats`, `pause_bot`, `set_policy` | ❌ | ❌ | ❌ | ✅ |

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -14,6 +14,7 @@ import {
   listKnowledge,
   purgeUserData,
   recentAuditEntries,
+  recentQuestionClusters,
   recordAdminAction,
   removeMember,
   saveKnowledge,
@@ -474,6 +475,28 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     { annotations: { readOnlyHint: true } },
   );
 
+  const questionDigest = tool(
+    'question_digest',
+    'Show recurring questions asked in your conversations over recent days (count >= 2), a signal for what should become a knowledge entry. Admin only.',
+    {
+      days: z.number().optional().describe('Window in days (default 7, max 30)'),
+      limit: z.number().optional().describe('Max clusters to return (default 10)'),
+    },
+    async (args) => {
+      assertAtLeast(caller.role, 'admin', 'question_digest');
+      const allowed = await callerScope();
+      const clusters = await recentQuestionClusters(allowed, args.days ?? 7, args.limit ?? 10);
+      if (clusters.length === 0) return text('No recurring questions in that window (within your conversations).');
+      return text(
+        untrusted(
+          'Recurring questions',
+          clusters.map((c, i) => `${i + 1}. (${c.count}x) ${c.representative.slice(0, 300)}`).join('\n'),
+        ),
+      );
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
   const addMember = tool(
     'add_member',
     'Register a user as a community member so the bot will talk to them (gated mode). Admin only; grants member tier only.',
@@ -708,6 +731,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
       updateKnowledgeTool,
       deleteKnowledgeTool,
       listAccessRequestsTool,
+      questionDigest,
       addMember,
       removeMemberTool,
       grantAdmin,

--- a/src/auth/rbac.ts
+++ b/src/auth/rbac.ts
@@ -57,6 +57,7 @@ export const ADMIN_TOOLS = [
   'mcp__community__update_knowledge',
   'mcp__community__delete_knowledge',
   'mcp__community__list_access_requests',
+  'mcp__community__question_digest',
   'mcp__community__add_member',
   'mcp__community__remove_member',
 ] as const;

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -687,3 +687,74 @@ export async function listAccessRequests(limit = 50): Promise<AccessRequest[]> {
 export async function clearAccessRequest(platform: Platform, userId: string): Promise<void> {
   await pool.query(`DELETE FROM access_requests WHERE platform = $1 AND user_id = $2`, [platform, userId]);
 }
+
+// --- Question digest ---------------------------------------------------------
+
+export interface QuestionCluster {
+  representative: string;
+  count: number;
+}
+
+const QUESTION_CLUSTER_SIMILARITY_THRESHOLD = 0.85;
+
+/** Dot product of two embed()-produced (L2-normalized) vectors equals cosine similarity. */
+function cosineSim(a: number[], b: number[]): number {
+  let dot = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+/**
+ * Greedily cluster recently-addressed inbound messages by embedding
+ * similarity to surface recurring, un-curated questions — a signal for what
+ * should become a `knowledge` entry. Clustering runs in application code over
+ * an already time-bounded, conversation-scoped result set (no SQL self-join;
+ * see #21 for why that's the right tradeoff at this scale).
+ */
+export async function recentQuestionClusters(
+  conversationIds: readonly string[] | null,
+  days = 7,
+  limit = 10,
+): Promise<QuestionCluster[]> {
+  const clampedDays = Math.min(Math.max(Math.trunc(days) || 7, 1), 30);
+  const clampedLimit = Math.min(Math.max(Math.trunc(limit) || 10, 1), 50);
+
+  const params: unknown[] = [`${clampedDays} days`];
+  let scope = '';
+  if (conversationIds) {
+    params.push([...conversationIds]);
+    scope = `AND conversation_id = ANY($${params.length})`;
+  }
+
+  const { rows } = await pool.query(
+    `SELECT content, embedding
+       FROM interactions
+      WHERE addressed_to_bot = true AND direction = 'inbound'
+        AND embedding IS NOT NULL
+        AND created_at > now() - $1::interval
+        ${scope}
+      ORDER BY created_at ASC`,
+    params,
+  );
+
+  const clusters: Array<{ representative: string; embedding: number[]; count: number }> = [];
+  for (const row of rows) {
+    const vec = row.embedding as number[] | null;
+    if (!vec) continue;
+    const match = clusters.find(
+      (c) => cosineSim(c.embedding, vec) >= QUESTION_CLUSTER_SIMILARITY_THRESHOLD,
+    );
+    if (match) {
+      match.count += 1;
+    } else {
+      clusters.push({ representative: row.content, embedding: vec, count: 1 });
+    }
+  }
+
+  return clusters
+    .filter((c) => c.count >= 2)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, clampedLimit)
+    .map((c) => ({ representative: c.representative, count: c.count }));
+}

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -15,6 +15,8 @@ process.env.WHATSAPP_PROVIDER ??= 'disabled';
 const skip = hasDb ? false : 'DATABASE_URL not set — skipping DB-integration tests (CLAUDE.md: exercise against a local Postgres 16 + pgvector)';
 
 const { pool, closeDb } = await import('../src/storage/db.js');
+const { config } = await import('../src/config.js');
+const pgvector = (await import('pgvector/pg')).default;
 const {
   recordInteraction,
   userMessages,
@@ -25,6 +27,7 @@ const {
   updateKnowledge,
   deleteKnowledge,
   recordAdminAction,
+  recentQuestionClusters,
 } = await import('../src/storage/repository.js');
 
 // Unique per test-run tag so fixtures never collide across runs and can be
@@ -232,4 +235,68 @@ test('SECURITY: repository: admin conversation scoping excludes conversations ou
   );
 
   await pool.query(`DELETE FROM interactions WHERE user_id = $1`, [userId]);
+});
+
+test('repository: recentQuestionClusters groups near-duplicate embeddings, separates unrelated ones, and enforces count >= 2', { skip }, async () => {
+  const conversationId = `${RUN}-c-digest`;
+
+  // Hand-crafted vectors (not run through the real embedding model) so
+  // similarity is deterministic: two identical "same question" vectors
+  // cluster together; an orthogonal vector stays its own singleton cluster
+  // and is dropped by the count >= 2 filter.
+  const dim = config.db.embeddingDim;
+  const sameQuestionVec = new Array(dim).fill(0);
+  sameQuestionVec[0] = 1;
+  const unrelatedVec = new Array(dim).fill(0);
+  unrelatedVec[1] = 1;
+
+  const insertAddressed = (content: string, vec: number[]) =>
+    pool.query(
+      `INSERT INTO interactions
+         (platform, conversation_id, user_id, role, direction, content, addressed_to_bot, embedding)
+       VALUES ($1,$2,$3,$4,'inbound',$5,true,$6)`,
+      ['discord', conversationId, `${RUN}-digest-user`, 'member', content, pgvector.toSql(vec)],
+    );
+
+  await insertAddressed('How do I reset my password?', sameQuestionVec);
+  await insertAddressed('I forgot my password, how do I reset it?', sameQuestionVec);
+  await insertAddressed('What time is the next meetup?', unrelatedVec);
+
+  const clusters = await recentQuestionClusters([conversationId], 7, 10);
+  assert.equal(clusters.length, 1, 'only the count >= 2 cluster survives; the singleton is dropped');
+  assert.equal(clusters[0].count, 2);
+  assert.equal(clusters[0].representative, 'How do I reset my password?', 'representative is the first message seen');
+
+  await pool.query(`DELETE FROM interactions WHERE conversation_id = $1`, [conversationId]);
+});
+
+test('SECURITY: repository: recentQuestionClusters excludes conversations outside the given scope', { skip }, async () => {
+  const inScopeConvo = `${RUN}-c-digest-in`;
+  const outOfScopeConvo = `${RUN}-c-digest-out`;
+  const dim = config.db.embeddingDim;
+  const vec = new Array(dim).fill(0);
+  vec[2] = 1;
+
+  const insertAddressed = (conversationId: string, content: string) =>
+    pool.query(
+      `INSERT INTO interactions
+         (platform, conversation_id, user_id, role, direction, content, addressed_to_bot, embedding)
+       VALUES ($1,$2,$3,$4,'inbound',$5,true,$6)`,
+      ['discord', conversationId, `${RUN}-digest-scope-user`, 'member', content, pgvector.toSql(vec)],
+    );
+
+  await insertAddressed(inScopeConvo, 'in-scope question A');
+  await insertAddressed(inScopeConvo, 'in-scope question B');
+  await insertAddressed(outOfScopeConvo, 'out-of-scope question A');
+  await insertAddressed(outOfScopeConvo, 'out-of-scope question B');
+
+  const scoped = await recentQuestionClusters([inScopeConvo], 7, 10);
+  assert.equal(scoped.length, 1, 'clusters only reflect the in-scope conversation');
+  assert.equal(scoped[0].count, 2);
+
+  const unscoped = await recentQuestionClusters(null, 7, 10);
+  const totalUnscoped = unscoped.reduce((n, c) => n + c.count, 0);
+  assert.ok(totalUnscoped >= 4, 'without a scope filter (super admin), both conversations contribute');
+
+  await pool.query(`DELETE FROM interactions WHERE conversation_id = ANY($1)`, [[inScopeConvo, outOfScopeConvo]]);
 });


### PR DESCRIPTION
Closes #21

## Summary

Adds an admin-tier `question_digest` tool that surfaces recurring, un-curated
questions from an admin's own conversations — a signal for what should become
a `knowledge` entry — without any new schema, embedding calls, or background
job.

- `recentQuestionClusters(conversationIds, days, limit)` in
  `src/storage/repository.ts`: selects `content`/`embedding` from
  `interactions` where `addressed_to_bot = true AND direction = 'inbound'`,
  scoped by conversation id (or unscoped for super admin) and a clamped
  day window (default 7, max 30), then greedily clusters the rows in
  application code by cosine similarity (dot product, since `embed()`
  already L2-normalizes vectors) at a `0.85` threshold. Returns clusters
  with `count >= 2`, sorted by count desc, capped at `limit` (default 10,
  max 50).
- `question_digest` tool in `src/agent/tools.ts`, gated
  `assertAtLeast(caller.role, 'admin', ...)`, reusing the same
  `callerScope()` helper every other admin data tool uses for conversation
  scoping. Read-only, so no `audited()`/CONFIRM wrapper (matches
  `usage_stats`' own read-only shape).
- Registered in `ADMIN_TOOLS` (`src/auth/rbac.ts`).
- `docs/ARCHITECTURE.md`: added a capability-table row and a short mention
  next to the existing knowledge-curation description.

Matches the smallest-viable scope from the proposal: no auto-promotion to
knowledge, no cross-check against existing `knowledge` entries — an admin
reads the digest and decides whether to `save_knowledge` it themselves.

## Security impact

- **No new data exposure beyond what admins can already read.** Same
  category of content (message text from conversations the admin is
  already scoped to) as `remember_search`/`user_history`, just grouped by
  similarity.
- **Scoping is identical to existing admin tools** — reuses `callerScope()`,
  the same platform-verified conversation-membership filter every other
  admin data tool applies. A dedicated test proves an admin-scoped query
  excludes another conversation's clusters.
- **Read-only, no side effects** — no audit/CONFIRM gate needed.
- **No new untrusted-input surface** — inputs are an optional day-count and
  limit, both server-clamped (days: 1–30, limit: 1–50); no message content
  is treated as instructions in the query or clustering path. Output is
  wrapped with the existing `untrusted()` framing before being handed back
  to the model, same as other tools that echo past chat content.
- **Bounded cost** — no new embedding calls (reuses already-computed
  vectors), one indexed SQL `SELECT` per invocation, in-process clustering
  over a capped, time-windowed row count. No recurring background job.

## Verification

- `npm run typecheck` — clean.
- `npm test` — all tests pass, including two new DB-integration tests in
  `tests/repository.test.ts` exercised against a local Postgres 16 +
  `pgvector` instance (migrated via `npm run migrate`):
  - clustering groups near-duplicate embeddings, separates an unrelated
    one, and enforces the `count >= 2` filter (hand-crafted vectors, so
    the assertion doesn't depend on the real embedding model's actual
    similarity output for paraphrases).
  - `SECURITY:` scoping test — an admin-scoped query excludes another
    conversation's clusters; an unscoped (super-admin) query sees both.
- `npm run build` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015MvF9WPwUhHX65a8AutbEf)_