### PR TITLE
Backport push-loop hardening to autofix; scope conflict discover job

### DIFF
--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -83,6 +83,12 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          # Do NOT leave the job's GITHUB_TOKEN in .git/config: the fix agent
+          # reads untrusted CI logs / PR content and can `cat .git/config` / read
+          # it via node, then exfiltrate it. The agent pushes with the action's
+          # own App token, and the deterministic steps use `gh` (GH_TOKEN env),
+          # so no persisted git credential is needed anywhere.
+          persist-credentials: false
 
       - name: Resolve PR + eligibility
         id: pr
@@ -188,26 +194,32 @@ jobs:
                failure is not something you can safely fix, then just STOP
                without committing/pushing: a later step detects "no new commit"
                and escalates `needs-human` for you.
-          # Tool surface is least-privilege so the safety guarantees are
-          # structural, not prompt-only:
+          # Tool surface is least-privilege — defence in depth, NOT a hard
+          # guarantee (the agent also has Edit/Write + node/npm code execution,
+          # so it could rewrite .git/HEAD on disk; see the main-push note below):
           #   * `gh` is READ-only (diagnose the failure) — no merge/close/create.
+          #   * `git fetch` is pinned to `Bash(git fetch origin:*)` so the agent
+          #     can only fetch from origin, not an arbitrary remote/URL.
           #   * `git` excludes `reset`/`remote`/blanket push. The only push tool
           #     is `Bash(git push origin HEAD)` with NO `:*` wildcard, i.e. an
           #     EXACT match: the agent may run only that literal command. A
           #     wildcard form (`git push origin HEAD:*`) would also permit
           #     `git push origin HEAD:main` (refspec src:dst) and
-          #     `git push origin HEAD --force`; the exact match forbids both, so
-          #     it can push ONLY the current branch, fast-forward, never main and
-          #     never force. The push runs via the action's App token because a
-          #     GITHUB_TOKEN push wouldn't re-trigger CI. Labelling/commenting/
+          #     `git push origin HEAD --force`. Combined with the checkout
+          #     pinning the local branch name, this keeps the *tool surface* on
+          #     the current branch — but note code execution (above) means it is
+          #     not a hard stop. The push runs via the action's App token because
+          #     a GITHUB_TOKEN push wouldn't re-trigger CI. Labelling/commenting/
           #     escalation are done by the deterministic shell steps, not here.
-          #   * Defence in depth: branch protection on `main` (blocking direct/
-          #     force pushes) is the recommended backstop regardless of token —
-          #     see docs. It is a repo setting, not something this file enforces.
+          #   * The ENFORCEABLE guarantee that this loop cannot push to `main` is
+          #     branch protection on `main` (blocking direct/force pushes) — a
+          #     required repo setting (see docs/SECURITY.md), not something this
+          #     file enforces. The allowlist above raises the bar; it does not
+          #     replace branch protection.
           claude_args: |
             --max-turns 200
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch origin:*),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
@@ -216,8 +228,12 @@ jobs:
         run: |
           set -euo pipefail
           n="${{ steps.pr.outputs.number }}"
-          git fetch origin "$HEAD_BRANCH"
-          after="$(git rev-parse "origin/$HEAD_BRANCH")"
+          # Read the branch's current remote tip via the API (gh/GH_TOKEN) rather
+          # than `git fetch` — with persist-credentials:false there is no git
+          # credential in .git/config for a fetch, and this avoids reintroducing
+          # one. head_before was captured from the local checkout (git rev-parse
+          # HEAD needs no credential).
+          after="$(gh pr view "$n" --json headRefOid --jq '.headRefOid')"
           if [ "$after" != "${{ steps.mark.outputs.head_before }}" ]; then
             echo "Autofix pushed a change; CI will re-run on the new commit."
             exit 0

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -61,6 +61,13 @@ jobs:
   discover:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Read-only: this job only runs `gh pr list`/`gh pr view`. A job-level
+    # override REPLACES the workflow-level grant, so discover never carries the
+    # write scopes the resolve job needs (least privilege — it does no writes
+    # and runs no agent/untrusted code).
+    permissions:
+      contents: read
+      pull-requests: read
     env:
       HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     outputs:


### PR DESCRIPTION
## Summary

Follow-up to the two non-blocking security notes from #122's reviews (deferred there so as not to hold the merge). Applies the same hardening the conflict resolver received to the already-merged `pipeline-pr-autofix.yml`, and tightens the conflict resolver's read-only job.

**`pipeline-pr-autofix.yml`** — it had the same gaps #122 fixed for the new resolver:
- **`persist-credentials: false`** on checkout, so the job's `GITHUB_TOKEN` is not left in `.git/config` where the fix agent (which reads untrusted CI logs / PR content and can `cat`/`node`) could read and exfiltrate it. The verify step now reads the branch tip via `gh pr view --json headRefOid` instead of `git fetch`, since there's no longer a persisted git credential.
- **Pinned `Bash(git fetch:*)` → `Bash(git fetch origin:*)`** so the agent can only fetch from origin, not an arbitrary remote/URL.
- **Corrected the tool-surface comment** to stop claiming a *structural* "never push main" guarantee: the agent has `node`/`npm` code execution and could rewrite `.git/HEAD`, so the allowlist is defence-in-depth and branch protection on `main` is the enforceable guarantee — now stated as required, consistent with `pipeline-pr-conflict.yml` and `docs/SECURITY.md`.

**`pipeline-pr-conflict.yml`** — the read-only `discover` job now takes a job-level `permissions: { contents: read, pull-requests: read }` override, so it never carries the write scopes only the `resolve` job needs (a job-level block replaces the workflow-level grant).

## Security / privacy impact

Net **reduction** in privilege for the two CI push-loops; no change to the bot's runtime auth, tool gating, outbound filtering, or data access (no `src/`/`tests/` touched). Specifically: closes a `GITHUB_TOKEN` exposure path in autofix, narrows the agent's fetch scope, and drops write scopes from a read-only job. The honest-posture doc/comment changes make explicit that **branch protection on `main` is the enforceable guarantee** for all three write-capable loops (build, autofix, conflict-resolver) — confirmed enabled on this repo.

## How verified

- `python3 -c "import yaml"` parse of both workflows passes; confirmed `git fetch:*` is gone from autofix (replaced by `git fetch origin:*`), `persist-credentials: false` present on both checkouts, verify steps use `gh ... headRefOid`, and the `discover` job carries a read-only `permissions` block.
- No application/source code changed, so `typecheck`/`test`/`build` are unaffected; the autofix change validates on the next real CI-failure event and the resolver change on the next conflict.

Note: the bot cannot push `.github/workflows/*`, so this PR needs a human to merge it to go live.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_