### PR TITLE
Raise build-worker turn cap to 300 (and timeout to 60 min to match)

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -42,7 +42,10 @@ jobs:
     # Only react to the approved label; ignore every other label event.
     if: github.event.label.name == 'status:approved'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Wall-clock guard sized to the turn cap below: ~7s/turn observed means
+    # 300 turns can legitimately run ~40 min; 60 keeps headroom without
+    # letting a hung run camp on the concurrency slot all day.
+    timeout-minutes: 60
     env:
       # secrets are allowed in job-level env; this keeps the action step inert
       # until the token exists, so the workflow is safe to merge beforehand.
@@ -94,13 +97,14 @@ jobs:
           # (potentially adversarial) issue content, so we keep the shell
           # surface minimal — file rewrites go through Edit/Write and tracked
           # deletions through `git rm` (covered by Bash(git:*)).
-          # A full implement→typecheck/test/build→git→PR→relabel cycle for even
-          # a small proposal runs past 40 turns once test/build iteration is
-          # counted (issue #27's run hit error_max_turns at turn 41 with zero
-          # permission denials). timeout-minutes: 45 is the real wall-clock
-          # guard; 80 turns fits comfortably inside it (~5 min for ~40 turns).
+          # Turn-cap history: 40 died at turn 41 on a small 4-file proposal
+          # (issue #27); 80 died at turn 81 on a repo-wide job (issue #41,
+          # ESLint+Prettier — formatting sweeps and lint-fix iteration eat
+          # turns fast). 300 gives real proposals room to finish; the
+          # timeout-minutes above stays the wall-clock guard (~7s/turn
+          # observed, so 300 turns ≈ 40 min worst case).
           claude_args: |
-            --max-turns 80
+            --max-turns 300
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 


### PR DESCRIPTION
## What & why

Run `28666164080` — the build worker attempting issue #41 (ESLint + Prettier) — died at the turn cap:

```
"subtype": "error_max_turns", "num_turns": 81, "duration_ms": 573220
```

The verify step then escalated correctly (labelled #41 `needs-human`, commented, failed the job loudly) — the fail-loudly design working, not a regression.

Turn-cap history: 40 died at turn 41 on a small 4-file proposal (#27); 80 died at turn 81 on a repo-wide job (#41 — a formatting sweep plus lint-fix iteration eats turns fast). Per the maintainer's direction, raise the cap to **300** so real proposals can finish.

## Changes

- `--max-turns 80` → `--max-turns 300` in the build worker's `claude_args`.
- `timeout-minutes: 45` → `60`: at the observed ~7s/turn, 300 turns can legitimately run ~40 minutes, so the old timeout would have made the new cap unreachable. The timeout remains the wall-clock guard against hung runs.
- Updated the comment to carry the cap history so the next person sees why it's 300.

## Security / privacy impact

CI-only; no runtime/RBAC change. A single build run can now draw more from the shared Max pool (this failed 80-turn run cost ~$2.95-equivalent; a full 300-turn run could be roughly 4x that), still bounded by `timeout-minutes: 60` and the `concurrency` WIP=1 serialisation.

## How verified

- `yaml.safe_load(...)` — workflow parses.
- Diagnosis directly from the failing run's result JSON.
- End-to-end confirmation is the re-trigger of #41 after this merges.

## Follow-up (after merge)

- **#41 needs re-triggering**: it currently carries `needs-human` (from the escalation) plus `status:approved`. Remove `needs-human`, then toggle `status:approved` off/on to fire the fixed worker.
- Observed but not blocking: this run had `permission_denials_count: 6` (versus 0 on #27's run) — some tool calls were denied but didn't stall progress. Worth watching on the next run; if a legitimately-needed tool shows up repeatedly we can add it to `allowedTools` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_