### PR TITLE
Add proactive super-admin usage alert for shared Max-pool budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ HEALTH_ALERT_AFTER_MINUTES=5
 # (no listening port). If set, bind to localhost and put a reverse proxy in
 # front — same guidance as the WhatsApp Cloud webhook port.
 HEALTH_PORT=
+# Proactive super-admin DM alert when the rolling-24h outbound reply count
+# reaches this threshold. Unset/0 = disabled (default; no timer, no extra
+# queries). Reply count is a coarse proxy for shared Max-pool draw, not an
+# exact token reading — tune to your own community's traffic.
+USAGE_ALERT_DAILY_REPLIES=
 # Log level: trace|debug|info|warn|error
 LOG_LEVEL=info
 # Set to "true" to pretty-print logs (dev only).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,6 +188,32 @@ The debounce/payload logic lives in `src/healthState.ts`, deliberately free
 of config/HTTP/adapter imports so it's unit-tested directly (`src/health.ts`
 is the thin I/O wrapper around it).
 
+## Usage & shared Max-pool alerting
+
+The bot authenticates against a Claude **subscription** (see SECURITY.md
+"Subscription-auth caveat"), and that same weekly token pool is shared with
+the automated multi-loop pipeline sessions (see PIPELINE.md). `src/usageAlert.ts`
+adds an opt-in proactive check on top of the existing (pull-only, super-admin)
+`usage_stats` tool:
+
+- Off unless `USAGE_ALERT_DAILY_REPLIES` is set — no timer is created, zero
+  extra queries, when unconfigured.
+- When set, an hourly check calls `usageStats(1)` (rolling 24h) and compares
+  the **outbound reply count** — not `cost_usd` — against the threshold.
+  Reply count is a coarse proxy for shared Max-pool draw (a short reply and a
+  long one draw very differently), so tune the threshold to your own
+  traffic; `cost_usd` is still shown in the alert as supplementary context,
+  but SECURITY.md already documents that it can silently under-report if
+  recording degrades open, so it's never the trigger condition.
+- Debounced with a rolling-window latch (`stepUsageAlertTracker`, pure and
+  unit-tested like `healthState.ts`'s disconnect tracker): one DM per
+  crossed window, no repeat while still over, no "back to normal" DM when it
+  drops back below — it just silently re-arms.
+- The alert DM rides the same `sendDirectMessage` super-admin path
+  `health.ts`'s disconnect alert already uses. No new privileged tool, no
+  new RBAC surface, no auto-`pause_bot` — a super admin decides whether to
+  pause manually.
+
 ## Switching WhatsApp providers
 
 The Baileys adapter is the default (immediate, free, dedicated number, but

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,6 +86,13 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
 - `cost_usd` is recorded per outbound turn for monitoring.
 - The bot only responds when **addressed** (mention/reply) or in a direct
   chat — it does not react to every message in a channel.
+- Optional proactive alert (`USAGE_ALERT_DAILY_REPLIES`, off by default):
+  when the rolling-24h outbound reply count reaches the configured
+  threshold, super admins get one debounced DM (`src/usageAlert.ts`) instead
+  of having to remember to run `usage_stats`. Reply count, not `cost_usd`, is
+  the trigger — it's a coarse proxy for shared Max-pool draw that can't
+  silently under-report the way `cost_usd` can (see below). No auto-pause;
+  a super admin decides.
 
 ### 4. Moderation misuse / accountability
 **Controls**

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,11 @@ const EnvSchema = z.object({
   INTERACTION_RETENTION_DAYS: z.coerce.number().int().nonnegative().default(0),
   // Sustained platform disconnect -> one debounced super-admin DM alert.
   HEALTH_ALERT_AFTER_MINUTES: z.coerce.number().positive().default(5),
+  // Proactive super-admin alert when rolling-24h outbound reply count
+  // reaches this threshold — a coarse proxy for shared Max-pool draw (short
+  // vs long replies draw differently; tune to your traffic). Unset/0 =
+  // disabled (no timer, no behaviour change on upgrade).
+  USAGE_ALERT_DAILY_REPLIES: z.coerce.number().int().nonnegative().default(0),
   // /healthz endpoint (native http, no auth). Unset = disabled; bind to
   // localhost via reverse proxy if you expose it, like the Cloud webhook.
   HEALTH_PORT: z.coerce.number().int().positive().optional(),
@@ -158,6 +163,7 @@ export const config = {
     interactionRetentionDays: env.INTERACTION_RETENTION_DAYS,
     healthAlertAfterMinutes: env.HEALTH_ALERT_AFTER_MINUTES,
     healthPort: env.HEALTH_PORT,
+    usageAlertDailyReplies: env.USAGE_ALERT_DAILY_REPLIES,
   },
   log: {
     level: env.LOG_LEVEL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Router } from './router.js';
 import { closeDb, healthcheck } from './storage/db.js';
 import { purgeOldInteractions, verifyEmbeddingDim } from './storage/repository.js';
 import { startDisconnectAlerts, startHealthServer } from './health.js';
+import { startUsageAlert } from './usageAlert.js';
 import type { PlatformAdapter } from './platforms/types.js';
 import { DiscordAdapter } from './platforms/discord/adapter.js';
 import { BaileysAdapter } from './platforms/whatsapp/baileysAdapter.js';
@@ -73,11 +74,15 @@ async function main(): Promise<void> {
   const disconnectAlertTimer = startDisconnectAlerts(adapters);
   const healthServer = await startHealthServer(adapters);
 
+  // 4d. Optional proactive usage alert (disabled unless configured).
+  const usageAlertTimer = startUsageAlert(adapters);
+
   // 5. Graceful shutdown.
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutting down');
     if (retentionTimer) clearInterval(retentionTimer);
     clearInterval(disconnectAlertTimer);
+    if (usageAlertTimer) clearInterval(usageAlertTimer);
     if (healthServer) await new Promise<void>((resolve) => healthServer.close(() => resolve()));
     await Promise.allSettled(adapters.map((a) => a.stop()));
     await closeDb();

--- a/src/usageAlert.ts
+++ b/src/usageAlert.ts
@@ -1,0 +1,83 @@
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { superAdminIds } from './auth/roles.js';
+import { usageStats } from './storage/repository.js';
+import type { PlatformAdapter } from './platforms/types.js';
+
+const CHECK_INTERVAL_MS = 60 * 60_000; // hourly — cheap read query, no need for health.ts's 30s cadence
+
+export interface UsageAlertTracker {
+  crossed: boolean;
+}
+
+export function initialUsageAlertTracker(): UsageAlertTracker {
+  return { crossed: false };
+}
+
+/**
+ * Pure rolling-window latch: `outbound` (replies in the last 24h) is a
+ * coarse proxy for shared Max-pool draw, not a precise token count — short
+ * vs long replies draw differently, so operators should tune the threshold
+ * to their own traffic. An alert fires once when outbound first reaches the
+ * threshold, and the latch only re-arms once a later check sees outbound
+ * drop back under — so oscillating just above the threshold across ticks
+ * yields exactly one alert, not one per tick.
+ */
+export function stepUsageAlertTracker(
+  tracker: UsageAlertTracker,
+  outbound: number,
+  threshold: number,
+): { tracker: UsageAlertTracker; shouldAlert: boolean } {
+  if (outbound < threshold) {
+    return { tracker: { crossed: false }, shouldAlert: false };
+  }
+  return { tracker: { crossed: true }, shouldAlert: !tracker.crossed };
+}
+
+/**
+ * Hourly check of usageStats(1) (rolling 24h) against USAGE_ALERT_DAILY_REPLIES.
+ * Disabled (no timer created) unless the threshold is configured. On trip,
+ * DMs super admins via the same sendDirectMessage path health.ts's
+ * disconnect alert already uses — no new privileged tool, no new send
+ * cadence, no message content or per-user detail beyond the aggregate
+ * usage_stats already exposes.
+ */
+export function startUsageAlert(adapters: readonly PlatformAdapter[]): ReturnType<typeof setInterval> | null {
+  const threshold = config.behaviour.usageAlertDailyReplies;
+  if (!threshold) return null;
+
+  let tracker = initialUsageAlertTracker();
+
+  const check = () => {
+    usageStats(1)
+      .then((stats) => {
+        const step = stepUsageAlertTracker(tracker, stats.outbound, threshold);
+        tracker = step.tracker;
+        if (step.shouldAlert) {
+          logger.warn({ outbound: stats.outbound, threshold, costUsd: stats.costUsd }, 'Usage alert threshold crossed');
+          void alertSuperAdmins(
+            adapters,
+            `⚠️ Usage alert: ${stats.outbound} replies in the last 24h (threshold ${threshold}).` +
+              (stats.costUsd > 0 ? ` ~$${stats.costUsd.toFixed(2)} recorded.` : '') +
+              ' Reply count is a coarse proxy for shared Max-pool draw, not an exact reading — consider pause_bot if this is unexpected.',
+          );
+        }
+      })
+      .catch((err) => logger.error({ err }, 'Usage alert check failed'));
+  };
+  check();
+  const timer = setInterval(check, CHECK_INTERVAL_MS);
+  timer.unref();
+  return timer;
+}
+
+async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
+  for (const adapter of adapters) {
+    if (!adapter.isConnected()) continue; // can't send through a dead connection
+    for (const id of superAdminIds(adapter.platform)) {
+      adapter.sendDirectMessage(id, message).catch((err) =>
+        logger.warn({ err, platform: adapter.platform, id }, 'Usage alert DM failed'),
+      );
+    }
+  }
+}

--- a/tests/usageAlert.test.ts
+++ b/tests/usageAlert.test.ts
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// config.ts validates env at import time — provide a dummy environment
+// before importing anything that (transitively) loads it, matching the
+// convention in tests/agentOptions.test.ts. USAGE_ALERT_DAILY_REPLIES is
+// deliberately left unset so it exercises the disabled-by-default path.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
+
+const { initialUsageAlertTracker, stepUsageAlertTracker, startUsageAlert } = await import('../src/usageAlert.js');
+
+const THRESHOLD = 100;
+
+test('startUsageAlert: USAGE_ALERT_DAILY_REPLIES unset (default) creates no timer', () => {
+  const timer = startUsageAlert([]);
+  assert.equal(timer, null, 'disabled by default — no timer, no extra queries');
+});
+
+test('stepUsageAlertTracker: under the threshold never alerts', () => {
+  const { tracker, shouldAlert } = stepUsageAlertTracker(initialUsageAlertTracker(), THRESHOLD - 1, THRESHOLD);
+  assert.deepEqual(tracker, { crossed: false });
+  assert.equal(shouldAlert, false);
+});
+
+test('stepUsageAlertTracker: crossing the threshold alerts exactly once', () => {
+  let tracker = initialUsageAlertTracker();
+  const first = stepUsageAlertTracker(tracker, THRESHOLD, THRESHOLD);
+  assert.equal(first.shouldAlert, true, 'alert fires the first tick at/over the threshold');
+  tracker = first.tracker;
+
+  const stillOver = stepUsageAlertTracker(tracker, THRESHOLD + 5, THRESHOLD);
+  assert.equal(stillOver.shouldAlert, false, 'debounced: no repeat alert while still over');
+  assert.equal(stillOver.tracker.crossed, true);
+});
+
+test('SECURITY/correctness: oscillating just above the threshold across ticks yields exactly one alert', () => {
+  let tracker = initialUsageAlertTracker();
+  let alerts = 0;
+  const ticks = [THRESHOLD, THRESHOLD + 1, THRESHOLD, THRESHOLD + 2, THRESHOLD];
+  for (const outbound of ticks) {
+    const step = stepUsageAlertTracker(tracker, outbound, THRESHOLD);
+    tracker = step.tracker;
+    if (step.shouldAlert) alerts += 1;
+  }
+  assert.equal(alerts, 1, 'no re-fire per tick while oscillating above the threshold without ever dropping below');
+});
+
+test('stepUsageAlertTracker: dropping back below the threshold clears the latch silently (no alert)', () => {
+  let tracker = initialUsageAlertTracker();
+  ({ tracker } = stepUsageAlertTracker(tracker, THRESHOLD, THRESHOLD)); // crossed = true
+
+  const dropped = stepUsageAlertTracker(tracker, THRESHOLD - 1, THRESHOLD);
+  assert.equal(dropped.shouldAlert, false, 'clearing the latch is silent, not an alert');
+  assert.deepEqual(dropped.tracker, { crossed: false });
+});
+
+test('stepUsageAlertTracker: re-arms only after dropping below and crossing again', () => {
+  let tracker = initialUsageAlertTracker();
+  ({ tracker } = stepUsageAlertTracker(tracker, THRESHOLD, THRESHOLD)); // first alert, crossed = true
+  ({ tracker } = stepUsageAlertTracker(tracker, THRESHOLD - 1, THRESHOLD)); // drops below, re-arms
+
+  const secondCrossing = stepUsageAlertTracker(tracker, THRESHOLD, THRESHOLD);
+  assert.equal(secondCrossing.shouldAlert, true, 'a fresh crossing after dropping below can alert again');
+});


### PR DESCRIPTION
Closes #22

## Summary

Adds an opt-in proactive usage alert so super admins learn the shared Max
subscription pool is trending toward exhaustion without having to remember
to invoke `usage_stats` manually.

- `src/config.ts` — `USAGE_ALERT_DAILY_REPLIES` (optional int, default
  0/unset = disabled, matching the existing opt-in pattern for
  `INTERACTION_RETENTION_DAYS`/`HEALTH_PORT`).
- `src/usageAlert.ts` (new) — `stepUsageAlertTracker`/`initialUsageAlertTracker`:
  a pure rolling-window latch (mirrors `healthState.ts`'s disconnect
  tracker so it's unit-testable without timers/DB) — `crossed` is set true
  the first tick `outbound >= threshold`, and only clears once a later tick
  sees `outbound` drop back below. `startUsageAlert(adapters)` wires an
  hourly `usageStats(1)` check to it; returns `null` (no timer) when the
  threshold is unset, so a disabled deployment runs zero extra queries.
  On trip: logs at `warn` and DMs super admins via the same
  `sendDirectMessage` path `health.ts`'s disconnect alert already uses.
- `src/index.ts` — wires `startUsageAlert` alongside `startRetentionPurge`/
  `startDisconnectAlerts`, including it in the graceful-shutdown
  `clearInterval` block.
- `docs/ARCHITECTURE.md` — new "Usage & shared Max-pool alerting" section.
- `docs/SECURITY.md` — note under "Abuse / cost runaway".
- `.env.example` — documents the new var.

The trigger is the rolling-24h **outbound reply count**, not `cost_usd`:
SECURITY.md already documents that cost recording can silently degrade
open, whereas reply count is a plain, always-populated row count. Reply
count is still a coarse proxy for actual token/pool draw (short vs long
replies draw differently) — the config comment and docs say so, and
`cost_usd` is surfaced in the alert body as supplementary context when
non-zero. No auto-`pause_bot` — this is alert-only; a super admin decides.

## Security impact

- **No new data exposure** — reuses `usageStats()`, already `super_admin`-only
  via the existing `usage_stats` tool; this just pushes the same aggregate
  counts/cost to the same audience (super admins) proactively instead of
  on-demand. No message content, no per-user identifying detail.
- **No new privileged tool, no new RBAC surface** — reuses the existing
  `sendDirectMessage` super-admin alert path from `health.ts`; no caller,
  so no `assertAtLeast` needed (system-triggered DM, like the disconnect
  alert).
- **No new untrusted-input surface** — the only input is a server-config
  threshold (optional int, env-validated).
- **Bounded cost** — one cheap indexed aggregate query per hour (the same
  query `usage_stats` already runs on demand), well below the existing 30s
  health-check cadence. Off by default, so no behaviour change for existing
  deployments until an operator opts in.
- **No new outbound-message cadence** — the alert is gated by the latch, so
  it sends at most once per crossed window through the existing
  super-admin-only DM path; not a new bulk/broadcast path, no WhatsApp
  ToS/send-cadence delta.

## Verification

- `npm run typecheck` — clean.
- `npm test` — all 81 tests pass (0 skipped), including new unit tests in
  `tests/usageAlert.test.ts`:
  - `startUsageAlert` creates no timer when `USAGE_ALERT_DAILY_REPLIES` is
    unset (default-disabled path).
  - crossing the threshold alerts exactly once and does not repeat while
    still over.
  - oscillating just above the threshold across several ticks (without
    ever dropping below) yields exactly one alert.
  - dropping back below the threshold clears the latch silently (no
    "back to normal" alert).
  - re-arms only after dropping below and crossing again.
  - DB-integration tests (`tests/repository.test.ts`, unrelated to this
    change but exercised as part of the full suite) ran against a local
    Postgres 16 + `pgvector` instance (migrated via `npm run migrate`).
- `npm run build` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015MvF9WPwUhHX65a8AutbEf)_