### PR TITLE
Build/autofix workers: migrate base schema deterministically (fixes run 28693678835)

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -99,6 +99,19 @@ jobs:
       - uses: actions/checkout@v4
         if: env.HAS_TOKEN == 'true'
 
+      # Create the base schema deterministically BEFORE the agent runs, so its
+      # `npm test` sees a migrated DB. Leaving migration to the agent's prose
+      # gate was fragile: a run that executed `npm test` before `npm run migrate`
+      # failed EVERY DB-integration test with "relation does not exist" and
+      # produced no PR (run 28693678835). node_modules persists into the action
+      # step below; the agent still re-runs `npm run migrate` after adding any
+      # new migration of its own (idempotent).
+      - name: Migrate base schema (deterministic — do not leave to the agent)
+        if: env.HAS_TOKEN == 'true'
+        run: |
+          npm ci
+          npm run migrate
+
       - name: Build the approved proposal
         id: build
         if: env.HAS_TOKEN == 'true'

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -138,6 +138,21 @@ jobs:
             echo "attempt=$attempt"
           } >> "$GITHUB_OUTPUT"
 
+      # Create the base schema deterministically before the fix agent runs, so
+      # its `npm test` sees a migrated DB (same fix as pipeline-build.yml — an
+      # un-migrated DB makes every DB-integration test fail with "relation does
+      # not exist"). node_modules persists into the fix step.
+      - name: Migrate base schema (deterministic — do not leave to the agent)
+        if: env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
+          DISCORD_BOT_TOKEN: ci-dummy-token
+          DISCORD_GUILD_ID: ci-dummy-guild
+          WHATSAPP_PROVIDER: disabled
+        run: |
+          npm ci
+          npm run migrate
+
       - name: Fix the failing checks
         id: fix
         if: env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'


### PR DESCRIPTION
## What happened (run 28693678835)

The build worker ran ~13 min and the Verify step escalated `needs-human` because **no PR was produced**. The Postgres service logs show why:

```
relation "interactions" does not exist
relation "community_users" does not exist
relation "content_reports" does not exist
relation "policies" does not exist   ... (all tables)
```

`npm test`'s DB-integration suite ran against the pgvector service with **no schema** — `npm run migrate` had not run first. Every DB test failed en masse, the agent never got the gate green, and it gave up without opening a PR.

## Root cause (regression from #85)

#85's Lever 1 gave the build job a real Postgres and told the agent — **in the prose prompt** — to run `npm run migrate` before `npm test`. The agent ran the tests first. Because I left a deterministic setup step to the model's discretion, an un-migrated DB broke every DB test.

Ironic edge: before #85 the worker had *no* DB, so DB tests skipped and passed. #85, meant to catch DB bugs pre-PR, instead made builds *more* likely to fail — the opposite of its intent. This is the exact "don't leave a deterministic step to the model" lesson the rest of the pipeline hardening is built on; I violated it.

## Fix

Run `npm ci && npm run migrate` as a **deterministic step before the agent** in both the build worker and the autofix worker (which had the identical pattern). The base schema now always exists regardless of the order the agent runs its gate. `node_modules` persists into the action step; the agent still re-runs `npm run migrate` (idempotent) after adding any new migration of its own.

## Security / privacy impact

None — CI/pipeline orchestration only. No bot runtime, RBAC, or data-path change.

## How verified

- Both workflows parse (`yaml.safe_load`).
- Root cause is directly evidenced by the failing run's Postgres logs (mass `relation ... does not exist` before any migrate).
- End-to-end validation is the next build-worker run after merge (its build job will show a "Migrate base schema" step succeed before the agent, and DB tests will find their tables).

## Follow-up

The proposal that failed in run 28693678835 is now labelled `needs-human`; once this merges, it can be re-triggered (toggle `status:approved`) and should build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_