### PR TITLE
Build worker: per-issue concurrency so approved issues build in parallel

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -11,8 +11,9 @@ name: Pipeline build worker
 #   2. Add repo secret CLAUDE_CODE_OAUTH_TOKEN (Settings → Secrets → Actions).
 #
 # COST: every run draws on the SAME Max pool as the production bot and every
-# other session. `concurrency` serialises builds (enforces WIP=1) and
-# `--max-turns` + `timeout-minutes` bound a single run.
+# other session. `concurrency` is now per-issue (see below), so distinct
+# issues build in parallel; `--max-turns` + `timeout-minutes` bound a single
+# run, and releasing issues in small batches bounds total parallel draw.
 #
 # WHY the explicit allowedTools + verify step: an earlier run finished with
 # conclusion=success but 12 permission denials and no branch/PR/relabel — the
@@ -27,8 +28,14 @@ on:
   issues:
     types: [labeled]
 
+# Per-issue concurrency: distinct approved issues build in PARALLEL (faster
+# backlog drain), while re-triggering the SAME issue queues instead of
+# double-running (kills duplicate PRs). GitHub can't express a hard "max N
+# concurrent", so throughput is governed by how many issues are released at
+# once; every run still draws on the shared Max pool, so release in small
+# batches to avoid exhausting the weekly token allowance.
 concurrency:
-  group: pipeline-build
+  group: pipeline-build-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,10 @@ ownership rules:
 - **Only the build loop** writes code or opens PRs. PR-review comments only;
   research & adversarial touch issues only.
 - **No loop merges PRs** — a human merges.
-- WIP caps: ≤3 open `status:draft`, exactly ≤1 `status:building`.
+- WIP caps: ≤3 open `status:draft`. Builds run per-issue-parallel (the build
+  worker's `concurrency` is keyed by issue number), so multiple
+  `status:building` issues are allowed; keep the number in flight small (≈2)
+  since every run draws on the shared Max pool.
 - Coordinate only through issue labels; when blocked or ambiguous, add
   `needs-human` and stop rather than guess.
 - Everything traces to an issue number; the build session works in its own git


### PR DESCRIPTION
## Summary

The build worker used a single static `concurrency` group (`pipeline-build`), so approved proposals built strictly one-at-a-time — slow for draining a backlog. This keys the group by **issue number** instead:

- **Distinct issues build in parallel** → faster backlog drain.
- **Re-triggering the same issue queues** (same group) instead of double-running → also fixes the duplicate-PR races seen earlier when a label got toggled twice.

## Why not a hard "max 2"

GitHub Actions `concurrency` is one-run-per-group; it has no native "max N concurrent" cap. Per-issue grouping means parallelism is governed by **how many issues are released (`status:approved`) at once**. Releasing in pairs → ~2 in parallel. This is a deliberate operational lever, not a hard ceiling — documented in the workflow comment.

## Security / privacy impact

None to the bot runtime. This is pipeline orchestration only. The important cost note: every parallel run draws on the **same shared Max token pool** (we hit the weekly session limit once already today), so the workflow comment and `CLAUDE.md` both say to release issues in small batches. No change to build-worker permissions, the `allowedTools` set, or the deterministic verify/escalate step.

## Docs

- `CLAUDE.md`: the WIP note updated — `≤1 status:building` no longer holds; multiple parallel builds are expected, keep the number in flight small (~2).
- Workflow header comment updated to match.

## How verified

- `python -c "yaml.safe_load(...)"` — workflow parses.
- Behaviour is config-only; the effect is observable on the next batch of `status:approved` re-triggers (distinct issues get their own concurrency group and run concurrently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_