### PR TITLE
ci(pr-review): raise review worker turn cap 20 -> 60

### DIFF
--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -48,8 +48,13 @@ jobs:
         if: env.HAS_TOKEN == 'true'
 
       # Read-only review: produce the verdict as the FINAL text message. Only
-      # read tools are allowed, so there are no permission denials and no
-      # max-turns thrash. The model is explicitly told NOT to post anything.
+      # read tools are allowed, so there are no permission denials. The model is
+      # explicitly told NOT to post anything.
+      # Turn cap: 20 was too low for a large PR — reviewing a big diff means
+      # reading the diff + many changed files, and a ~15-file/~1200-line PR
+      # exhausted 20 turns and finished with `error_max_turns` and NO review
+      # text, failing the check. 60 gives large PRs room; the review is
+      # read-only + posts once, so it can't run away.
       - id: analyze
         if: env.HAS_TOKEN == 'true'
         continue-on-error: true # a bad run must still reach the post step below
@@ -86,7 +91,7 @@ jobs:
               or "Changes requested", or "Needs a human decision".
             - Then the findings as short bullets, or "No issues found." if clean.
           claude_args: |
-            --max-turns 20
+            --max-turns 60
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,TodoWrite"
 
       # Deterministic: extract the review text from the action's execution log


### PR DESCRIPTION
## Summary

The PR-review worker (`pipeline-pr-review.yml`) ran with `--max-turns 20`,
which is too low for a large PR. Reviewing a big diff means reading the diff
plus many changed files; a ~15-file/~1200-line PR (#146) exhausted the 20-turn
budget and finished with `error_max_turns` and no review text. That tripped the
"no review output was captured" guard and failed the `review` check even though
nothing was wrong with the PR itself. This raises the cap to 60 so large PRs
have room to read the diff + files and still emit the verdict. The comment
block is updated to drop the now-false "no max-turns thrash" claim and explain
the cap.

## Security / privacy impact

None. The review job remains strictly read-only — its `allowedTools` are
`gh pr diff/view` + `Read/Grep/Glob/TodoWrite` — and it posts a single comment
via the deterministic post step. A higher turn cap gives it more room to read,
but cannot grant it a write/merge/push capability it doesn't have, so it still
can't run away or take a destructive action.

## How verified

- YAML validated (`yaml.safe_load`) — parses clean.
- Change is confined to the workflow file (comment + `--max-turns` value); no
  application code, schema, or test touched, so `typecheck`/`test`/`build` are
  unaffected. This workflow-file change takes effect once merged to `main`
  (the action runs the default-branch version of the workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9c2BDLYYdRGpghMGHBYo)_