### PR TITLE
Discord: suppress link-preview embeds on the bot's messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 - Members can now rate the bot's last answer with `rate_answer` (helpful/unhelpful, no free text, rate-capped) so admins finally get a calibrated signal on answer quality — the deferred half of #60. Admins read the aggregate, scoped to their own conversations, with the new `list_answer_feedback` tool (#118).
 
 ### Changed
+- Discord replies and DMs now send with `SuppressEmbeds`, so links the bot posts no longer expand into large preview cards — the message text is unchanged, just no auto-embed.
 - Auto-moderation warnings are now **public and minimal**: the warning is posted in the channel the offending message was posted in (not only the private admin channel), and names **only the member** — no user id, matched word, or message excerpt. The detailed record (id + matched term, needed for `clear_warnings`) still goes to the private admin channel, and the member still gets a DM. Follow-up to the auto-moderation feature (#141).
 
 ### Fixed

--- a/src/platforms/discord/adapter.ts
+++ b/src/platforms/discord/adapter.ts
@@ -2,6 +2,7 @@ import {
   Client,
   Events,
   GatewayIntentBits,
+  MessageFlags,
   Partials,
   PermissionFlagsBits,
   type GuildMember,
@@ -327,9 +328,14 @@ export class DiscordAdapter implements PlatformAdapter, ModerationEnforcer {
       throw new Error(`Discord channel ${out.conversationId} is not sendable`);
     }
     // Discord caps messages at 2000 chars; chunk longer replies. Mentions are
-    // never parsed so an injected "@everyone" can't mass-ping.
+    // never parsed so an injected "@everyone" can't mass-ping. SuppressEmbeds
+    // stops Discord from expanding any links in the reply into preview cards.
     for (const chunk of chunkText(await this.filtered(out.text), MAX_DISCORD_LEN)) {
-      await channel.send({ content: chunk, allowedMentions: { parse: [] } });
+      await channel.send({
+        content: chunk,
+        allowedMentions: { parse: [] },
+        flags: MessageFlags.SuppressEmbeds,
+      });
     }
   }
 
@@ -343,7 +349,11 @@ export class DiscordAdapter implements PlatformAdapter, ModerationEnforcer {
   async sendDirectMessage(userId: string, text: string): Promise<void> {
     const user = await this.client.users.fetch(userId);
     for (const chunk of chunkText(await this.filtered(text), MAX_DISCORD_LEN)) {
-      await user.send({ content: chunk, allowedMentions: { parse: [] } });
+      await user.send({
+        content: chunk,
+        allowedMentions: { parse: [] },
+        flags: MessageFlags.SuppressEmbeds,
+      });
     }
   }
 


### PR DESCRIPTION
Per operator request: the bot should not expand links it posts into Discord's large preview cards.

## Change
`sendMessage` (replies) and `sendDirectMessage` (DMs) now send with `flags: MessageFlags.SuppressEmbeds`. Discord then renders the URL as plain text with no auto-embed. Message text, chunking, and the existing `allowedMentions: { parse: [] }` are unchanged.

Scope: the bot's own outbound content messages. Static welcome and moderation-alert sends are left as-is (they don't post user links).

## Verification
`typecheck` (confirms the flag is a valid send option) / `build` / `lint` / `format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)