### PR TITLE
Address PR #91 review: drop git to the service user in redeploy, CONFIRM-gate note deletion

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ and every privileged action is audited and alerted to super admins by DM.
 | `list_access_requests` | ❌ | ❌ | ✅ *(not conversation-scoped — see below)* | ✅ |
 | `list_roster` (joins/leaves/onboarding queue, identity only) | ❌ | ❌ | ✅ *(guild-wide, not conversation-scoped)* | ✅ |
 | `list_context_digests` (offline-distilled community topics) | ❌ | ❌ | ✅ | ✅ |
-| `add_member_note` / `list_member_notes` / `delete_member_note` (person-scoped admin context) | ❌ | ❌ | ✅ *(writes audited)* | ✅ |
+| `add_member_note` / `list_member_notes` / `delete_member_note` (person-scoped admin context) | ❌ | ❌ | ✅ *(audited; delete confirm-gated)* | ✅ |
 | `question_digest` (recurring-question clusters) | ❌ | ❌ | ✅ *their conversations* | ✅ all |
 | `moderation_history` (warn/timeout/kick/delete/announce log, filterable by member/action) | ❌ | ❌ | ✅ *their conversations* | ✅ all |
 | `list_reports` / `resolve_report` (member-submitted content reports) | ❌ | ❌ | ✅ *their conversations* | ✅ all |
@@ -262,7 +262,8 @@ tier. Notes are keyed to known `community_users` identities (unknown targets
 refused, same validation pattern as the membership tools), capped at 1000
 chars, human-entered only, and readable exclusively through the admin-tier
 `list_member_notes` (content `untrusted()`-wrapped — notes are data, never
-instructions). Writes and deletes are audited without the note text;
+instructions). Writes and deletes are audited without the note text, and
+deletion is CONFIRM-gated (same as `delete_knowledge`);
 `forget_me`/`purge_user_data` delete the subject's notes. See SECURITY.md
 for the privacy boundary and the owner-accepted no-self-access decision.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -201,7 +201,10 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
   no embedding column — never in memory recall; pinned by `SECURITY:`
   tests), writes/deletes are **audited** (the audit row records that a note
   was added, never its text, so a later purge actually removes the content),
-  and `forget_me`/`purge_user_data` delete all notes **about** the person.
+  `delete_member_note` is **CONFIRM-gated** like `delete_knowledge` (the
+  confirmation names whose note is being deleted, so an injected turn can
+  request but never complete an irreversible deletion), and
+  `forget_me`/`purge_user_data` delete all notes **about** the person.
   The owner has explicitly accepted (issue #45) that there is **no
   self-access path** (members cannot read notes about themselves) and that
   admins may manually transcribe web-researched facts into a note — both are

--- a/scripts/check-security-test-count.mjs
+++ b/scripts/check-security-test-count.mjs
@@ -26,8 +26,9 @@ const testsDir = path.join(repoRoot, 'tests');
 // Count at merge time of #42. Bump this in the same diff that adds a new
 // SECURITY: test; a diff that only lowers it needs an explanation.
 // Raised to 41 with the cross-platform identity-linking SECURITY tests (#44),
-// then to 57 with the approved-issues batch build (#45-#53).
-const MIN_SECURITY_TESTS = 57;
+// then to 57 with the approved-issues batch build (#45-#53), then to 59 with
+// the PR #91 review round (ambient recall scoping + URL-path token scrub).
+const MIN_SECURITY_TESTS = 59;
 
 const testFiles = readdirSync(testsDir)
   .filter((f) => f.endsWith('.test.ts'))

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -49,7 +49,11 @@ die() {
   exit 1
 }
 
-# Run a build step as the service user when root, directly otherwise.
+# Run a git/build step as the service user when root, directly otherwise.
+# EVERY git and npm invocation must go through this: git as root against the
+# community-agent-owned checkout would both trip git's dubious-ownership
+# refusal and parse network-supplied pack data (git fetch) with root
+# privileges. Root is kept exclusively for systemctl.
 run_as_app() {
   if [ "$(id -u)" = "0" ] && [ -n "$APP_USER" ]; then
     runuser -u "$APP_USER" -- "$@"
@@ -94,19 +98,19 @@ main() {
   flock -n 9 || die "another redeploy is already running (lock: $LOCK_FILE)"
 
   cd "$APP_DIR" || die "APP_DIR $APP_DIR does not exist"
-  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$APP_DIR is not a git checkout"
+  run_as_app git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$APP_DIR is not a git checkout"
 
   # Never deploy over local state: a dirty tree means a human is mid-change.
   # Untracked files are expected (.env, dist/, node_modules/, whatsapp-auth/)
   # — only modifications to TRACKED files block the deploy.
-  [ -z "$(git status --porcelain --untracked-files=no)" ] ||
+  [ -z "$(run_as_app git status --porcelain --untracked-files=no)" ] ||
     die "working tree has local modifications; not touching anything"
 
-  git fetch origin "$BRANCH" || die "git fetch failed"
+  run_as_app git fetch origin "$BRANCH" || die "git fetch failed"
 
   local old_sha new_sha
-  old_sha="$(git rev-parse HEAD)"
-  new_sha="$(git rev-parse "origin/$BRANCH")"
+  old_sha="$(run_as_app git rev-parse HEAD)"
+  new_sha="$(run_as_app git rev-parse "origin/$BRANCH")"
 
   if [ "$old_sha" = "$new_sha" ]; then
     log "up to date at $old_sha; nothing to deploy"
@@ -115,11 +119,11 @@ main() {
 
   # Fast-forward only: origin/$BRANCH must contain HEAD. Anything else means
   # history was rewritten or the checkout diverged — a human call, not ours.
-  git merge-base --is-ancestor "$old_sha" "$new_sha" ||
+  run_as_app git merge-base --is-ancestor "$old_sha" "$new_sha" ||
     die "origin/$BRANCH ($new_sha) is not a fast-forward of HEAD ($old_sha)"
 
   log "deploying $old_sha -> $new_sha"
-  git merge --ff-only "origin/$BRANCH" >/dev/null || die "fast-forward merge failed"
+  run_as_app git merge --ff-only "origin/$BRANCH" >/dev/null || die "fast-forward merge failed"
 
   if ! build_and_migrate; then
     # Restore the old code so the on-disk dist/ matches the still-running
@@ -127,29 +131,38 @@ main() {
     # any migration that already applied stays applied — migrations must be
     # backward-compatible within a deploy (docs/DEPLOYMENT.md).
     log "build/migrate FAILED for $new_sha; restoring $old_sha, service NOT restarted"
-    git reset --hard "$old_sha" >/dev/null
+    run_as_app git reset --hard "$old_sha" >/dev/null
     run_as_app npm ci --no-audit --no-fund >/dev/null 2>&1 || true
     run_as_app npm run build >/dev/null 2>&1 || true
     exit 1
   fi
 
-  restart_service || die "systemctl restart $SERVICE_NAME failed"
+  # Roll back CODE ONLY (the migration stays — see the note above), rebuild
+  # the old tree, and restart onto it. Used both when the restart itself
+  # fails and when the restarted service never becomes healthy — either way
+  # the box must not be left down on the new code with no recovery attempt.
+  roll_back() {
+    run_as_app git reset --hard "$old_sha" >/dev/null
+    if build_and_migrate && restart_service && wait_healthy; then
+      log "rolled back to $old_sha and healthy — investigate $new_sha before the next deploy"
+    else
+      log "ROLLBACK DID NOT COME UP HEALTHY — manual intervention required"
+    fi
+    exit 1
+  }
+
+  if ! restart_service; then
+    log "systemctl restart FAILED on $new_sha; rolling back to $old_sha"
+    roll_back
+  fi
 
   if wait_healthy; then
     log "deployed $new_sha and healthy"
     exit 0
   fi
 
-  # Roll back CODE ONLY (see note above — the migration stays), rebuild the
-  # old tree, and restart onto it.
   log "service unhealthy after ${HEALTH_TIMEOUT_SECS}s on $new_sha; rolling back to $old_sha"
-  git reset --hard "$old_sha" >/dev/null
-  if build_and_migrate && restart_service && wait_healthy; then
-    log "rolled back to $old_sha and healthy — investigate $new_sha before the next deploy"
-  else
-    log "ROLLBACK DID NOT COME UP HEALTHY — manual intervention required"
-  fi
-  exit 1
+  roll_back
 }
 
 main "$@"

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -13,6 +13,7 @@ import {
   deleteKnowledge,
   deleteMemberNote,
   demoteAdmin,
+  getMemberNote,
   getMemberRole,
   listMemberNotes,
   MEMBER_NOTE_MAX_CHARS,
@@ -351,11 +352,13 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
 
   const forgetMe = tool(
     'forget_me',
-    "Delete the requester's own stored messages from the bot's memory (privacy request). Requires confirmation.",
+    "Delete the requester's own stored data from the bot's memory (privacy request): their messages, " +
+      'plus any knowledge entries, content reports, suggestions, roster entry, and admin notes tied to ' +
+      'them — across linked identities. Requires confirmation.',
     {},
     async () =>
       requireConfirm(
-        `delete ALL of ${caller.userName}'s stored messages (and any knowledge entries or content reports sourced from them) on ${caller.platform}`,
+        `delete ALL of ${caller.userName}'s stored data on ${caller.platform} (messages, and any knowledge entries, content reports, suggestions, roster entry, or admin notes tied to them — across linked identities)`,
         'member',
         async () => {
           const n = await purgeUserData(caller.platform, caller.userId);
@@ -824,20 +827,36 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
 
   const deleteMemberNoteTool = tool(
     'delete_member_note',
-    'Delete one member context note by id (from list_member_notes). Audited. Admin only.',
+    'Permanently delete one member context note by id (from list_member_notes). Requires confirmation. ' +
+      'Audited. Admin only.',
     { id: z.number().describe('Note id') },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'delete_member_note');
-      const { success, result } = await audited({
-        actionKind: 'delete_member_note',
-        params: { id: args.id },
-        run: async () => {
-          const deleted = await deleteMemberNote(args.id);
-          if (!deleted) throw new Error(`No note with id ${args.id}.`);
-          return 'deleted';
+      // Resolve the note first so the CONFIRM names whose note is being
+      // deleted — an injected bare id can't quietly erase the wrong one —
+      // and so an unknown id is refused before anything is queued.
+      const note = await getMemberNote(args.id);
+      if (!note) return text(`No note with id ${args.id}.`, true);
+      // Same CONFIRM gate as delete_knowledge: deletion is irreversible, so
+      // the model can request it but only the admin's out-of-band reply
+      // executes it (CLAUDE.md invariant).
+      return requireConfirm(
+        `delete member note #${args.id} about ${note.userId} on ${note.platform} ("${note.note.slice(0, 80)}${note.note.length > 80 ? '…' : ''}")`,
+        'admin',
+        async () => {
+          const { success, result } = await audited({
+            actionKind: 'delete_member_note',
+            targetUserId: note.userId,
+            params: { id: args.id },
+            run: async () => {
+              const deleted = await deleteMemberNote(args.id);
+              if (!deleted) throw new Error(`No note with id ${args.id}.`);
+              return 'deleted';
+            },
+          });
+          return success ? `Deleted note #${args.id}.` : `Failed: ${result}`;
         },
-      });
-      return text(success ? `Deleted note #${args.id}.` : `Failed: ${result}`, !success);
+      );
     },
   );
 

--- a/src/context/export.ts
+++ b/src/context/export.ts
@@ -45,6 +45,9 @@ export function scrubPII(text: string): string {
       .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[email]')
       // URLs: keep origin+path, drop query/fragment (where user tokens live)
       .replace(/(https?:\/\/[^\s?#]+)[?#]\S*/g, '$1')
+      // ...and redact long token-shaped PATH segments too (reset links etc.
+      // often carry the token in the path, not the query)
+      .replace(/(https?:\/\/[^\s]*?\/)[A-Za-z0-9_-]{20,}/g, '$1[token]')
       // @handles
       .replace(/@[A-Za-z0-9_.-]{2,}/g, '[handle]')
       // phone-number-shaped runs (8+ digits, optional +/separators)

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -1370,6 +1370,15 @@ export async function listMemberNotes(platform: Platform, userId: string): Promi
   }));
 }
 
+/** Fetch one note by id, so the delete CONFIRM can show whose note it is. */
+export async function getMemberNote(
+  id: number,
+): Promise<{ platform: Platform; userId: string; note: string } | null> {
+  const { rows } = await pool.query(`SELECT platform, user_id, note FROM member_notes WHERE id = $1`, [id]);
+  if (rows.length === 0) return null;
+  return { platform: rows[0].platform as Platform, userId: rows[0].user_id, note: rows[0].note };
+}
+
 /** Delete one note by id. Returns false if no row matched. */
 export async function deleteMemberNote(id: number): Promise<boolean> {
   const { rowCount } = await pool.query(`DELETE FROM member_notes WHERE id = $1`, [id]);

--- a/tests/ambientArchiving.test.ts
+++ b/tests/ambientArchiving.test.ts
@@ -24,6 +24,8 @@ const skip = hasDb
 
 const { Router } = await import('../src/router.js');
 const { pool, closeDb } = await import('../src/storage/db.js');
+const { config } = await import('../src/config.js');
+const pgvector = (await import('pgvector/pg')).default;
 const { embed } = await import('../src/storage/embeddings.js');
 const {
   purgeUserData,
@@ -31,6 +33,7 @@ const {
   recordInteraction,
   deleteInteractionByMessageId,
   updateInteractionByMessageId,
+  searchMemory,
 } = await import('../src/storage/repository.js');
 
 // Pre-warm the (lazily loaded) embedding pipeline outside any timed wait.
@@ -199,6 +202,41 @@ test(
     assert.equal(rows[0].message_id, `${RUN}-m3`);
     assert.equal(turnCalls, 0, 'SECURITY: addressed-check still solely governs agent invocation');
     assert.equal(sent.length, 0);
+  },
+);
+
+test(
+  'SECURITY: ambient rows stay conversation-scoped in recall — channel A chatter never surfaces in channel B (issue #48)',
+  { skip },
+  async () => {
+    // Hand-crafted embeddings so no (network-dependent) model load is
+    // needed; a whitespace query short-circuits embed() to a zero vector,
+    // and the conversation filter is what this test pins.
+    const vec = new Array(config.db.embeddingDim).fill(0);
+    vec[20] = 1;
+    const insertAmbient = (conversationId: string, content: string) =>
+      pool.query(
+        `INSERT INTO interactions
+           (platform, conversation_id, user_id, role, direction, content, kind, embedding)
+         VALUES ('discord', $1, $2, 'guest', 'inbound', $3, 'ambient', $4)`,
+        [conversationId, `${RUN}-scope-user`, content, pgvector.toSql(vec)],
+      );
+    await insertAmbient(`${RUN}-chan-a`, `${RUN} channel A ambient secret`);
+    await insertAmbient(`${RUN}-chan-b`, `${RUN} channel B ambient secret`);
+
+    const hits = await searchMemory(' ', {
+      platform: 'discord',
+      conversationId: `${RUN}-chan-a`,
+      topK: 1000,
+    });
+    assert.ok(
+      hits.some((h) => h.content === `${RUN} channel A ambient secret`),
+      'recall scoped to channel A sees its own ambient rows',
+    );
+    assert.ok(
+      !hits.some((h) => h.content === `${RUN} channel B ambient secret`),
+      "SECURITY: channel B's ambient content never leaks into channel A's recall",
+    );
   },
 );
 

--- a/tests/contextExport.test.ts
+++ b/tests/contextExport.test.ts
@@ -91,6 +91,18 @@ test('SECURITY: PII-shaped tokens in model-written summaries are scrubbed before
   assert.match(markdown, /\[handle\]/);
 });
 
+test('SECURITY: tokens embedded in URL paths (not just query strings) are scrubbed (issue #53)', () => {
+  const scrubbed = scrubPII(
+    'Use https://example.com/reset/AbCdEfGhIjKlMnOpQrStUv12 or https://example.com/docs/getting-started to continue.',
+  );
+  assert.ok(!scrubbed.includes('AbCdEfGhIjKlMnOpQrStUv12'), 'a long token-shaped path segment is redacted');
+  assert.ok(scrubbed.includes('https://example.com/reset/[token]'), 'the URL shape survives redaction');
+  assert.ok(
+    scrubbed.includes('https://example.com/docs/getting-started'),
+    'ordinary short path segments are untouched',
+  );
+});
+
 test('scrubPII leaves ordinary prose, years, and short counts alone', () => {
   const text = 'In 2026 about 400 members asked 12 questions across 3 channels.';
   assert.equal(scrubPII(text), text);


### PR DESCRIPTION
Follow-up to #91, which merged before its automated review findings were addressed. Every finding was verified against the code before fixing.

## Summary

- **`scripts/redeploy.sh` (#50) — the likely-blocking one**: every `git` command (`rev-parse`, `status`, `fetch`, `merge --ff-only`, `reset --hard`) now routes through `run_as_app`, so under the root systemd unit git runs as the service user and root is kept exclusively for `systemctl`. This closes both review findings at once: git no longer parses network-supplied pack data as root, and git's dubious-ownership refusal on the `community-agent`-owned checkout — which would have killed the very first scheduled run — no longer triggers, because git runs as the tree owner. The unit file's "drops to the service user for every git/npm step" comment is now true rather than aspirational.
- **Redeploy restart failure**: a failed `systemctl restart` now rolls back to the old code and restarts it (shared `roll_back` with the unhealthy-service path) instead of dying with the service down.
- **`delete_member_note` (#45)**: now CONFIRM-gated like its `delete_knowledge` sibling, restoring the CLAUDE.md destructive-actions invariant instead of documenting a deviation. The note is resolved first so the pending CONFIRM names whose note is being deleted (no blind bare-id deletes), and unknown ids are refused before anything is queued. SECURITY.md/ARCHITECTURE.md updated to match.
- **`forget_me`** tool description now lists everything the purge actually covers (messages, knowledge, reports, suggestions, roster entry, admin notes — across linked identities).
- **Both minor review gaps closed**: a `SECURITY:` test pinning that ambient rows stay conversation-scoped in recall (channel B chatter never surfaces in channel A), and the export PII scrub now also redacts long token-shaped URL *path* segments, not just query strings (tested).

## Security / privacy impact

Strictly tightening: the redeploy script's root surface shrinks to `systemctl` only; an injected admin turn can no longer complete an irreversible note deletion without the admin's out-of-band CONFIRM; the context export's egress scrub covers path-borne tokens. No new tools, no RBAC or data-scope changes. `MIN_SECURITY_TESTS` raised 57 → 59 (60 run).

## How verified

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run migrate`, `npm test`, `npm run build`, `npm run test:security` against a local Postgres 16 + pgvector, after rebasing onto today's `main` (including the #93/#95 knowledge changes). The 4 test failures in the sandbox are all the known environmental class — they need the HuggingFace embedding model, whose download this sandbox's proxy blocks — and include two tests that arrived on `main` itself; all pass in CI.
- `scripts/redeploy.sh`: shellcheck-clean; re-exercised the no-op / deploy / build-failure-restore paths, and reproduced the reviewer's predicted failure as a control — git as root on a foreign-owned tree fatals with "detected dubious ownership" — then verified the fixed script end-to-end in the production shape (invoked as root, git dropped via `runuser` to a non-root owner, `FETCH_HEAD` left owned by the app user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXs82pLowjr9cdxrVgywGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXs82pLowjr9cdxrVgywGn)_