### PR TITLE
Auto-fix failing PRs: full-gate build verification + bounded autofix loop

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -53,11 +53,37 @@ jobs:
     # 300 turns can legitimately run ~40 min; 60 keeps headroom without
     # letting a hung run camp on the concurrency slot all day.
     timeout-minutes: 60
+    # A real pgvector Postgres so the worker's OWN verification runs the
+    # DB-integration tests (which skip without DATABASE_URL) against the same
+    # database CI will use on the PR. Without this the worker "passes" locally
+    # while DB-behaviour/latency bugs only surface in CI's build job (see #79).
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: community_agent_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       # secrets are allowed in job-level env; this keeps the action step inert
       # until the token exists, so the workflow is safe to merge beforehand.
       HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
+      # Dummy app config so the repo's tests/migrate can load config.ts; only
+      # DATABASE_URL is real. CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT set
+      # here — the action injects the real one for the agent, and overriding it
+      # would break the agent's auth.
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
+      DISCORD_BOT_TOKEN: ci-dummy-token
+      DISCORD_GUILD_ID: ci-dummy-guild
+      WHATSAPP_PROVIDER: disabled
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -87,9 +113,19 @@ jobs:
             Read CLAUDE.md (conventions + security posture you must not regress) and
             docs/PIPELINE.md (ownership rules) first, then:
             1. Relabel this issue `status:building` and comment that you've claimed it.
-            2. Implement the approved proposal on a new branch. Match existing style,
-               write/extend tests, and make `npm run typecheck`, `npm test`, and
-               `npm run build` all pass.
+            2. Implement the approved proposal on a new branch. Match existing style
+               and write/extend tests. A pgvector Postgres is available at
+               DATABASE_URL, so run the FULL gate CI will run on your PR and make
+               every one green BEFORE opening it:
+                 - npm run typecheck
+                 - npm run lint
+                 - npm run format:check   (run `npm run format` to fix, then re-check)
+                 - npm run migrate
+                 - npm test               (DB-integration tests run here — NOT skipped)
+                 - npm run build
+                 - npm run test:security
+               Do not open the PR until all of these pass. CI runs the identical
+               checks, so a red PR only creates rework for a human.
             3. Open a pull request whose body starts with "Closes #${{ github.event.issue.number }}",
                summarising the change, its security/privacy impact, and how you verified
                it. Then relabel the issue `status:built`.

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -63,7 +63,11 @@ jobs:
       HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       RUN_ID: ${{ github.event.workflow_run.id }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # NB: GH_TOKEN is deliberately NOT job-level. It is set per-step on the
+      # deterministic gh steps only, so the claude-code-action "Fix" step (whose
+      # agent runs node/npm/cat and reads untrusted CI logs) never inherits a
+      # GITHUB_TOKEN it could exfiltrate. The agent gets its own gh/git auth from
+      # the action's App token.
       # Only ATTEMPT_MARKER comments count toward the 2-try cap. The terminal
       # escalation comment uses a DIFFERENT marker so it can't inflate the count
       # (a re-run of the same failed CI must not read one real attempt as two).
@@ -83,6 +87,8 @@ jobs:
       - name: Resolve PR + eligibility
         id: pr
         if: env.HAS_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           pr_json="$(gh pr list --head "$HEAD_BRANCH" --state open --json number,author,isCrossRepository --limit 1)"
@@ -107,6 +113,8 @@ jobs:
 
       - name: Escalate if attempt cap reached
         if: env.HAS_TOKEN == 'true' && steps.pr.outputs.eligible == 'true' && fromJSON(steps.pr.outputs.attempts) >= 2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"
@@ -117,6 +125,8 @@ jobs:
       - name: Mark attempt + record current HEAD
         id: mark
         if: env.HAS_TOKEN == 'true' && steps.pr.outputs.eligible == 'true' && fromJSON(steps.pr.outputs.attempts) < 2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"
@@ -163,22 +173,28 @@ jobs:
           # Tool surface is least-privilege so the safety guarantees are
           # structural, not prompt-only:
           #   * `gh` is READ-only (diagnose the failure) — no merge/close/create.
-          #   * `git` excludes `reset`/`remote`/blanket push; the ONLY push form
-          #     allowed is `git push origin HEAD` (Bash(git push origin HEAD:*)),
-          #     which cannot target `main` or another branch. The push must run
-          #     via the action's App token (a GITHUB_TOKEN push would not
-          #     re-trigger CI), so it stays with the agent rather than moving to
-          #     a deterministic step; force-push-to-own-branch is the one residue
-          #     left to the prompt, since a trailing `--force` flag can't be
-          #     denied by prefix matching. Labelling/commenting/escalation are
-          #     done by the deterministic shell steps (GITHUB_TOKEN), not here.
+          #   * `git` excludes `reset`/`remote`/blanket push. The only push tool
+          #     is `Bash(git push origin HEAD)` with NO `:*` wildcard, i.e. an
+          #     EXACT match: the agent may run only that literal command. A
+          #     wildcard form (`git push origin HEAD:*`) would also permit
+          #     `git push origin HEAD:main` (refspec src:dst) and
+          #     `git push origin HEAD --force`; the exact match forbids both, so
+          #     it can push ONLY the current branch, fast-forward, never main and
+          #     never force. The push runs via the action's App token because a
+          #     GITHUB_TOKEN push wouldn't re-trigger CI. Labelling/commenting/
+          #     escalation are done by the deterministic shell steps, not here.
+          #   * Defence in depth: branch protection on `main` (blocking direct/
+          #     force pushes) is the recommended backstop regardless of token —
+          #     see docs. It is a repo setting, not something this file enforces.
           claude_args: |
             --max-turns 200
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(git push origin HEAD:*),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -147,16 +147,22 @@ jobs:
                DATABASE_URL, so run the full gate and make EVERY check green:
                npm run typecheck && npm run lint && npm run format:check &&
                npm run migrate && npm test && npm run build && npm run test:security
-            3. Commit and push to THIS SAME branch. Do NOT open a new PR and do NOT
-               merge. If the fix needs a change under `.github/workflows/` (you
-               cannot push those — the token lacks the `workflows` scope) or the
-               failure is not something you can safely fix, do NOT thrash: add the
-               `needs-human` label to PR #${{ steps.pr.outputs.number }} and
-               comment what a human needs to do.
+            3. Commit and push to THIS SAME branch with a normal fast-forward
+               push — NEVER force-push (the branch may carry commits you did not
+               make). Do NOT open a new PR and do NOT merge. If the fix needs a
+               change under `.github/workflows/` (you cannot push those — the
+               token lacks the `workflows` scope) or the failure is not something
+               you can safely fix, then just STOP without pushing: a later step
+               detects "no new commit" and escalates `needs-human` for you.
+          # `gh` is restricted to READ subcommands (diagnose the failure); the
+          # agent's only write is `git push` to this branch. Merging, closing,
+          # labelling and commenting are done by the deterministic shell steps
+          # (with GITHUB_TOKEN), not the model — so "never merges"/"escalate on
+          # failure" are structurally enforced, not just asked for in the prompt.
           claude_args: |
             --max-turns 200
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -1,0 +1,176 @@
+name: Pipeline PR autofix
+
+# Event-driven CURE loop: when CI fails on a build-worker PR, invoke Claude to
+# fix the branch and push, so a red PR gets repaired without a human doing it by
+# hand. Prevention is the primary lever (pipeline-build.yml now runs the full CI
+# gate — lint, real-DB tests, test:security — BEFORE opening a PR); this is the
+# safety net for the residue: genuine flakes and re-breaks when main advances
+# under an open PR.
+#
+# Guardrails (this spends the shared Max pool and pushes code, so they matter):
+#   * Same-repo PRs only. workflow_run carries secrets even for fork PRs, so
+#     running a fix on fork-controlled code would be an injection vector — the
+#     `if` below hard-requires head_repository == this repo.
+#   * Bot-authored PRs only (the build worker). Human PRs are left alone.
+#   * Hard cap of 2 attempts per PR, counted via marker comments. After that it
+#     STOPS and escalates `needs-human` — without this it could fix→fail→fix in
+#     a loop that drains the weekly token pool.
+#   * It CANNOT push .github/workflows/* (the App token lacks the `workflows`
+#     scope), so the prompt tells it to escalate those rather than thrash.
+#   * Never merges — a human merges.
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+concurrency:
+  group: pipeline-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write # claude-code-action mints its GitHub App token via OIDC
+
+jobs:
+  autofix:
+    # Only react to a FAILED CI run triggered by a same-repo pull request.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Same pgvector Postgres as the build/CI jobs so the autofix agent can run
+    # the full gate (incl. DB-integration tests) locally before pushing.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: community_agent_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MARKER: '<!-- pipeline-autofix -->'
+    steps:
+      - name: Inert notice (token not set)
+        if: env.HAS_TOKEN != 'true'
+        run: echo "CLAUDE_CODE_OAUTH_TOKEN not set — PR autofix worker is inert."
+
+      - uses: actions/checkout@v4
+        if: env.HAS_TOKEN == 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Resolve PR + eligibility
+        id: pr
+        if: env.HAS_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+          pr_json="$(gh pr list --head "$HEAD_BRANCH" --state open --json number,author,isCrossRepository --limit 1)"
+          number="$(jq -r '.[0].number // empty' <<<"$pr_json")"
+          if [ -z "$number" ]; then
+            echo "No open PR for branch $HEAD_BRANCH — nothing to autofix."
+            exit 0
+          fi
+          is_bot="$(jq -r '.[0].author.is_bot // false' <<<"$pr_json")"
+          xrepo="$(jq -r '.[0].isCrossRepository // false' <<<"$pr_json")"
+          if [ "$is_bot" != "true" ] || [ "$xrepo" = "true" ]; then
+            echo "PR #$number is not an eligible (same-repo, bot-authored) PR — skipping."
+            exit 0
+          fi
+          # Prior autofix attempts = number of marker comments already on the PR.
+          attempts="$(gh pr view "$number" --json comments --jq "[.comments[] | select(.body | contains(\"$MARKER\"))] | length")"
+          {
+            echo "number=$number"
+            echo "attempts=$attempts"
+            echo "eligible=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Escalate if attempt cap reached
+        if: env.HAS_TOKEN == 'true' && steps.pr.outputs.eligible == 'true' && fromJSON(steps.pr.outputs.attempts) >= 2
+        run: |
+          set -euo pipefail
+          n="${{ steps.pr.outputs.number }}"
+          gh pr edit "$n" --add-label needs-human || true
+          gh pr comment "$n" --body "${MARKER}
+          🤖 Autofix has already tried twice and CI is still red. Stopping to avoid a fix-fail loop; labelled \`needs-human\` for a maintainer. Latest failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID}"
+
+      - name: Mark attempt + record current HEAD
+        id: mark
+        if: env.HAS_TOKEN == 'true' && steps.pr.outputs.eligible == 'true' && fromJSON(steps.pr.outputs.attempts) < 2
+        run: |
+          set -euo pipefail
+          n="${{ steps.pr.outputs.number }}"
+          attempt=$(( ${{ steps.pr.outputs.attempts }} + 1 ))
+          gh pr comment "$n" --body "${MARKER}
+          🤖 Autofix attempt ${attempt}/2: CI failed, attempting a fix on this branch."
+          {
+            echo "head_before=$(git rev-parse HEAD)"
+            echo "attempt=$attempt"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fix the failing checks
+        id: fix
+        if: env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
+        continue-on-error: true # the verify step below is the source of truth
+        uses: anthropics/claude-code-action@v1
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
+          DISCORD_BOT_TOKEN: ci-dummy-token
+          DISCORD_GUILD_ID: ci-dummy-guild
+          WHATSAPP_PROVIDER: disabled
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            CI failed on pull request #${{ steps.pr.outputs.number }} for the NZ
+            Claude Community agent. The PR's branch is already checked out here.
+
+            1. Find what failed: `gh run view ${{ env.RUN_ID }} --log-failed` and
+               `gh pr checks ${{ steps.pr.outputs.number }}`.
+            2. Read CLAUDE.md (conventions + security posture you must not regress).
+               Fix the cause on this branch. A pgvector Postgres is available at
+               DATABASE_URL, so run the full gate and make EVERY check green:
+               npm run typecheck && npm run lint && npm run format:check &&
+               npm run migrate && npm test && npm run build && npm run test:security
+            3. Commit and push to THIS SAME branch. Do NOT open a new PR and do NOT
+               merge. If the fix needs a change under `.github/workflows/` (you
+               cannot push those — the token lacks the `workflows` scope) or the
+               failure is not something you can safely fix, do NOT thrash: add the
+               `needs-human` label to PR #${{ steps.pr.outputs.number }} and
+               comment what a human needs to do.
+          claude_args: |
+            --max-turns 200
+            --model sonnet
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+
+      - name: Verify a fix was pushed (else escalate loudly)
+        if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
+        run: |
+          set -euo pipefail
+          n="${{ steps.pr.outputs.number }}"
+          git fetch origin "$HEAD_BRANCH"
+          after="$(git rev-parse "origin/$HEAD_BRANCH")"
+          if [ "$after" != "${{ steps.mark.outputs.head_before }}" ]; then
+            echo "Autofix pushed a change; CI will re-run on the new commit."
+            exit 0
+          fi
+          echo "::error::Autofix produced no new commit on ${HEAD_BRANCH}."
+          gh pr edit "$n" --add-label needs-human || true
+          gh pr comment "$n" --body "${MARKER}
+          🤖 Autofix attempt ${{ steps.mark.outputs.attempt }} pushed no fix — either the cause needs a workflow-file change I can't push, or it wasn't safely fixable. Labelled \`needs-human\`."
+          exit 1

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -64,7 +64,11 @@ jobs:
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       RUN_ID: ${{ github.event.workflow_run.id }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      MARKER: '<!-- pipeline-autofix -->'
+      # Only ATTEMPT_MARKER comments count toward the 2-try cap. The terminal
+      # escalation comment uses a DIFFERENT marker so it can't inflate the count
+      # (a re-run of the same failed CI must not read one real attempt as two).
+      ATTEMPT_MARKER: '<!-- pipeline-autofix-attempt -->'
+      ESCALATE_MARKER: '<!-- pipeline-autofix-escalation -->'
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -93,8 +97,8 @@ jobs:
             echo "PR #$number is not an eligible (same-repo, bot-authored) PR — skipping."
             exit 0
           fi
-          # Prior autofix attempts = number of marker comments already on the PR.
-          attempts="$(gh pr view "$number" --json comments --jq "[.comments[] | select(.body | contains(\"$MARKER\"))] | length")"
+          # Prior autofix attempts = number of ATTEMPT_MARKER comments (only).
+          attempts="$(gh pr view "$number" --json comments --jq "[.comments[] | select(.body | contains(\"$ATTEMPT_MARKER\"))] | length")"
           {
             echo "number=$number"
             echo "attempts=$attempts"
@@ -107,7 +111,7 @@ jobs:
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"
           gh pr edit "$n" --add-label needs-human || true
-          gh pr comment "$n" --body "${MARKER}
+          gh pr comment "$n" --body "${ESCALATE_MARKER}
           🤖 Autofix has already tried twice and CI is still red. Stopping to avoid a fix-fail loop; labelled \`needs-human\` for a maintainer. Latest failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID}"
 
       - name: Mark attempt + record current HEAD
@@ -147,22 +151,31 @@ jobs:
                DATABASE_URL, so run the full gate and make EVERY check green:
                npm run typecheck && npm run lint && npm run format:check &&
                npm run migrate && npm test && npm run build && npm run test:security
-            3. Commit and push to THIS SAME branch with a normal fast-forward
-               push — NEVER force-push (the branch may carry commits you did not
-               make). Do NOT open a new PR and do NOT merge. If the fix needs a
-               change under `.github/workflows/` (you cannot push those — the
-               token lacks the `workflows` scope) or the failure is not something
-               you can safely fix, then just STOP without pushing: a later step
-               detects "no new commit" and escalates `needs-human` for you.
-          # `gh` is restricted to READ subcommands (diagnose the failure); the
-          # agent's only write is `git push` to this branch. Merging, closing,
-          # labelling and commenting are done by the deterministic shell steps
-          # (with GITHUB_TOKEN), not the model — so "never merges"/"escalate on
-          # failure" are structurally enforced, not just asked for in the prompt.
+            3. Stage and commit your fix, then push it to THIS branch with
+               EXACTLY this command (nothing else — no other push form is
+               permitted): `git push origin HEAD`. NEVER force-push and NEVER
+               push any other ref or branch. Do NOT open a new PR and do NOT
+               merge. If the fix needs a change under `.github/workflows/` (you
+               cannot push those — the token lacks the `workflows` scope) or the
+               failure is not something you can safely fix, then just STOP
+               without committing/pushing: a later step detects "no new commit"
+               and escalates `needs-human` for you.
+          # Tool surface is least-privilege so the safety guarantees are
+          # structural, not prompt-only:
+          #   * `gh` is READ-only (diagnose the failure) — no merge/close/create.
+          #   * `git` excludes `reset`/`remote`/blanket push; the ONLY push form
+          #     allowed is `git push origin HEAD` (Bash(git push origin HEAD:*)),
+          #     which cannot target `main` or another branch. The push must run
+          #     via the action's App token (a GITHUB_TOKEN push would not
+          #     re-trigger CI), so it stays with the agent rather than moving to
+          #     a deterministic step; force-push-to-own-branch is the one residue
+          #     left to the prompt, since a trailing `--force` flag can't be
+          #     denied by prefix matching. Labelling/commenting/escalation are
+          #     done by the deterministic shell steps (GITHUB_TOKEN), not here.
           claude_args: |
             --max-turns 200
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git:*),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(git push origin HEAD:*),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
@@ -177,6 +190,6 @@ jobs:
           fi
           echo "::error::Autofix produced no new commit on ${HEAD_BRANCH}."
           gh pr edit "$n" --add-label needs-human || true
-          gh pr comment "$n" --body "${MARKER}
+          gh pr comment "$n" --body "${ESCALATE_MARKER}
           🤖 Autofix attempt ${{ steps.mark.outputs.attempt }} pushed no fix — either the cause needs a workflow-file change I can't push, or it wasn't safely fixable. Labelled \`needs-human\`."
           exit 1

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -121,7 +121,7 @@ jobs:
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"
           attempt=$(( ${{ steps.pr.outputs.attempts }} + 1 ))
-          gh pr comment "$n" --body "${MARKER}
+          gh pr comment "$n" --body "${ATTEMPT_MARKER}
           🤖 Autofix attempt ${attempt}/2: CI failed, attempting a fix on this branch."
           {
             echo "head_before=$(git rev-parse HEAD)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,14 @@ This repo is developed by a supervised multi-session pipeline — see
 ownership rules:
 
 - **Only the build loop** writes code or opens PRs. PR-review comments only;
-  research & adversarial touch issues only.
+  research & adversarial touch issues only. One exception: the **autofix loop**
+  (`pipeline-pr-autofix.yml`) may push fixes to an existing build-worker PR
+  branch when its CI fails — bounded to 2 attempts, same-repo bot PRs only,
+  then it escalates `needs-human`. It never opens or merges PRs.
+- The build worker runs the **full CI gate** (typecheck, lint, format:check,
+  migrate, test against a real pgvector Postgres, build, test:security) BEFORE
+  opening a PR, so "green locally" matches CI. Keep it that way when editing
+  either `pipeline-build.yml` or `ci.yml` — they must run the same checks.
 - **No loop merges PRs** — a human merges.
 - WIP caps: ≤3 open `status:draft`. Builds run per-issue-parallel (the build
   worker's `concurrency` is keyed by issue number), so multiple

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -40,10 +40,17 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
 ## Ownership rules (enforced by every loop; also in CLAUDE.md)
 
 - **Only the build loop** writes code / opens PRs. PR-review comments only;
-  research & adversarial touch issues only (no files ⇒ no git conflicts).
+  research & adversarial touch issues only (no files ⇒ no git conflicts). One
+  exception: the **autofix loop** (`pipeline-pr-autofix.yml`) may push fixes to
+  an existing build-worker PR branch when its CI fails — same-repo bot PRs only,
+  capped at 2 attempts, then it escalates `needs-human`. It never opens or
+  merges PRs. Do not misflag its pushes as an ownership violation.
 - **No loop merges PRs.** A human merges — especially important for this
   security-sensitive bot.
-- **WIP caps:** ≤3 open `status:draft`; exactly **≤1** `status:building`.
+- **WIP caps:** ≤3 open `status:draft`. Builds run per-issue-parallel (the
+  build worker's `concurrency` is keyed by issue number), so multiple
+  `status:building` issues are allowed; keep the number in flight small (≈2),
+  since every run draws on the shared Max pool.
 - **Label transitions are the only cross-session messaging.** When blocked or
   genuinely ambiguous, add `needs-human` and stop rather than guess.
 - **Everything traces to an issue number.**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -243,3 +243,8 @@ number could reach an unrelated person).
 - [ ] A retention/deletion policy is defined (`forget_me`/`purge_user_data`
       for per-user requests; `INTERACTION_RETENTION_DAYS` for age-based purge).
 - [ ] `journalctl -u community-agent` reviewed for redaction leaks.
+- [ ] **Branch protection on `main`** blocks direct and force pushes (require a
+      PR + review). This is the backstop for the pipeline's write-scoped
+      automation — the build and autofix workers hold a `contents: write` token,
+      so branch protection is what guarantees nothing reaches `main` without a
+      human merge even if a worker is prompt-injected into misusing `git push`.


### PR DESCRIPTION
## Summary

Stops build-worker PRs from landing red — the recurring pattern behind the six PRs I've hand-fixed (#54, #56, #59, #73, #74, #79). Two levers.

### Lever 1 — Prevention (`pipeline-build.yml`)
The build worker verified with a **weaker gate than CI**: no lint/format, no real DB (so DB-integration tests skipped), no `test:security`. That's why lint failures and DB-only bugs (#79's flake) only surfaced *after* the PR opened.

- Give the build job a real **pgvector Postgres** service + dummy app env (`DATABASE_URL` real, the rest dummy; `CLAUDE_CODE_OAUTH_TOKEN` left untouched so the agent's auth isn't clobbered).
- Change the worker prompt to run the **full CI gate before opening the PR**: `typecheck → lint → format:check → migrate → test (DB tests now run) → build → test:security`, and not open the PR until all pass.

Result: "green locally" now equals CI, so most failures never reach a PR.

### Lever 2 — Cure (`pipeline-pr-autofix.yml`, new)
A `workflow_run`-triggered loop: when **CI** completes `failure` on a build-worker PR, invoke Claude to read the failing logs, fix the branch, and push — exactly what I've been doing by hand.

Guardrails (this spends the Max pool and pushes code):
- **Same-repo PRs only** — `workflow_run` carries secrets even on forks, so running a fix on fork-controlled code would be an injection vector; the `if` hard-requires `head_repository == this repo`.
- **Bot-authored PRs only** (the build worker); human PRs untouched.
- **Hard cap of 2 attempts/PR**, counted via marker comments → then it stops and escalates `needs-human`, so it can't fix→fail→fix in a pool-draining loop.
- **Fail-loud**: if an attempt pushes no commit, it labels `needs-human` and exits non-zero (no silent no-op).
- **Cannot touch `.github/workflows/`** (App-token scope) — the prompt tells it to escalate those rather than thrash.
- **Never merges** — a human merges.

## Security / privacy impact

CI/pipeline orchestration only; no bot-runtime change. The autofix loop is the notable new surface — its guardrails above are the design, chosen specifically so it can't run fork code with secrets, can't loop on the pool, and can't silently fail. `CLAUDE.md` documents it as the one exception to "only the build loop writes code."

## How verified

- `python -c "yaml.safe_load(...)"` on both workflows — parse clean.
- Lever 1 is exercised the next time an approved issue builds (its build job now shows a `postgres` service and the worker runs the full gate).
- Lever 2 is inherently **validated on the first real CI failure** after merge — I can't manufacture a failing build-worker PR to trigger it here. It's built fail-loud so the worst case is "escalates `needs-human`," not a silent loop. I'll watch the first real trigger and confirm it behaves.

## Note

Both files are workflow files, so a human (you) must merge this — the bot can't push `.github/workflows/`. Recommend merging Lever 1's benefit is immediate; Lever 2 activates on the next red CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_