### PR TITLE
Let PR-review worker review build-worker (bot) PRs

### DIFF
--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -56,6 +56,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The build worker opens its PRs as the `claude[bot]` GitHub App, and
+          # claude-code-action refuses to run on a bot-authored PR unless the
+          # bot is allow-listed ("Workflow initiated by non-human actor").
+          # Without this, EVERY build-worker PR fails review before the model
+          # even starts. `*` is safe here: this review job is strictly
+          # read-only (its allowedTools are gh pr diff/view + Read/Grep/Glob),
+          # it only posts a comment and can never merge or push, and fork PRs
+          # get no token (HAS_TOKEN empty -> inert) so this can't be abused
+          # from outside the repo.
+          allowed_bots: "*"
           prompt: |
             You are the PR-REVIEW worker for the NZ Claude Community agent.
             Review pull request #${{ env.PR }}. Use `gh pr diff ${{ env.PR }}` and


### PR DESCRIPTION
## What & why

The build worker successfully opened **PR #32** for issue #27 (the `--max-turns 80` fix worked). But its automated review then failed with:

```
Actor type: Bot
##[error]Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action` refuses to run on a **bot-authored** PR unless the bot is allow-listed. The build worker opens its PRs as the `claude[bot]` GitHub App, so the reviewer bailed out *before the model ran at all* — and the fail-loudly path (#26) then posted the "no output captured" notice.

This is a **structural gap**: every prior PR (#26–#31) was opened by a human, so the reviewer worked; #32 is the first build-worker-opened PR, and **every** future one would fail review identically until this is fixed.

## Changes

- Add `allowed_bots: "*"` to the review worker's `claude-code-action` step, with a comment explaining why.

## Security / privacy impact

CI-only. `*` is safe in this specific job because it is **strictly read-only**:
- `allowedTools` are `Bash(gh pr diff:*)`, `Bash(gh pr view:*)`, `Read`, `Grep`, `Glob`, `TodoWrite` — no write, no push, no merge.
- The job only posts a review comment; a human still merges.
- Fork PRs receive no secrets, so `HAS_TOKEN` is empty and the job is inert — this can't be driven from outside the repo.

In practice, same-repo bot PRs realistically only come from our own `claude[bot]`, so the effective surface is "review the build worker's PRs," which is the entire point of the pipeline. It can be narrowed to a specific bot login later if desired.

## How verified

- `yaml.safe_load(...)` — workflow parses.
- Root cause is directly from run `28658446907`'s logs (`Workflow initiated by non-human actor`).
- End-to-end confirmation: once merged, re-running the review on a build-worker PR should produce a real verdict instead of the "no output" notice.

## Follow-up

- PR #32 (the actual #27 implementation) is open and green on its own checks; its only red mark is this review failure. Once this merges, its review can be re-run (push/reopen) to get a real verdict before you merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_