### PR TITLE
Let membership tools target either platform + validate ids (fixes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 - Pipeline loops documented as cloud Routines (#16).
 
 ### Fixed
+- Membership tools (`add_member`, `grant_admin`, `remove_member`, `revoke_admin`) can now target either platform via an optional `platform` argument instead of always assuming the caller's; ids are shape-validated so a WhatsApp number can no longer be filed as a Discord user (#78).
 - Blank optional numeric env vars (e.g. `HEALTH_PORT=`) no longer fail config validation (#40).
 - Build-worker verify step hardened against spoofed or stale PRs (#30).
 - Build worker uses an explicit allowedTools list and deterministic PR verification (#29).

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -191,7 +191,10 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
    * authority, so it requires super_admin. The id is shape-checked per platform
    * so a WhatsApp number can't be silently filed as a Discord user (issue #78).
    */
-  function resolveMemberTarget(rawUserId: string, platformArg?: Platform): { platform: Platform; userId: string } {
+  function resolveMemberTarget(
+    rawUserId: string,
+    platformArg?: Platform,
+  ): { platform: Platform; userId: string } {
     const platform = platformArg ?? caller.platform;
     if (platform !== caller.platform) {
       assertAtLeast(caller.role, 'super_admin', `managing a ${platform} user from ${caller.platform}`);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2,6 +2,7 @@ import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { Platform, PlatformAdapter } from '../platforms/types.js';
 import { assertAtLeast, type CallerContext } from '../auth/rbac.js';
+import { normalizeMemberId } from '../auth/memberId.js';
 import { isSuperAdmin, superAdminIds } from '../auth/roles.js';
 import { logger } from '../logger.js';
 import {
@@ -153,6 +154,28 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
         `(Confirmation is handled outside the AI and must come from you in this conversation.)`,
     );
   }
+
+  /**
+   * Resolve + validate the target of a membership tool. The platform defaults
+   * to the caller's; managing a user on a *different* platform is broader
+   * authority, so it requires super_admin. The id is shape-checked per platform
+   * so a WhatsApp number can't be silently filed as a Discord user (issue #78).
+   */
+  function resolveMemberTarget(rawUserId: string, platformArg?: Platform): { platform: Platform; userId: string } {
+    const platform = platformArg ?? caller.platform;
+    if (platform !== caller.platform) {
+      assertAtLeast(caller.role, 'super_admin', `managing a ${platform} user from ${caller.platform}`);
+    }
+    return { platform, userId: normalizeMemberId(platform, rawUserId) };
+  }
+
+  /** Optional `platform` argument shared by the membership tools. */
+  const platformArg = z
+    .enum(['discord', 'whatsapp'])
+    .optional()
+    .describe(
+      'Target platform. Defaults to the platform you are messaging from; set explicitly (e.g. "whatsapp" while on Discord) to manage a user on the other platform. Cross-platform management requires super admin.',
+    );
 
   // --- Member tools ----------------------------------------------------------
 
@@ -574,13 +597,14 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     'Register a user as a community member so the bot will talk to them (gated mode). Admin only; grants member tier only.',
     {
       userId: z.string().min(1).describe('Platform user id (Discord user id / WhatsApp number without +)'),
+      platform: platformArg,
       displayName: z.string().optional().describe('Human-readable name for records'),
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'add_member');
-      const userId = args.userId.trim();
+      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
       const finalRole = await upsertMember({
-        platform: caller.platform,
+        platform,
         userId,
         role: 'member',
         addedBy: caller.userId,
@@ -588,38 +612,40 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
       });
       await audited({
         actionKind: 'add_member',
-        targetUserId: args.userId,
-        params: { displayName: args.displayName },
-        run: async () => `registered as ${finalRole}`,
+        targetUserId: userId,
+        params: { platform, displayName: args.displayName },
+        run: async () => `registered as ${finalRole} on ${platform}`,
       });
-      await clearAccessRequest(caller.platform, userId).catch((err) =>
+      await clearAccessRequest(platform, userId).catch((err) =>
         logger.warn({ err, userId }, 'Failed to clear access request'),
       );
-      return text(`Added ${args.displayName ?? args.userId} as ${finalRole} on ${caller.platform}.`);
+      return text(`Added ${args.displayName ?? userId} as ${finalRole} on ${platform}.`);
     },
   );
 
   const removeMemberTool = tool(
     'remove_member',
     'Remove a member (revokes bot access in gated mode). Cannot remove admins. Admin only.',
-    { userId: z.string().min(1).describe('Platform user id to remove') },
+    { userId: z.string().min(1).describe('Platform user id to remove'), platform: platformArg },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'remove_member');
-      if (isSuperAdmin(caller.platform, args.userId)) {
+      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      if (isSuperAdmin(platform, userId)) {
         return text('Refusing: that user is a super admin.', true);
       }
       const { result } = await audited({
         actionKind: 'remove_member',
-        targetUserId: args.userId,
+        targetUserId: userId,
+        params: { platform },
         run: async () => {
-          const removed = await removeMember(caller.platform, args.userId);
+          const removed = await removeMember(platform, userId);
           if (!removed)
             throw new Error('No member row removed (not a member, or an admin — revoke admin first).');
           return 'membership removed';
         },
       });
       return text(
-        result === 'membership removed' ? `Removed ${args.userId} from members.` : `Failed: ${result}`,
+        result === 'membership removed' ? `Removed ${userId} from ${platform} members.` : `Failed: ${result}`,
         result !== 'membership removed',
       );
     },
@@ -632,24 +658,26 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     'Promote a user to admin. Super admin only.',
     {
       userId: z.string().min(1).describe('Platform user id to promote'),
+      platform: platformArg,
       displayName: z.string().optional(),
     },
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'grant_admin');
-      const userId = args.userId.trim();
+      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
       // Privilege escalation is the highest-blast-radius action in the
       // system — CONFIRM-gated like kick/purge so an injected turn can
       // request but never complete it.
       return requireConfirm(
-        `GRANT ADMIN to ${args.displayName ?? userId} (${userId}) on ${caller.platform}`,
+        `GRANT ADMIN to ${args.displayName ?? userId} (${userId}) on ${platform}`,
         'super_admin',
         async () => {
           const { success, result } = await audited({
             actionKind: 'grant_admin',
             targetUserId: userId,
+            params: { platform },
             run: async () => {
               await upsertMember({
-                platform: caller.platform,
+                platform,
                 userId,
                 role: 'admin',
                 addedBy: caller.userId,
@@ -659,7 +687,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
             },
           });
           return success
-            ? `Granted admin to ${args.displayName ?? userId} on ${caller.platform}.`
+            ? `Granted admin to ${args.displayName ?? userId} on ${platform}.`
             : `Failed: ${result}`;
         },
       );
@@ -669,22 +697,24 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
   const revokeAdmin = tool(
     'revoke_admin',
     'Demote an admin back to member. Super admin only.',
-    { userId: z.string().min(1).describe('Platform user id to demote') },
+    { userId: z.string().min(1).describe('Platform user id to demote'), platform: platformArg },
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'revoke_admin');
-      if (isSuperAdmin(caller.platform, args.userId)) {
+      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      if (isSuperAdmin(platform, userId)) {
         return text('Refusing: super admins are configured in the environment, not manageable here.', true);
       }
       const { success, result } = await audited({
         actionKind: 'revoke_admin',
-        targetUserId: args.userId,
+        targetUserId: userId,
+        params: { platform },
         run: async () => {
-          const done = await demoteAdmin(caller.platform, args.userId);
+          const done = await demoteAdmin(platform, userId);
           if (!done) throw new Error('User is not an admin.');
           return 'demoted to member';
         },
       });
-      return text(success ? `${args.userId} is now a member.` : `Failed: ${result}`, !success);
+      return text(success ? `${userId} is now a member on ${platform}.` : `Failed: ${result}`, !success);
     },
   );
 

--- a/src/auth/memberId.ts
+++ b/src/auth/memberId.ts
@@ -1,0 +1,32 @@
+import type { Platform } from '../platforms/types.js';
+
+/**
+ * Validate and normalize a membership target id for a platform, so a WhatsApp
+ * number can't be silently filed as a Discord user (issue #78). Strips a
+ * leading '+', requires an all-digit id, and range-checks the length by
+ * platform. Throws with an actionable message (pointing at the `platform`
+ * argument) on a mismatch — Discord snowflakes are 17-20 digits, WhatsApp
+ * E.164 numbers are 7-15.
+ */
+export function normalizeMemberId(platform: Platform, rawId: string): string {
+  const id = rawId.trim().replace(/^\+/, '');
+  if (!/^\d+$/.test(id)) {
+    throw new Error(
+      `"${rawId}" is not a valid ${platform} id: expected digits only ` +
+        `(${platform === 'whatsapp' ? 'E.164 number without +' : 'Discord snowflake'}).`,
+    );
+  }
+  if (platform === 'discord' && (id.length < 17 || id.length > 20)) {
+    throw new Error(
+      `"${rawId}" doesn't look like a Discord user id (expected a 17-20 digit snowflake). ` +
+        `If this is a WhatsApp number, pass platform: "whatsapp".`,
+    );
+  }
+  if (platform === 'whatsapp' && (id.length < 7 || id.length > 15)) {
+    throw new Error(
+      `"${rawId}" doesn't look like a WhatsApp number (expected 7-15 digits, E.164 without +). ` +
+        `If this is a Discord id, pass platform: "discord".`,
+    );
+  }
+  return id;
+}

--- a/tests/memberId.test.ts
+++ b/tests/memberId.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeMemberId } from '../src/auth/memberId.js';
+
+test('accepts a valid WhatsApp E.164 number and strips a leading +', () => {
+  assert.equal(normalizeMemberId('whatsapp', '64273938855'), '64273938855');
+  assert.equal(normalizeMemberId('whatsapp', '+64273938855'), '64273938855');
+  assert.equal(normalizeMemberId('whatsapp', '  64273938855 '), '64273938855');
+});
+
+test('accepts a valid Discord snowflake', () => {
+  assert.equal(normalizeMemberId('discord', '896672027275034646'), '896672027275034646');
+});
+
+test('rejects a WhatsApp number registered as Discord (issue #78 regression)', () => {
+  assert.throws(
+    () => normalizeMemberId('discord', '64273938855'),
+    /doesn't look like a Discord user id.*platform: "whatsapp"/s,
+  );
+});
+
+test('rejects a Discord snowflake registered as WhatsApp', () => {
+  assert.throws(
+    () => normalizeMemberId('whatsapp', '896672027275034646'),
+    /doesn't look like a WhatsApp number.*platform: "discord"/s,
+  );
+});
+
+test('rejects non-numeric ids', () => {
+  assert.throws(() => normalizeMemberId('whatsapp', 'not-a-number'), /expected digits only/);
+  assert.throws(() => normalizeMemberId('discord', '1234abcd'), /expected digits only/);
+});


### PR DESCRIPTION
Closes #78.

## Problem

`add_member`, `grant_admin`, `remove_member`, and `revoke_admin` hardcoded `platform: caller.platform`. Adding a user by their **WhatsApp** number while chatting on **Discord** filed them under `platform='discord'` — so they stayed unreachable on WhatsApp and left a bogus "Discord user" whose id was a phone number. (Seen in production: a WhatsApp number `64273938855` registered as a Discord admin.)

## Change

- **Optional `platform` argument** on all four membership tools, defaulting to the caller's platform. Managing a user on a *different* platform requires **super_admin** (broader authority).
- **`normalizeMemberId(platform, id)`** (new `src/auth/memberId.ts`): strips a leading `+`, requires an all-digit id, and range-checks length per platform — Discord snowflakes are 17-20 digits, WhatsApp E.164 numbers 7-15. A mismatch throws an actionable error ("… If this is a WhatsApp number, pass platform: \"whatsapp\""), so a phone number can no longer be silently filed as a Discord id.
- Resolved platform is threaded through `upsertMember` / `removeMember` / `demoteAdmin`, the audit `params`, and every confirmation/response string.
- Unit tests for the validator, including the #78 regression (a WhatsApp number rejected under `discord`).

## Verification

`npm run typecheck` clean, `npm run build` OK, and `tests/memberId.test.ts` + `tests/rbac.test.ts` + `tests/agentOptions.test.ts` all pass (18/18). CHANGELOG updated.

## Notes

- The production data was already corrected manually (the affected row moved `discord` → `whatsapp`); the historical `admin_audit` entry is left intact as an immutable record.
- Design choice open to review: cross-platform management is gated to super_admin. `grant_admin`/`revoke_admin` are already super-admin-only; this newly also applies to `add_member`/`remove_member` when the target platform differs from the caller's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)