### PR TITLE
Harden build-worker verify step against spoofed/stale PRs

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -53,6 +53,13 @@ jobs:
         if: env.HAS_TOKEN != 'true'
         run: echo "CLAUDE_CODE_OAUTH_TOKEN not set — build worker is inert. Add the secret + install the Claude GitHub App to enable."
 
+      # Stamp the moment this run starts, before the build can open anything.
+      # The verify step only counts a PR created AFTER this instant, so a stale
+      # PR left by a prior attempt can never be mistaken for this run's output.
+      - name: Record job start (PR freshness watermark)
+        if: env.HAS_TOKEN == 'true'
+        run: echo "STARTED_AT=$(date -u +%s)" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
         if: env.HAS_TOKEN == 'true'
 
@@ -83,10 +90,14 @@ jobs:
           # Pre-approve exactly the tools a build needs so there is no
           # permission-denial thrash. Without this the action falls back to its
           # opaque agent-mode defaults and silently denies git/gh/npm writes.
+          # Deliberately NO bare `rm`/`sed`: the build worker processes
+          # (potentially adversarial) issue content, so we keep the shell
+          # surface minimal — file rewrites go through Edit/Write and tracked
+          # deletions through `git rm` (covered by Bash(git:*)).
           claude_args: |
             --max-turns 40
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*),Bash(sed:*),Bash(rm:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a PR was produced (else escalate + fail loudly)
         if: always() && env.HAS_TOKEN == 'true'
@@ -95,12 +106,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A build "succeeded" only if there is an OPEN PR whose body closes
-          # this issue. Anything else (silent no-op, denial thrash, crash) must
-          # be surfaced, not swallowed by a green check.
+          # A build "succeeded" only if there is an OPEN PR that:
+          #   (a) closes THIS issue in its body,
+          #   (b) lives in THIS repo — not a fork (isCrossRepository == false),
+          #       so an external contributor's throwaway "Closes #N" PR can't
+          #       spoof success, and
+          #   (c) was created AFTER this run started (createdAt >= STARTED_AT),
+          #       so a stale PR from a prior attempt can't mask a fresh no-op.
+          # Anything else (silent no-op, denial thrash, crash) is surfaced, not
+          # swallowed by a green check.
           match="$(gh pr list --state open --limit 100 \
-            --json number,body \
-            --jq "[.[] | select((.body // \"\") | test(\"[Cc]loses #${ISSUE_NUMBER}\\\\b\"))] | .[0].number // empty")"
+            --json number,body,createdAt,isCrossRepository \
+            --jq "[.[] | select((.isCrossRepository | not) and ((.body // \"\") | test(\"[Cc]loses #${ISSUE_NUMBER}\\\\b\")) and ((.createdAt | fromdateiso8601) >= ${STARTED_AT}))] | .[0].number // empty")"
 
           if [ -n "${match}" ]; then
             echo "Build produced PR #${match} closing issue #${ISSUE_NUMBER}."


### PR DESCRIPTION
## What & why

Follow-up to #29 (merged). The automated PR review on #29 raised a **valid, blocking** correctness/security finding that landed just as the PR was merged, so it never got addressed there.

The verify step added in #29 counted **any** open PR whose body matched `Closes #N` as proof the run succeeded. That recreates the very silent-no-op failure mode #29 existed to kill, moved one layer over:

- **Fork spoof:** this repo accepts fork PRs. An external contributor could open a throwaway PR containing `Closes #N`, and a genuine build no-op would `exit 0` with no `needs-human` escalation.
- **Stale reuse:** the documented re-trigger flow re-adds `status:approved`. If a prior attempt left an open PR with matching text, a fresh *thrashing* run would pass verification against that old PR instead of its own (non-)output.

## Changes

- **Verify step now only counts a qualifying PR** — one that is:
  - (a) in **this repo, not a fork** (`isCrossRepository == false`), killing the fork spoof, and
  - (b) **created after this run started** (`createdAt >= STARTED_AT`), killing stale reuse.
  - A new first step stamps `STARTED_AT` (epoch seconds) into `$GITHUB_ENV` *before* the build step, so the watermark predates anything this run could open.
- **Tightened `allowedTools`:** dropped bare `Bash(rm:*)` and `Bash(sed:*)`. The build worker processes potentially adversarial issue content; file rewrites go through `Edit`/`Write` and tracked deletions through `git rm` (`Bash(git:*)`), so the extra shell surface isn't needed.

The `--limit 100` nit from the review is left as-is: WIP caps in `CLAUDE.md` (≤3 draft + ≤1 building) keep open-PR count far below 100.

## Security / privacy impact

CI-only; no change to the bot's runtime surface or RBAC. Net **reduction** in blast radius: the verify step can no longer be fooled into swallowing a failure, and the build worker's shell surface is smaller. The verify step still uses the default `GITHUB_TOKEN`.

## How verified

- `yaml.safe_load(...)` — workflow parses.
- Ran the hardened jq filter against a mixed fixture (stale same-repo PR, fresh fork PR, fresh same-repo PR, null-body PR): it correctly selects **only** the fresh same-repo PR and excludes the other three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_