### PR TITLE
Membership tool replies name the member, not a raw platform id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 ### Changed
 - Auto-moderation warnings are now **public and minimal**: the warning is posted in the channel the offending message was posted in (not only the private admin channel), and names **only the member** — no user id, matched word, or message excerpt. The detailed record (id + matched term, needed for `clear_warnings`) still goes to the private admin channel, and the member still gets a DM. Follow-up to the auto-moderation feature (#141).
 
+### Fixed
+- Membership tool replies (`add_member`, `remove_member`, `grant_admin`, `revoke_admin`, `unlink_member`) now name the member (from the membership row or the server roster) instead of echoing a raw platform id — e.g. "Granted admin to **Adam H** on discord" rather than "…to 310697646731952132". Falls back to the id only when no name is known.
+
 ## 2026-07-04
 
 ### Added

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -47,6 +47,7 @@ import {
   removeMember,
   REPORT_RATE_LIMIT_PER_DAY,
   resolveContentReport,
+  resolveDisplayName,
   resolveSuggestion,
   rosterCounts,
   resolveLinkedIdentities,
@@ -1452,7 +1453,8 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
         logger.warn({ err, userId }, 'Failed to clear access request'),
       );
       await notifyMemberApproved(adapter, userId, wasAlreadyMember);
-      return text(`Added ${args.displayName ?? userId} as ${finalRole} on ${platform}.`);
+      const label = args.displayName ?? (await resolveDisplayName(platform, userId)) ?? userId;
+      return text(`Added ${label} as ${finalRole} on ${platform}.`);
     },
   );
 
@@ -1463,6 +1465,8 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'remove_member');
       const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      // Resolve the name before the row is deleted (roster still has it after).
+      const label = (await resolveDisplayName(platform, userId)) ?? userId;
       if (isSuperAdmin(platform, userId)) {
         return text('Refusing: that user is a super admin.', true);
       }
@@ -1478,7 +1482,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
         },
       });
       return text(
-        result === 'membership removed' ? `Removed ${userId} from ${platform} members.` : `Failed: ${result}`,
+        result === 'membership removed' ? `Removed ${label} from ${platform} members.` : `Failed: ${result}`,
         result !== 'membership removed',
       );
     },
@@ -1553,6 +1557,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
       assertAtLeast(caller.role, 'admin', 'unlink_member');
       const platform = args.platform ?? caller.platform;
       const userId = normalizeMemberId(platform, args.userId);
+      const label = (await resolveDisplayName(platform, userId)) ?? userId;
       // An admin may unlink an identity on their own platform, or one linked to
       // an identity on their platform (they have authority over that person).
       // Unlinking a foreign identity with no on-platform link is super-admin-only
@@ -1563,7 +1568,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
           assertAtLeast(caller.role, 'super_admin', 'unlinking an identity on another platform');
         }
       }
-      return requireConfirm(`unlink ${userId} on ${platform} from its linked identity`, 'admin', async () => {
+      return requireConfirm(`unlink ${label} on ${platform} from its linked identity`, 'admin', async () => {
         const { success, result } = await audited({
           actionKind: 'unlink_member',
           targetUserId: userId,
@@ -1574,7 +1579,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
             return 'unlinked';
           },
         });
-        return success ? `Unlinked ${userId} on ${platform}: ${result}.` : `Failed: ${result}`;
+        return success ? `Unlinked ${label} on ${platform}: ${result}.` : `Failed: ${result}`;
       });
     },
   );
@@ -1592,33 +1597,28 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'grant_admin');
       const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const label = args.displayName ?? (await resolveDisplayName(platform, userId)) ?? userId;
       // Privilege escalation is the highest-blast-radius action in the
       // system — CONFIRM-gated like kick/purge so an injected turn can
       // request but never complete it.
-      return requireConfirm(
-        `GRANT ADMIN to ${args.displayName ?? userId} (${userId}) on ${platform}`,
-        'super_admin',
-        async () => {
-          const { success, result } = await audited({
-            actionKind: 'grant_admin',
-            targetUserId: userId,
-            params: { platform },
-            run: async () => {
-              await upsertMember({
-                platform,
-                userId,
-                role: 'admin',
-                addedBy: caller.userId,
-                displayName: args.displayName,
-              });
-              return 'granted';
-            },
-          });
-          return success
-            ? `Granted admin to ${args.displayName ?? userId} on ${platform}.`
-            : `Failed: ${result}`;
-        },
-      );
+      return requireConfirm(`GRANT ADMIN to ${label} on ${platform}`, 'super_admin', async () => {
+        const { success, result } = await audited({
+          actionKind: 'grant_admin',
+          targetUserId: userId,
+          params: { platform },
+          run: async () => {
+            await upsertMember({
+              platform,
+              userId,
+              role: 'admin',
+              addedBy: caller.userId,
+              displayName: args.displayName,
+            });
+            return 'granted';
+          },
+        });
+        return success ? `Granted admin to ${label} on ${platform}.` : `Failed: ${result}`;
+      });
     },
   );
 
@@ -1629,6 +1629,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'revoke_admin');
       const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const label = (await resolveDisplayName(platform, userId)) ?? userId;
       if (isSuperAdmin(platform, userId)) {
         return text('Refusing: super admins are configured in the environment, not manageable here.', true);
       }
@@ -1642,7 +1643,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter)
           return 'demoted to member';
         },
       });
-      return text(success ? `${userId} is now a member on ${platform}.` : `Failed: ${result}`, !success);
+      return text(success ? `${label} is now a member on ${platform}.` : `Failed: ${result}`, !success);
     },
   );
 

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -599,6 +599,29 @@ export async function getMemberRole(platform: Platform, userId: string): Promise
 }
 
 /**
+ * Best-known human-readable name for a platform user — the membership row's
+ * display name first, then the server roster — so tool replies can name the
+ * member instead of echoing a raw platform id. Returns null when nothing is
+ * stored (the caller decides on a fallback).
+ */
+export async function resolveDisplayName(platform: Platform, userId: string): Promise<string | null> {
+  const { rows } = await pool.query(
+    `SELECT display_name FROM (
+       SELECT display_name, 0 AS pref FROM community_users
+         WHERE platform = $1 AND platform_user_id = $2
+       UNION ALL
+       SELECT display_name, 1 AS pref FROM server_roster
+         WHERE platform = $1 AND user_id = $2
+     ) names
+     WHERE display_name IS NOT NULL AND display_name <> ''
+     ORDER BY pref
+     LIMIT 1`,
+    [platform, userId],
+  );
+  return rows[0]?.display_name ?? null;
+}
+
+/**
  * Upsert a membership grant. Never downgrades: adding an existing admin as a
  * member keeps them admin (downgrades go through revoke_admin explicitly).
  */

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -65,6 +65,7 @@ const {
   SUGGESTION_MAX_CHARS,
   upsertMember,
   getMemberRole,
+  resolveDisplayName,
   removeMember,
   linkMembers,
   unlinkMember,
@@ -2038,6 +2039,39 @@ test(
     await pool.query(`DELETE FROM community_users WHERE platform = 'whatsapp' AND platform_user_id = $1`, [
       w,
     ]);
+  },
+);
+
+test(
+  'resolveDisplayName prefers the membership row, falls back to the roster, else null',
+  { skip },
+  async () => {
+    const uid = `${RUN}-name`;
+    assert.equal(await resolveDisplayName('discord', uid), null, 'unknown user has no stored name');
+
+    await pool.query(
+      `INSERT INTO server_roster (platform, user_id, display_name) VALUES ('discord', $1, 'Roster Name')`,
+      [uid],
+    );
+    assert.equal(await resolveDisplayName('discord', uid), 'Roster Name', 'falls back to the roster name');
+
+    await upsertMember({
+      platform: 'discord',
+      userId: uid,
+      role: 'member',
+      addedBy: `${RUN}-admin`,
+      displayName: 'Member Name',
+    });
+    assert.equal(
+      await resolveDisplayName('discord', uid),
+      'Member Name',
+      'the membership display name takes precedence over the roster',
+    );
+
+    await pool.query(`DELETE FROM community_users WHERE platform = 'discord' AND platform_user_id = $1`, [
+      uid,
+    ]);
+    await pool.query(`DELETE FROM server_roster WHERE platform = 'discord' AND user_id = $1`, [uid]);
   },
 );
 


### PR DESCRIPTION
## Problem

`grant_admin`'s CONFIRM result is sent **verbatim** by the router (the confirm is executed deterministically, so the model never rewrites it), and it fell back to the raw user id:

> Granted admin to `310697646731952132` on discord.

The same `${... userId}` leak was in `add_member`, `remove_member`, `revoke_admin`, and `unlink_member`.

## Change

- New `resolveDisplayName(platform, userId)` (repository): best-known name — the `community_users` display name first, then `server_roster` — or `null`.
- The five membership tools now show that name in their confirm prompts and success messages, e.g. **"Granted admin to Adam H on discord"**. Falls back to the id only when no name is stored anywhere.
- DB-backed test for `resolveDisplayName` (membership-over-roster precedence, null when unknown).

No behaviour change beyond the wording; ids still drive the actual DB writes and the private `#moderation` admin log keeps the id for `clear_warnings`.

## Verification
`typecheck` / `build` / `lint` / `format` clean; full suite 283 pass / 0 fail / 104 DB-skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)