### PR TITLE
Finish Kaha→Dave persona rename (fix red test + id/alias casing)

### DIFF
--- a/src/agent/personas.ts
+++ b/src/agent/personas.ts
@@ -23,13 +23,13 @@ export interface Persona {
   voice: string;
 }
 
-export const DEFAULT_PERSONA_ID = 'Dave';
+export const DEFAULT_PERSONA_ID = 'dave';
 
 export const PERSONAS: Record<string, Persona> = {
-  Dave: {
-    id: 'Dave',
+  dave: {
+    id: 'dave',
     name: 'Dave',
-    aliases: ['Dave'],
+    aliases: ['dave'],
     voice: `
 You are "Dave", the NZ Claude Community's assistant. Warm, down-to-earth, and a
 bit cheeky, like a knowledgeable Kiwi maker who is genuinely glad to help, not a

--- a/tests/personas.test.ts
+++ b/tests/personas.test.ts
@@ -11,10 +11,10 @@ const caller = {
   conversationId: 'chan1',
 };
 
-test('default persona is Kaha and resolves for unknown/empty ids', () => {
+test('default persona is Dave and resolves for unknown/empty ids', () => {
   assert.equal(getPersona(null).id, DEFAULT_PERSONA_ID);
   assert.equal(getPersona('nope').id, DEFAULT_PERSONA_ID);
-  assert.equal(getPersona('kaha').name, 'Kaha');
+  assert.equal(getPersona('dave').name, 'Dave');
 });
 
 test('selectPersona falls back to the default when no alias matches', () => {
@@ -36,8 +36,8 @@ test('SECURITY: every persona keeps the security guidelines and human-style rule
 });
 
 test('persona changes voice, not the role note (permissions come from tier)', () => {
-  const asMember = buildSystemPrompt(caller, { codeAnswers: 'snippets' }, getPersona('kaha'));
-  const asAdmin = buildSystemPrompt({ ...caller, role: 'admin' }, { codeAnswers: 'snippets' }, getPersona('kaha'));
+  const asMember = buildSystemPrompt(caller, { codeAnswers: 'snippets' }, getPersona('dave'));
+  const asAdmin = buildSystemPrompt({ ...caller, role: 'admin' }, { codeAnswers: 'snippets' }, getPersona('dave'));
   // Same persona, but the tier-derived role note differs — persona never sets permissions.
   assert.match(asMember, /MEMBER/);
   assert.match(asAdmin, /an ADMIN/);


### PR DESCRIPTION
## Summary

The default persona was renamed Kaha → Dave in source, but a few references were missed, leaving `main` red on `tests/personas.test.ts` (`'Dave' !== 'Kaha'`). This finishes the rename. It shows up as a failure on PR #54 (the ESLint build) only because #54 branched from the already-red `main`; #54 correctly left it out of scope, so it's fixed here as its own change.

- **Fix the test** to expect Dave (`getPersona('dave').name === 'Dave'`, and the prompt-building assertions use `getPersona('dave')`).
- **Lowercase the persona `id`/key and `aliases`** to match the file's own documented convention (*"aliases: lowercase tokens that summon this persona"*) and the original `kaha`/`Kaha` pattern (lowercase id, capitalized display name). The rename left `id`/`aliases` as `'Dave'` (capitalized). Since `selectPersona` lowercases the incoming text before matching against `aliases`, a capitalized alias could **never** match — a latent bug that would bite the moment Dave stops being the default persona. Display `name` stays `Dave`.

No behaviour change for the default persona today (it's selected by fallback, not by alias); this just makes the registry internally consistent and unblocks CI.

## Security / privacy impact

None. Personas only change how the bot *sounds*, never what it can do (permissions come from RBAC tier + tool gating). The `SECURITY:` test that asserts every persona keeps the security guidelines + no-em-dash rule still passes.

## How verified

- `git grep -i kaha` — clean (no references remain).
- `npm run typecheck` — clean.
- `npm test` — 98 pass, 7 skipped (DB-integration, no `DATABASE_URL`), 0 fail.
- `npm run build` — clean.

## Note

Once this merges, PR #54 (ESLint/Prettier, #41) will go green after a rebase/update — its only failing check was this pre-existing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_