### PR TITLE
Raise build-worker turn cap from 40 to 80

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -94,8 +94,13 @@ jobs:
           # (potentially adversarial) issue content, so we keep the shell
           # surface minimal — file rewrites go through Edit/Write and tracked
           # deletions through `git rm` (covered by Bash(git:*)).
+          # A full implement→typecheck/test/build→git→PR→relabel cycle for even
+          # a small proposal runs past 40 turns once test/build iteration is
+          # counted (issue #27's run hit error_max_turns at turn 41 with zero
+          # permission denials). timeout-minutes: 45 is the real wall-clock
+          # guard; 80 turns fits comfortably inside it (~5 min for ~40 turns).
           claude_args: |
-            --max-turns 40
+            --max-turns 80
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 


### PR DESCRIPTION
## What & why

The build worker re-triggered on issue #27 (run `28657794823`) failed — but in the *right* way, which pinpointed the remaining gap.

The run showed:
```
"subtype": "error_max_turns", "num_turns": 41, "permission_denials_count": 0
```

- `permission_denials_count: 0` — the `--allowedTools` fix (#29) worked: **no denial thrash**.
- `error_max_turns` — the agent hit `--max-turns 40` mid-task and was cut off **before it could open the PR**.
- The verify step (#29/#30) then correctly labelled the issue `needs-human`, commented, and failed loudly — the intended behaviour, not a regression.

A full **implement → typecheck/test/build → git → PR → relabel** cycle for even a small proposal genuinely exceeds 40 turns once test/build iteration is counted. `timeout-minutes: 45` is the real wall-clock guard, and this run used only ~5 minutes for ~40 turns, so there's ample headroom.

## Changes

- `--max-turns 40` → `--max-turns 80` in the build worker's `claude_args`, with a comment explaining the wall-clock reasoning.

## Security / privacy impact

CI-only; no change to the bot's runtime surface or RBAC. A higher turn cap means a build can draw more from the shared Max pool per run, still bounded by `timeout-minutes: 45` and `concurrency` (WIP=1).

## How verified

- `yaml.safe_load(...)` — workflow parses.
- Diagnosis is directly from the failing run's result JSON (`error_max_turns` at turn 41, zero denials).
- End-to-end confirmation is the next `status:approved` re-trigger of #27 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_