### PR TITLE
Auto-retry failed builds instead of escalating needs-human on every flake

### DIFF
--- a/.github/workflows/pipeline-build-retry.yml
+++ b/.github/workflows/pipeline-build-retry.yml
@@ -1,0 +1,49 @@
+name: Pipeline build retry
+
+# Auto-recover the build worker from transient/infra failures so a human is
+# only pinged for PERSISTENT ones. When a "Pipeline build worker" run fails
+# (its verify step found no PR — a flake, a cold-start timing blip, a transient
+# DB/pool hiccup, etc.), re-run it via `gh run rerun`, bounded by run_attempt.
+# The build worker's verify step only labels the issue `needs-human` on its
+# FINAL attempt, so escalation happens once retries are exhausted — replacing
+# the manual "toggle status:approved to re-trigger" that a human kept doing.
+#
+# Why `gh run rerun` rather than re-adding a label: a GITHUB_TOKEN label edit
+# does NOT re-trigger the build worker (GitHub does not let Actions trigger
+# Actions via the default token — the same rule that stops GITHUB_TOKEN pushes
+# from re-running CI). Re-running the failed run is the reliable, no-PAT
+# mechanism, and it re-uses the original `issues` event so it rebuilds exactly
+# the same proposal with a fresh checkout, DB, and agent budget.
+#
+# A PERSISTENT failure (a real bug, or an exhausted Max pool) fails all attempts
+# and correctly lands at needs-human — auto-retry recovers flakes, it does not
+# paper over genuine breakage.
+
+on:
+  workflow_run:
+    workflows: ['Pipeline build worker']
+    types: [completed]
+
+permissions:
+  actions: write # to re-run the failed build run
+
+jobs:
+  retry:
+    # Only a FAILED build-worker run from the real (issues) build path, and only
+    # while under the attempt cap. run_attempt is 1 on the first run and
+    # increments on each rerun, so `< 3` = at most two auto-reruns before the
+    # build worker's own final-attempt escalation stands. MUST stay in sync with
+    # the `>= 3` cap in pipeline-build.yml's verify step.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'issues' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run the failed build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Build run ${{ github.event.workflow_run.id }} failed on attempt ${{ github.event.workflow_run.run_attempt }} — re-running (cap 3)."
+          gh run rerun "${{ github.event.workflow_run.id }}" -R "${{ github.repository }}"

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -195,12 +195,19 @@ jobs:
             exit 0
           fi
 
-          echo "::error::Build worker finished without opening a PR that closes issue #${ISSUE_NUMBER}."
-
-          # Escalate so the proposal does not sit silently at status:approved.
-          gh issue edit "${ISSUE_NUMBER}" --add-label needs-human || true
-
+          echo "::error::Build worker produced no PR closing issue #${ISSUE_NUMBER} (attempt ${{ github.run_attempt }})."
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh issue comment "${ISSUE_NUMBER}" --body "🤖 Build worker ran but produced **no pull request** closing this issue, so it could not be marked \`status:built\`. Labelled \`needs-human\` for a maintainer to investigate. Run: ${run_url}" || true
+
+          # Auto-retry: pipeline-build-retry.yml re-runs this run on failure (up
+          # to attempt 3), so transient/infra failures recover without a human.
+          # Only escalate needs-human on the FINAL attempt — a human is pinged
+          # once retries are exhausted, not on every flake. Keep this `>= 3` cap
+          # in sync with the `< 3` guard in pipeline-build-retry.yml.
+          if [ "${{ github.run_attempt }}" -ge 3 ]; then
+            gh issue edit "${ISSUE_NUMBER}" --add-label needs-human || true
+            gh issue comment "${ISSUE_NUMBER}" --body "🤖 Build worker produced **no pull request** after ${{ github.run_attempt }} attempts (auto-retried). Labelled \`needs-human\` for a maintainer — this is a persistent failure, not a flake. Latest run: ${run_url}" || true
+          else
+            echo "Not escalating yet — the auto-retry loop will re-run this build (attempt ${{ github.run_attempt }} < 3)."
+          fi
 
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,13 @@ ownership rules:
   (`pipeline-pr-autofix.yml`) may push fixes to an existing build-worker PR
   branch when its CI fails — bounded to 2 attempts, same-repo bot PRs only,
   then it escalates `needs-human`. It never opens or merges PRs.
+- The **build-retry loop** (`pipeline-build-retry.yml`) auto-re-runs a build
+  worker run that failed to produce a PR, via `gh run rerun`, bounded by
+  `run_attempt` (≤3 total attempts). The build worker escalates `needs-human`
+  only on its final attempt, so transient/infra failures recover unattended and
+  a human is pinged only for persistent ones — don't re-add manual re-trigger
+  steps for build failures. (A GITHUB_TOKEN label toggle can't re-trigger the
+  build worker, which is why this uses rerun, not a label change.)
 - The build worker runs the **full CI gate** (typecheck, lint, format:check,
   migrate, test against a real pgvector Postgres, build, test:security) BEFORE
   opening a PR, so "green locally" matches CI. Keep it that way when editing


### PR DESCRIPTION
## Why

Proposals kept landing at `needs-human` from *transient* build failures, and a human (me) kept re-triggering them by hand. That's the thing to automate: the build worker should recover from flakes itself and only ping a human for *persistent* failures.

## What

- **New `pipeline-build-retry.yml`:** on a failed "Pipeline build worker" run, re-run it with `gh run rerun`, bounded by `run_attempt` (`< 3` → up to two auto-reruns). Re-running re-uses the original `issues` event, so it rebuilds the same proposal with a fresh checkout, DB, and agent budget.
- **Build worker verify step** now escalates `needs-human` **only on its final attempt** (`github.run_attempt >= 3`). So a human is pinged once, after retries are exhausted — not on every flake. The two caps are kept in sync (`>= 3` / `< 3`).

## Why `gh run rerun` and not a label toggle

A `GITHUB_TOKEN` label edit **does not re-trigger** the build worker — GitHub doesn't let Actions trigger Actions via the default token (the same rule that stops `GITHUB_TOKEN` pushes from re-running CI). Re-running the failed run is the reliable mechanism that needs **no PAT** and no extra setup.

## Recovers flakes, doesn't hide breakage

A **persistent** failure — a real bug, or an exhausted Max pool — fails all three attempts and still lands at `needs-human` correctly. Auto-retry only rescues the transient class (which is exactly what's been generating the manual toil). The `run_attempt` cap also bounds pool spend: at most 3 attempts per issue, even during a rate-limited window.

## Security / privacy impact

CI-orchestration only; no bot runtime/RBAC/data change. The retry workflow's sole permission is `actions: write` (to re-run); it does no checkout, runs no untrusted code, and never merges.

## How verified

- Both workflows parse.
- Logic is the standard `workflow_run` + `gh run rerun` + `run_attempt`-cap pattern; the definitive test is the first real transient build failure after merge (it should silently re-run and recover rather than escalating). Built so the worst case is "escalates `needs-human` after 3 attempts" — never an unbounded loop.

## Note

Workflow files → needs your merge. Once in, the manual "toggle `status:approved` to re-trigger a failed build" step goes away for transient failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_