### PR TITLE
Add CHANGELOG.md + whats_new tool so the agent can report its own updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the NZ Claude Community Agent, newest first. The format
+loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
+`whats_new` tool reads this file, so keep entries user-legible and add a new
+`##` dated section (or version) as part of each release.
+
+## 2026-07-03
+
+### Added
+- `moderation_history` admin tool, scoped to the admin's own conversations (#34).
+- `question_digest` admin tool to surface recurring questions (#23).
+- Proactive super-admin alert when the shared Max-pool usage budget runs high (#25).
+- `/healthz` endpoint and sustained-disconnect super-admin alerting (#14).
+- Age-based retention purge for raw interactions, for privacy (#12).
+- Persona registry with "Kaha" as the default voice (#19).
+- Shared VISION.md rubric; richer research and adversarial prompts (#18).
+- Postgres + pgvector CI service and repository integration tests (#15).
+- Build + PR-review GitHub Actions using Claude Max subscription auth (#20).
+
+### Changed
+- Outbound replies now convert Discord-style markdown to WhatsApp-readable formatting (#38).
+- Long WhatsApp Cloud API replies are chunked under Meta's 4096-character limit (#36).
+- `knowledge_search` surfaces how recent each knowledge entry is (#32).
+- Build-worker turn cap raised to 300 with a matching 60-minute timeout (#49; earlier 40 → 80 in #31).
+- PR-review worker can now review build-worker PRs (#33).
+- Pipeline loops documented as cloud Routines (#16).
+
+### Fixed
+- Blank optional numeric env vars (e.g. `HEALTH_PORT=`) no longer fail config validation (#40).
+- Build-worker verify step hardened against spoofed or stale PRs (#30).
+- Build worker uses an explicit allowedTools list and deterministic PR verification (#29).
+- PR-review worker does read-only reviews and always posts a deterministic verdict (#26, #24).
+
+## 2026-07-02
+
+### Added
+- Three-tier RBAC (super_admin / admin / member) with gated access, plus security and correctness fixes and dependency upgrades (#1).
+- WhatsApp Cloud adapter against the official Meta Cloud API (#6).
+- Knowledge curation tools: list, update, delete (#8).
+- Proactive onboarding: a Discord welcome message and an access-request queue (#10).
+- Multi-loop pipeline scaffolding: labels, docs, conventions (#2).
+
+### Fixed
+- `setup-labels` workflow: restored `contents:read` so checkout works (#3).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "undici": "^6.27.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && cp src/storage/schema.sql dist/storage/schema.sql",
+    "build": "tsc -p tsconfig.json && cp src/storage/schema.sql dist/storage/schema.sql && cp CHANGELOG.md dist/CHANGELOG.md",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/src/agent/changelog.ts
+++ b/src/agent/changelog.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { logger } from '../logger.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * CHANGELOG.md is the maintained source of truth at the repo root. In a
+ * production build tsc emits this module to `dist/agent/` and the build step
+ * copies CHANGELOG.md to `dist/` (mirroring how schema.sql is bundled), so it
+ * sits at `dist/CHANGELOG.md`. Under tsx (dev / tests) this runs from
+ * `src/agent/` with the file still at the repo root. Try both layouts.
+ */
+const CANDIDATE_PATHS = [
+  join(__dirname, '..', 'CHANGELOG.md'), // dist/agent -> dist/CHANGELOG.md (prod)
+  join(__dirname, '..', '..', 'CHANGELOG.md'), // src/agent -> repo root (dev/tests)
+];
+
+export interface ChangelogSection {
+  /** The `##` heading text, e.g. "2026-07-03" or a version. */
+  heading: string;
+  /** Everything under that heading up to the next `##`, trimmed. */
+  body: string;
+}
+
+let cache: ChangelogSection[] | null = null;
+
+async function readChangelogFile(): Promise<string | null> {
+  for (const path of CANDIDATE_PATHS) {
+    try {
+      return await readFile(path, 'utf8');
+    } catch {
+      // Try the next candidate layout.
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse the top-level `##` sections of CHANGELOG.md in file order (newest
+ * first, by convention). The `#` title preamble and `###` subsections are not
+ * treated as section boundaries. Result is cached for the process lifetime
+ * (the file only changes on redeploy, which restarts the process).
+ */
+export async function loadChangelog(): Promise<ChangelogSection[]> {
+  if (cache) return cache;
+  const raw = await readChangelogFile();
+  if (raw === null) {
+    logger.warn({ paths: CANDIDATE_PATHS }, 'CHANGELOG.md not found; whats_new has nothing to report');
+    return [];
+  }
+  const sections: ChangelogSection[] = [];
+  for (const chunk of raw.split(/\n(?=## )/)) {
+    const match = chunk.match(/^## +(.+)$/m);
+    if (!match) continue; // skips the H1 preamble chunk
+    const heading = match[1].trim();
+    const body = chunk.slice(chunk.indexOf(match[0]) + match[0].length).trim();
+    if (body) sections.push({ heading, body });
+  }
+  cache = sections;
+  return sections;
+}
+
+/** Format the most recent `limit` changelog sections as a compact summary. */
+export async function recentChanges(limit = 2): Promise<string> {
+  const sections = await loadChangelog();
+  if (sections.length === 0) return 'No changelog is available right now.';
+  const count = Math.min(Math.max(1, limit), sections.length);
+  return sections
+    .slice(0, count)
+    .map((section) => `## ${section.heading}\n${section.body}`)
+    .join('\n\n');
+}

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -28,6 +28,7 @@ import {
 } from '../storage/repository.js';
 import { updatePolicy } from '../storage/policies.js';
 import { registerPendingAction } from './pendingActions.js';
+import { recentChanges } from './changelog.js';
 
 /** Helper: wrap a string into the MCP tool result shape. */
 function text(t: string, isError = false) {
@@ -165,6 +166,16 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
           'The bot answers questions, remembers this conversation, and searches curated community knowledge. ' +
           'Admins additionally moderate, announce, and manage membership. Access is member-gated; admins can add members.',
       ),
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const whatsNew = tool(
+    'whats_new',
+    "Report the bot's own recent updates from its changelog. Use this whenever " +
+      "someone asks what's new, what changed, what you've been upgraded with, or " +
+      'about your recent versions/releases.',
+    { limit: z.number().int().positive().max(10).optional().describe('How many recent changelog sections to include (default 2)') },
+    async (args) => text(await recentChanges(args.limit ?? 2)),
     { annotations: { readOnlyHint: true } },
   );
 
@@ -762,6 +773,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     version: '2.0.0',
     tools: [
       communityInfo,
+      whatsNew,
       knowledgeSearch,
       rememberSearch,
       forgetMe,

--- a/src/auth/rbac.ts
+++ b/src/auth/rbac.ts
@@ -42,6 +42,7 @@ export function assertAtLeast(role: Tier, min: Tier, action: string): void {
 /** Tools (mcp__community__*) available to members (and guests in open mode). */
 export const MEMBER_TOOLS = [
   'mcp__community__community_info',
+  'mcp__community__whats_new',
   'mcp__community__knowledge_search',
   'mcp__community__remember_search',
   'mcp__community__forget_me',

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// config.ts (pulled in transitively via logger) validates env at import time —
+// provide a dummy environment before importing anything that loads it.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
+
+const { loadChangelog, recentChanges } = await import('../src/agent/changelog.js');
+
+test('loadChangelog parses top-level ## sections and ignores ### subsections', async () => {
+  const sections = await loadChangelog();
+  assert.ok(sections.length >= 2, 'expected at least two dated sections');
+  for (const section of sections) {
+    assert.ok(!section.heading.startsWith('#'), `heading should be stripped of #: "${section.heading}"`);
+    assert.ok(section.body.length > 0, 'section body should not be empty');
+  }
+  // Subsection markers stay in the body, not promoted to their own sections.
+  assert.ok(sections.some((s) => s.body.includes('### ')), 'expected ### subsections inside a section body');
+});
+
+test('recentChanges returns exactly the requested number of sections', async () => {
+  const one = await recentChanges(1);
+  assert.equal((one.match(/^## /gm) ?? []).length, 1);
+
+  const two = await recentChanges(2);
+  assert.equal((two.match(/^## /gm) ?? []).length, 2);
+});
+
+test('recentChanges clamps a huge limit to what exists and never throws on 0', async () => {
+  const all = await loadChangelog();
+  const huge = await recentChanges(999);
+  assert.equal((huge.match(/^## /gm) ?? []).length, all.length);
+
+  const zero = await recentChanges(0);
+  assert.equal((zero.match(/^## /gm) ?? []).length, 1, 'a floor of 1 section is returned');
+});


### PR DESCRIPTION
Closes #55.

## What

The bot couldn't answer "what changed / what are your recent upgrades" — there was no changelog and no tool exposing version history, so it truthfully said it had no visibility. This adds both.

- **`CHANGELOG.md`** (Keep a Changelog style) at the repo root, seeded from recent merged PRs — the maintained source of truth. Add a new `##` dated section per release.
- **`src/agent/changelog.ts`** — parses the top-level `##` sections (ignoring the `#` title and `###` subsections) and returns the most recent N, formatted. Path resolution tries both `dist/CHANGELOG.md` (prod) and the repo root (tsx dev/tests); result cached per process.
- **`whats_new` tool** (`mcp__community__whats_new`) added to `MEMBER_TOOLS`, so members, admins, super admins, and open-mode guests can ask. Read-only, optional `limit` (default 2).
- **Build** copies `CHANGELOG.md` into `dist/` (same pattern as `src/storage/schema.sql`) so it's readable under the systemd deploy.
- **Tests** for the parser (section splitting, limit clamping, floor-of-1).

## Verification

`npm run typecheck`, `npm run build` (emits `dist/CHANGELOG.md`), and the new `tests/changelog.test.ts` (3/3) all pass; `tests/rbac.test.ts` + `tests/agentOptions.test.ts` still green (12/12) after the `MEMBER_TOOLS` addition.

## Follow-up (not in this PR)

Keeping `CHANGELOG.md` current is now part of the release process; a future CI step could append merged-PR titles automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)