### PR TITLE
Fix build worker: explicit allowedTools + deterministic PR verify

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -13,6 +13,15 @@ name: Pipeline build worker
 # COST: every run draws on the SAME Max pool as the production bot and every
 # other session. `concurrency` serialises builds (enforces WIP=1) and
 # `--max-turns` + `timeout-minutes` bound a single run.
+#
+# WHY the explicit allowedTools + verify step: an earlier run finished with
+# conclusion=success but 12 permission denials and no branch/PR/relabel — the
+# action's opaque agent-mode defaults denied the write tools it needed, so it
+# narrated the work instead of doing it and the proposal stuck at
+# `status:approved` with no visible failure. We now (a) pre-approve exactly the
+# tools a build needs so there is zero denial thrash, and (b) verify the
+# outcome deterministically: if no open PR closing this issue exists, relabel
+# `needs-human`, comment, and fail the job loudly.
 
 on:
   issues:
@@ -38,6 +47,7 @@ jobs:
       # secrets are allowed in job-level env; this keeps the action step inert
       # until the token exists, so the workflow is safe to merge beforehand.
       HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -47,7 +57,9 @@ jobs:
         if: env.HAS_TOKEN == 'true'
 
       - name: Build the approved proposal
+        id: build
         if: env.HAS_TOKEN == 'true'
+        continue-on-error: true # never let a mid-run failure hide the outcome; the verify step below is the source of truth
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -68,6 +80,39 @@ jobs:
                unsafe as specified, add the `needs-human` label and explain instead of
                forcing it.
             Implement only this one approved issue.
+          # Pre-approve exactly the tools a build needs so there is no
+          # permission-denial thrash. Without this the action falls back to its
+          # opaque agent-mode defaults and silently denies git/gh/npm writes.
           claude_args: |
             --max-turns 40
             --model sonnet
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*),Bash(sed:*),Bash(rm:*)"
+
+      - name: Verify a PR was produced (else escalate + fail loudly)
+        if: always() && env.HAS_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # A build "succeeded" only if there is an OPEN PR whose body closes
+          # this issue. Anything else (silent no-op, denial thrash, crash) must
+          # be surfaced, not swallowed by a green check.
+          match="$(gh pr list --state open --limit 100 \
+            --json number,body \
+            --jq "[.[] | select((.body // \"\") | test(\"[Cc]loses #${ISSUE_NUMBER}\\\\b\"))] | .[0].number // empty")"
+
+          if [ -n "${match}" ]; then
+            echo "Build produced PR #${match} closing issue #${ISSUE_NUMBER}."
+            exit 0
+          fi
+
+          echo "::error::Build worker finished without opening a PR that closes issue #${ISSUE_NUMBER}."
+
+          # Escalate so the proposal does not sit silently at status:approved.
+          gh issue edit "${ISSUE_NUMBER}" --add-label needs-human || true
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue comment "${ISSUE_NUMBER}" --body "🤖 Build worker ran but produced **no pull request** closing this issue, so it could not be marked \`status:built\`. Labelled \`needs-human\` for a maintainer to investigate. Run: ${run_url}" || true
+
+          exit 1


### PR DESCRIPTION
## What & why

The pipeline build worker (`.github/workflows/pipeline-build.yml`) could finish with `conclusion=success` yet produce **no branch, no PR, and no issue relabel**, leaving the approved proposal stuck at `status:approved` with no visible failure. Actions run `28656605798` is the concrete case: success, but `permission_denials_count: 12`, `num_turns: 17`, no output.

**Root cause:** `claude_args` set no `--allowedTools`, so `claude-code-action` fell back to its opaque agent-mode defaults and denied the `git`/`gh`/`npm` write tools a build actually needs. The agent thrashed on denials, then narrated the work instead of doing it — and the green check hid it.

## Changes

- **Pre-approve exactly the tools a build needs** via `--allowedTools` (`Edit`, `Write`, `Read`, `MultiEdit`, `Grep`, `Glob`, `LS`, `TodoWrite`, and scoped `Bash(git:*|gh:*|npm:*|npx:*|node:*|...)`) so there is zero permission-denial thrash.
- **`continue-on-error: true`** on the action step so a mid-run failure can't be the thing that reports the outcome.
- **New deterministic verify step** (`if: always()`): queries `gh pr list` for an **open** PR whose body closes this issue. If one exists, pass. If none exists, relabel the issue `needs-human`, comment a link back to the run, and **`exit 1`** so a silent no-op becomes a loud, visible failure instead of a green check.

This mirrors the same fail-loudly pattern already applied to the PR-review worker in #26.

## Security / privacy impact

No change to the bot's runtime surface or RBAC. This is CI-only. The added `Bash` scopes apply solely to the build worker's own GitHub Actions run (which already had `contents`/`issues`/`pull-requests: write`); the verify step uses the default `GITHUB_TOKEN`. No secrets are added or exposed.

## How verified

- `python3 -c "yaml.safe_load(...)"` — workflow YAML parses.
- jq filter guards against null PR bodies (`(.body // "")`).
- Behaviour confirmed by inspection against the failing run's symptoms; the true end-to-end test is the next `status:approved` label event (the stuck proposal, once re-triggered after merge).

## Follow-ups (not in this PR)

- The proposal *"surface knowledge-entry recency to the model so stale FAQs get hedged"* is stuck at `status:approved` with no PR; after this merges it needs re-triggering (remove + re-add the `status:approved` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_