### PR TITLE
Give the migrate step a dummy CLAUDE_CODE_OAUTH_TOKEN (fixes #96's migrate step)

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -108,6 +108,12 @@ jobs:
       # new migration of its own (idempotent).
       - name: Migrate base schema (deterministic — do not leave to the agent)
         if: env.HAS_TOKEN == 'true'
+        env:
+          # config.ts (loaded by migrate) requires CLAUDE_CODE_OAUTH_TOKEN, but
+          # the job env omits it (the action injects the real one). migrate
+          # never calls Claude, so a dummy satisfies the zod schema — matching
+          # ci.yml's build job.
+          CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
         run: |
           npm ci
           npm run migrate

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -149,6 +149,9 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
+          # migrate loads config.ts which requires this; migrate never calls
+          # Claude, so a dummy satisfies the schema (see pipeline-build.yml).
+          CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
         run: |
           npm ci
           npm run migrate


### PR DESCRIPTION
## What happened

The re-triggered builds for #90 and #92 failed in ~25 seconds (runs `28699070792` / `28699071444`) — at the new **"Migrate base schema"** step added in #96, *before* the agent even ran.

## Root cause

`npm run migrate` loads `config.ts`, whose zod schema requires `CLAUDE_CODE_OAUTH_TOKEN`. The build job's env **deliberately omits** that token (so the action injects the real one), and #96's migrate step runs *outside* the action — so config validation exits 1 immediately:

```
Invalid environment configuration:
  - CLAUDE_CODE_OAUTH_TOKEN: expected string, received undefined
```

Reproduced locally. So #96 fixed the *ordering* (migrate before the agent) but the new step couldn't load config. A one-line miss on my part.

## Fix

Set `CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token` at the migrate **step level** in both the build and autofix workers. `migrate` never calls Claude, so a dummy satisfies the schema — this is exactly what `ci.yml`'s own build job already does. Step-level, so the action step still receives the real token.

## Verified

- Both workflows parse.
- Locally: with the dummy token, config validation **passes** and migrate proceeds to the DB connection (`ECONNREFUSED` with no local DB — expected; proves config no longer blocks). The failing case reproduced without it.

## Security / privacy impact

None — CI orchestration only. The dummy token is a schema-satisfying placeholder for a step that does no Claude work; the real token stays scoped to the action step.

## Follow-up

Once merged, re-trigger #90 and #92 again (toggle `status:approved`) — this is now the *second* layer of the migrate fix, so the next run is the real end-to-end test. Both are currently back at `needs-human` from this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_