### PR TITLE
generate_image review round 2: argv regression test, enforce absolute GROK_BIN

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -303,6 +303,11 @@ const imageGenDaily = new Map<string, { day: string; count: number }>();
  * Reserve one image-generation slot for `key` against today's per-user cap.
  * Returns false (and does not increment) if the cap is already reached.
  * A limit of 0 means unlimited.
+ *
+ * A reservation is deliberately NOT refunded if the generation later fails: the
+ * cap bounds heavyweight `grok` subprocess spawns, and a failed attempt still
+ * spawned (and paid for) one — so a timeout/crash counts, and induced-failure
+ * retry spam can't bypass the cap.
  */
 function reserveImageGenDaily(key: string, limit: number): boolean {
   if (limit <= 0) return true;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from 'node:path';
 import { config as loadEnv } from 'dotenv';
 import { z } from 'zod';
 
@@ -276,7 +277,14 @@ const EnvSchemaChecked = EnvSchema.refine(
       message: `ROSTER_DEPARTED_RETENTION_DAYS must be 0 (disabled) or at least ${MIN_ROSTER_DEPARTED_RETENTION_DAYS}`,
       path: ['ROSTER_DEPARTED_RETENTION_DAYS'],
     },
-  );
+  )
+  .refine((e) => !e.IMAGE_GEN_ENABLED || isAbsolute(e.GROK_BIN), {
+    // A bare `grok` is PATH-resolved; a writable PATH entry could shadow it with
+    // a hostile binary run as the service user (see docs/SECURITY.md §8). Fail
+    // fast when the feature is on rather than trusting the deploy to get it right.
+    message: 'GROK_BIN must be an absolute path when IMAGE_GEN_ENABLED=true (avoids PATH hijack)',
+    path: ['GROK_BIN'],
+  });
 
 const parsed = EnvSchemaChecked.safeParse(emptyStringsToUndefined(process.env));
 if (!parsed.success) {

--- a/src/media/grokImage.ts
+++ b/src/media/grokImage.ts
@@ -143,23 +143,36 @@ async function locateSessionImage(
   return null;
 }
 
+/**
+ * The argv for the grok subprocess. Exported and kept pure so a test can assert
+ * the security-critical flags never silently drift:
+ *  - `--tools GenerateImage` is the allowlist that makes unattended
+ *    `--always-approve` safe (no Bash/file/exec tool for it to approve). If a
+ *    refactor drops it, `--always-approve` becomes a host-code-execution surface.
+ *  - `--output-format json` is how we read the session id back to locate the image.
+ */
+export function buildGrokArgs(instruction: string): string[] {
+  return [
+    '--tools',
+    'GenerateImage',
+    '--output-format',
+    'json',
+    '--always-approve',
+    '--disable-web-search',
+    '-p',
+    instruction,
+  ];
+}
+
 /** Spawn grok headlessly, locked to the image tool, and resolve its stdout. */
 function runGrok(instruction: string, cwd: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      config.imageGen.grokBin,
-      [
-        '--tools',
-        'GenerateImage',
-        '--output-format',
-        'json',
-        '--always-approve',
-        '--disable-web-search',
-        '-p',
-        instruction,
-      ],
-      { cwd, env: grokEnv(), stdio: ['ignore', 'pipe', 'pipe'], timeout: config.imageGen.timeoutMs },
-    );
+    const child = spawn(config.imageGen.grokBin, buildGrokArgs(instruction), {
+      cwd,
+      env: grokEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: config.imageGen.timeoutMs,
+    });
     let stdout = '';
     let stderr = '';
     child.stdout?.on('data', (d: Buffer) => {

--- a/tests/grokImage.test.ts
+++ b/tests/grokImage.test.ts
@@ -7,7 +7,7 @@ process.env.DISCORD_BOT_TOKEN ??= 'test-token';
 process.env.DISCORD_GUILD_ID ??= '1';
 process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
 
-const { sniffImageType, parseSessionId } = await import('../src/media/grokImage.js');
+const { sniffImageType, parseSessionId, buildGrokArgs } = await import('../src/media/grokImage.js');
 
 test('sniffImageType detects JPEG / PNG / WebP from magic bytes', () => {
   assert.deepEqual(sniffImageType(Buffer.from([0xff, 0xd8, 0xff, 0xe0])), {
@@ -27,6 +27,22 @@ test('sniffImageType returns null for non-image or empty bytes (never mislabels)
   assert.equal(sniffImageType(Buffer.alloc(0)), null);
   // A near-miss that shares no full signature must not be treated as an image.
   assert.equal(sniffImageType(Buffer.from([0xff, 0xd8, 0x00])), null);
+});
+
+test('SECURITY: buildGrokArgs locks the CLI to the image tool so --always-approve is safe', () => {
+  const args = buildGrokArgs('draw a cat');
+  // The allowlist that removes Bash/file/exec — without it, --always-approve
+  // becomes a host-code-execution surface. --tools must be immediately followed
+  // by exactly GenerateImage.
+  const i = args.indexOf('--tools');
+  assert.ok(i >= 0, '--tools must be present');
+  assert.equal(args[i + 1], 'GenerateImage');
+  assert.ok(args.includes('--always-approve'));
+  assert.ok(args.includes('--disable-web-search'));
+  // The free-text prompt is the value of -p, an argv element (never a shell string).
+  const p = args.indexOf('-p');
+  assert.ok(p >= 0);
+  assert.equal(args[p + 1], 'draw a cat');
 });
 
 test('parseSessionId reads the session id from grok JSON stdout', () => {

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -9,6 +9,7 @@
   "contextBuilder.test.ts": 2,
   "contextExport.test.ts": 4,
   "discordAdapter.test.ts": 2,
+  "grokImage.test.ts": 1,
   "knowledgeScope.test.ts": 3,
   "moderation.test.ts": 3,
   "moderationRepo.test.ts": 1,


### PR DESCRIPTION
Follow-up to #153 (already merged). The second automated review of #153 landed after the merge, confirming the Critical/High/Medium fixes are in and requesting three small hardening follow-ups. This PR lands them.

- **Regression test for the security boundary.** The safety model rests on `runGrok` invoking `grok --tools GenerateImage --always-approve …` — the `--tools` allowlist is what makes unattended `--always-approve` safe (no Bash/file/exec tool for it to approve), and that was only verified by hand. Extracted the argv into a pure `buildGrokArgs()` and added a `SECURITY:` test asserting `--tools` is immediately followed by `GenerateImage` (plus `--always-approve`/`--disable-web-search` and the prompt as the `-p` argv value). A refactor that drops the allowlist now fails CI. Floor bumped (`grokImage.test.ts: 1`).
- **Enforce the GROK_BIN PATH-hijack guard, don't just document it.** Added a config `.refine()` requiring an absolute `GROK_BIN` when `IMAGE_GEN_ENABLED=true`, matching the repo's fail-fast convention (cf. `WHATSAPP_PROVIDER=cloud`). A careless deploy can no longer silently reintroduce the PATH-hijack surface the docs warn about.
- **Document the daily-cap semantics.** A reservation is deliberately not refunded on a failed generation (each attempt still spawns a heavyweight `grok` process), so a timeout/induced-failure can't spam past the cap — added a comment saying so.

Verified locally: format:check, lint, build, and the grokImage tests (5/5, incl. the new SECURITY test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)