### PR TITLE
Give build worker room under pool contention (timeout 60→120), keep per-issue concurrency

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -28,14 +28,21 @@ on:
   issues:
     types: [labeled]
 
-# Per-issue concurrency: distinct approved issues build in PARALLEL (faster
-# backlog drain), while re-triggering the SAME issue queues instead of
-# double-running (kills duplicate PRs). GitHub can't express a hard "max N
-# concurrent", so throughput is governed by how many issues are released at
-# once; every run still draws on the shared Max pool, so release in small
-# batches to avoid exhausting the weekly token allowance.
+# SERIAL builds — one at a time across the whole repo (a single fixed group,
+# NOT keyed by issue). Why the change from per-issue-parallel: every build draws
+# on the SAME shared Max pool, and per-issue parallelism let N approved/retried
+# issues run at once, so each turn got rate-limited, every build blew past its
+# 60-minute wall-clock, and ALL of them escalated `needs-human` — then the
+# build-retry loop re-ran the failures, adding MORE parallel load: a contention
+# death spiral (observed 2026-07-04: five small proposals, incl. #90, all
+# cancelled at exactly 60 min with `npm test` still running). Serialising means
+# each build gets the full pool and finishes in time; the backlog drains one PR
+# at a time instead of failing all at once. `cancel-in-progress: false` queues
+# rather than cancelling, so a re-trigger of the same (or any) issue never
+# double-runs. Slower but reliable — the shared pool is the bottleneck, not CI
+# minutes.
 concurrency:
-  group: pipeline-build-${{ github.event.issue.number }}
+  group: pipeline-build
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -185,8 +185,9 @@ jobs:
           # (issue #27); 80 died at turn 81 on a repo-wide job (issue #41,
           # ESLint+Prettier — formatting sweeps and lint-fix iteration eat
           # turns fast). 300 gives real proposals room to finish; the
-          # timeout-minutes above stays the wall-clock guard (~7s/turn
-          # observed, so 300 turns ≈ 40 min worst case).
+          # `timeout-minutes` above (120) is the wall-clock guard — solo, 300
+          # turns ≈ 40 min (~7s/turn), but under shared-pool throttling a
+          # legitimate build runs slower, which is why the guard is 120 not 60.
           claude_args: |
             --max-turns 300
             --model sonnet

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -11,9 +11,11 @@ name: Pipeline build worker
 #   2. Add repo secret CLAUDE_CODE_OAUTH_TOKEN (Settings → Secrets → Actions).
 #
 # COST: every run draws on the SAME Max pool as the production bot and every
-# other session. Builds are SERIALISED (see the `concurrency` block below —
-# one at a time repo-wide) precisely because that shared pool can't sustain
-# parallel builds; `--max-turns` + `timeout-minutes` bound a single run.
+# other session. Builds run per-issue (distinct issues in parallel — see the
+# concurrency block below for why a shared serial group is NOT used); the shared
+# pool is the real bottleneck, so `--max-turns` bounds a run and
+# `timeout-minutes` is sized generously so a contended (throttled) build finishes
+# rather than being killed mid-gate.
 #
 # WHY the explicit allowedTools + verify step: an earlier run finished with
 # conclusion=success but 12 permission denials and no branch/PR/relabel — the
@@ -28,21 +30,30 @@ on:
   issues:
     types: [labeled]
 
-# SERIAL builds — one at a time across the whole repo (a single fixed group,
-# NOT keyed by issue). Why the change from per-issue-parallel: every build draws
-# on the SAME shared Max pool, and per-issue parallelism let N approved/retried
-# issues run at once, so each turn got rate-limited, every build blew past its
-# 60-minute wall-clock, and ALL of them escalated `needs-human` — then the
-# build-retry loop re-ran the failures, adding MORE parallel load: a contention
-# death spiral (observed 2026-07-04: five small proposals, incl. #90, all
-# cancelled at exactly 60 min with `npm test` still running). Serialising means
-# each build gets the full pool and finishes in time; the backlog drains one PR
-# at a time instead of failing all at once. `cancel-in-progress: false` queues
-# rather than cancelling, so a re-trigger of the same (or any) issue never
-# double-runs. Slower but reliable — the shared pool is the bottleneck, not CI
-# minutes.
+# Per-issue concurrency: each issue gets its OWN group, so re-triggering the
+# SAME issue queues instead of double-running, while distinct issues do not
+# evict each other.
+#
+# WHY NOT a single shared group to force one-build-at-a-time: a GitHub
+# concurrency group holds only ONE pending run — when a new run is queued to a
+# group that already has one running + one pending, the previously-pending run
+# is CANCELLED (`cancel-in-progress: false` only protects the *running* job, not
+# the pending queue). So a burst of approvals against a shared group would
+# silently drop all but the last-queued build; worse, a `cancelled` run is not a
+# `failure`, so the build-retry loop (which triggers on `conclusion == failure`)
+# never reruns it and the verify/escalate step never runs — the issue would sit
+# at `status:approved` with no PR, no retry, no `needs-human`, invisibly. That
+# is why shared-group "serialisation" is the wrong tool here.
+#
+# Shared-pool contention (the 2026-07-04 spiral: parallel builds throttling each
+# other into the wall-clock and all escalating `needs-human`) is instead bounded
+# by a generous `timeout-minutes` below — a throttled build finishes slowly
+# rather than being killed mid-gate — plus the human approval cadence. If real
+# bursts still saturate the pool, the proper fix is a true FIFO lock the job
+# polls (a queue step), not `concurrency.group`; deferred as its own change
+# because a lock deployed wrong deadlocks every build.
 concurrency:
-  group: pipeline-build
+  group: pipeline-build-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 permissions:
@@ -56,10 +67,14 @@ jobs:
     # Only react to the approved label; ignore every other label event.
     if: github.event.label.name == 'status:approved'
     runs-on: ubuntu-latest
-    # Wall-clock guard sized to the turn cap below: ~7s/turn observed means
-    # 300 turns can legitimately run ~40 min; 60 keeps headroom without
-    # letting a hung run camp on the concurrency slot all day.
-    timeout-minutes: 60
+    # Wall-clock guard. Solo, 300 turns ≈ 40 min (~7s/turn). But builds share
+    # the Max pool, so under contention turns are throttled and a legitimate
+    # build runs several× slower — 60 min was killing real builds mid-gate (the
+    # 2026-07-04 spiral: cancelled at 60 min with `npm test` still running), and
+    # a cancelled run is not retried. 120 gives a contended build room to finish
+    # instead of being killed. Still well under GitHub's 6 h job cap; a genuinely
+    # hung run is still caught by the verify step (and costs at most 2 h).
+    timeout-minutes: 120
     # A real pgvector Postgres so the worker's OWN verification runs the
     # DB-integration tests (which skip without DATABASE_URL) against the same
     # database CI will use on the PR. Without this the worker "passes" locally

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -11,9 +11,9 @@ name: Pipeline build worker
 #   2. Add repo secret CLAUDE_CODE_OAUTH_TOKEN (Settings → Secrets → Actions).
 #
 # COST: every run draws on the SAME Max pool as the production bot and every
-# other session. `concurrency` is now per-issue (see below), so distinct
-# issues build in parallel; `--max-turns` + `timeout-minutes` bound a single
-# run, and releasing issues in small batches bounds total parallel draw.
+# other session. Builds are SERIALISED (see the `concurrency` block below —
+# one at a time repo-wide) precisely because that shared pool can't sustain
+# parallel builds; `--max-turns` + `timeout-minutes` bound a single run.
 #
 # WHY the explicit allowedTools + verify step: an earlier run finished with
 # conclusion=success but 12 permission denials and no branch/PR/relabel — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,12 @@ ownership rules:
   opening a PR, so "green locally" matches CI. Keep it that way when editing
   either `pipeline-build.yml` or `ci.yml` — they must run the same checks.
 - **No loop merges PRs** — a human merges.
-- WIP caps: ≤3 open `status:draft`. Builds run per-issue-parallel (the build
-  worker's `concurrency` is keyed by issue number), so multiple
-  `status:building` issues are allowed; keep the number in flight small (≈2)
-  since every run draws on the shared Max pool.
+- WIP caps: ≤3 open `status:draft`. Builds run **serially** — the build
+  worker's `concurrency` is a single fixed group (`pipeline-build`), so only
+  one build runs at a time and the rest queue. This is deliberate: every run
+  draws on the shared Max pool, and running many at once rate-limited every
+  build into its 60-min timeout (all escalating `needs-human` at once). Approve
+  freely; they drain one at a time rather than contending.
 - Coordinate only through issue labels; when blocked or ambiguous, add
   `needs-human` and stop rather than guess.
 - Everything traces to an issue number; the build session works in its own git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,14 @@ ownership rules:
   opening a PR, so "green locally" matches CI. Keep it that way when editing
   either `pipeline-build.yml` or `ci.yml` — they must run the same checks.
 - **No loop merges PRs** — a human merges.
-- WIP caps: ≤3 open `status:draft`. Builds run **serially** — the build
-  worker's `concurrency` is a single fixed group (`pipeline-build`), so only
-  one build runs at a time and the rest queue. This is deliberate: every run
-  draws on the shared Max pool, and running many at once rate-limited every
-  build into its 60-min timeout (all escalating `needs-human` at once). Approve
-  freely; they drain one at a time rather than contending.
+- WIP caps: ≤3 open `status:draft`. Builds run **per-issue** (each issue its own
+  `concurrency` group, so distinct issues run in parallel and none evicts
+  another — a single shared group would silently *cancel* queued builds, and
+  cancellations aren't retried). Every run draws on the shared Max pool, so
+  don't release large bursts at once: parallel builds throttle each other, and
+  the mitigation is a generous build `timeout-minutes` (contended builds finish
+  slowly rather than being killed), not a hard cap. A true FIFO lock is the
+  proper fix if bursts keep saturating the pool.
 - Coordinate only through issue labels; when blocked or ambiguous, add
   `needs-human` and stop rather than guess.
 - Everything traces to an issue number; the build session works in its own git

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -55,12 +55,16 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   as an ownership violation either.
 - **No loop merges PRs.** A human merges — especially important for this
   security-sensitive bot.
-- **WIP caps:** ≤3 open `status:draft`. Builds run **serially** — the build
-  worker's `concurrency` is a single fixed group (`pipeline-build`), so only one
-  build runs at a time and the rest queue. This is deliberate: every run draws
-  on the shared Max pool, and per-issue parallelism rate-limited every build
-  into its 60-min wall-clock timeout, escalating them all to `needs-human` at
-  once (observed 2026-07-04). Serial is slower but each build actually finishes.
+- **WIP caps:** ≤3 open `status:draft`. Builds run **per-issue** (each issue its
+  own `concurrency` group — distinct issues in parallel, no cross-eviction; a
+  single shared group would silently *cancel* queued builds, which aren't
+  retried). Every run draws on the shared Max pool, so avoid releasing large
+  bursts at once: parallel builds throttle each other on the pool, and 2026-07-04
+  showed a 5-issue burst rate-limiting every build into its wall-clock timeout.
+  The mitigation is a generous build `timeout-minutes` (a contended build
+  finishes slowly rather than being killed mid-gate), plus staggering approvals;
+  a true FIFO lock the job polls is the proper fix if bursts keep saturating the
+  pool.
 - **Label transitions are the only cross-session messaging.** When blocked or
   genuinely ambiguous, add `needs-human` and stop rather than guess.
 - **Everything traces to an issue number.**

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -55,10 +55,12 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   as an ownership violation either.
 - **No loop merges PRs.** A human merges — especially important for this
   security-sensitive bot.
-- **WIP caps:** ≤3 open `status:draft`. Builds run per-issue-parallel (the
-  build worker's `concurrency` is keyed by issue number), so multiple
-  `status:building` issues are allowed; keep the number in flight small (≈2),
-  since every run draws on the shared Max pool.
+- **WIP caps:** ≤3 open `status:draft`. Builds run **serially** — the build
+  worker's `concurrency` is a single fixed group (`pipeline-build`), so only one
+  build runs at a time and the rest queue. This is deliberate: every run draws
+  on the shared Max pool, and per-issue parallelism rate-limited every build
+  into its 60-min wall-clock timeout, escalating them all to `needs-human` at
+  once (observed 2026-07-04). Serial is slower but each build actually finishes.
 - **Label transitions are the only cross-session messaging.** When blocked or
   genuinely ambiguous, add `needs-human` and stop rather than guess.
 - **Everything traces to an issue number.**


### PR DESCRIPTION
## Summary

Fixes the recurring "multiple proposals stuck at `needs-human`" problem. **Note the approach changed after review** — see below.

**Diagnosis (run 28703635677 + four failed attempts on #90):** the build worker's builds all draw on the **same shared Max pool**. When several are approved/retried at once they throttle each other's Claude turns, so each build blew past its **60-minute wall-clock** and was `cancelled` *mid-`npm test`*, producing no PR → `needs-human`. The build-retry loop then re-ran the failures, adding more parallel load — a contention spiral. #90 (a one-helper change) ran a full 59 min and was killed at the 60-min timeout.

**First attempt (reverted):** a single shared `concurrency.group` to force one-build-at-a-time. The automated review correctly caught that this is unsafe — a GitHub concurrency group keeps only **one** pending run, so a burst of approvals *cancels* all but the last-queued (`cancel-in-progress: false` only protects the running job, not the pending queue). A `cancelled` run isn't a `failure`, so the retry loop wouldn't rerun it and the verify/escalate step never runs — issues would sit at `status:approved` invisibly. Worse than the status quo.

**Shipped approach:**
- **Keep per-issue `concurrency`** (each issue its own group) so distinct issues never evict each other and same-issue re-triggers still queue — no silent drops.
- **Raise `timeout-minutes` 60 → 120** so a throttled/contended build finishes slowly rather than being killed mid-gate (and cancellations aren't retried). Still well under GitHub's 6 h job cap.
- Document why a shared serial group is the wrong tool, and note a **true FIFO lock** (a queue step the job polls) as the proper fix if bursts keep saturating the pool — deferred as its own change because a lock deployed wrong deadlocks every build.
- `CLAUDE.md` + `docs/PIPELINE.md` updated to match.

This is a **mitigation, not hard serialization**: it stops the 60-min-kill failure mode and removes all silent-drop risk, but a large enough simultaneous burst could still contend. Staggering approvals (or the future FIFO lock) covers that.

## Security / privacy impact

None. CI-orchestration only — no `src/`/`tests/`, no change to tool gating, RBAC, outbound filtering, secret redaction, or SQL scoping.

## How verified

- `python3 -c "import yaml"`: parses; `concurrency.group` is back to `pipeline-build-${{ github.event.issue.number }}` and `timeout-minutes` is 120.
- Root cause traced to a real run (build step `cancelled` at ~59 min with `npm test`/`node`/`claude` as terminated orphans — legitimate work killed by the wall-clock, not idle).
- No application code changed, so `typecheck`/`test`/`build` are unaffected.

Separately (not in this PR): tonight's stuck backlog is being drained by re-triggering the affected issues **one at a time** by hand, which sidesteps contention regardless of this change.
