### PR TITLE
Reset target's session on grant_admin/revoke_admin so role changes apply immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 - Auto-moderation warnings are now **public and minimal**: the warning is posted in the channel the offending message was posted in (not only the private admin channel), and names **only the member** — no user id, matched word, or message excerpt. The detailed record (id + matched term, needed for `clear_warnings`) still goes to the private admin channel, and the member still gets a DM. Follow-up to the auto-moderation feature (#141).
 
 ### Fixed
+- A role change now takes effect on the target's **very next message**. Previously `grant_admin`/`revoke_admin` updated the role in the DB, but the target's live conversation session still carried the old-role framing in its history, so the bot would keep treating a freshly-promoted admin as a member (refusing admin actions) — or, worse, keep treating a freshly-*revoked* admin as an admin — until the session rolled over (30 turns / 24h). Both tools now reset the target's active-conversation session(s) on success (`clearUserSessions`, non-destructive — only session continuity is cleared, stored memory is untouched), so the new tier applies immediately.
 - Membership tool replies (`add_member`, `remove_member`, `grant_admin`, `revoke_admin`, `unlink_member`) now name the member (from the membership row or the server roster) instead of echoing a raw platform id — e.g. "Granted admin to **Adam H** on discord" rather than "…to 310697646731952132". Falls back to the id only when no name is known.
 
 ## 2026-07-04

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -15,6 +15,7 @@ import {
   createAnswerFeedback,
   createContentReport,
   createSuggestion,
+  clearUserSessions,
   declineKnowledgeCandidate,
   deleteKnowledge,
   deleteMemberNote,
@@ -311,6 +312,24 @@ export async function notifyReportWithdrawn(
       `Marked 'withdrawn' and kept on record — no action needed unless you want to check in.`,
     info.reporterUserId,
   );
+}
+
+/**
+ * After a role change (grant_admin/revoke_admin) commits, reset the target's
+ * active-conversation sessions so their new tier takes effect on the very next
+ * message rather than being shadowed by stale in-session context until the
+ * session rolls over (see `clearUserSessions`). Best-effort: a reset failure is
+ * logged but never fails or reverses the already-committed role change.
+ */
+async function resetSessionsForRoleChange(platform: Platform, userId: string, action: string): Promise<void> {
+  try {
+    const cleared = await clearUserSessions(platform, userId);
+    if (cleared > 0) {
+      logger.info({ action, platform, userId, cleared }, 'Reset target sessions after role change');
+    }
+  } catch (err) {
+    logger.warn({ err, action, platform, userId }, 'Failed to reset target sessions after role change');
+  }
 }
 
 /**
@@ -1757,6 +1776,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter,
             return 'granted';
           },
         });
+        if (success) await resetSessionsForRoleChange(platform, userId, 'grant_admin');
         return success ? `Granted admin to ${label} on ${platform}.` : `Failed: ${result}`;
       });
     },
@@ -1783,6 +1803,7 @@ export function buildToolServer(caller: CallerContext, adapter: PlatformAdapter,
           return 'demoted to member';
         },
       });
+      if (success) await resetSessionsForRoleChange(platform, userId, 'revoke_admin');
       return text(success ? `${label} is now a member on ${platform}.` : `Failed: ${result}`, !success);
     },
   );

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -290,6 +290,37 @@ export async function clearClaudeSessionId(platform: Platform, conversationId: s
 }
 
 /**
+ * Reset the stored Claude session for every conversation the given user is
+ * active in on `platform`, so a role change (grant_admin/revoke_admin) takes
+ * effect on their very next message instead of being shadowed by the old-role
+ * framing still in a live session's history until it rolls over
+ * (SESSION_MAX_TURNS/AGE). Without this, a freshly-promoted admin keeps getting
+ * refused, and — more importantly — a freshly-*revoked* admin's session could
+ * keep treating them as admin for up to a full session's worth of turns.
+ *
+ * Non-destructive: only clears session *continuity* (nulls `claude_session_id`,
+ * same primitive as `clearClaudeSessionId`); stored interactions/memory are
+ * untouched and the next turn rebuilds context from them. Scoped to
+ * conversations the user has actually participated in — in a group that means
+ * the group's shared thread resets, which is the same fresh-start that happens
+ * on normal rollover. Returns the number of sessions cleared.
+ */
+export async function clearUserSessions(platform: Platform, userId: string): Promise<number> {
+  const { rowCount } = await pool.query(
+    `UPDATE sessions
+        SET claude_session_id = NULL, updated_at = now()
+      WHERE platform = $1
+        AND claude_session_id IS NOT NULL
+        AND conversation_id IN (
+          SELECT DISTINCT conversation_id FROM interactions
+           WHERE platform = $1 AND user_id = $2
+        )`,
+    [platform, userId],
+  );
+  return rowCount ?? 0;
+}
+
+/**
  * True if the bot has previously seen this conversation on this platform.
  * Used to stop privileged tools from targeting arbitrary ids (e.g. messaging
  * any phone number on WhatsApp).

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -21,6 +21,9 @@ const { config } = await import('../src/config.js');
 const pgvector = (await import('pgvector/pg')).default;
 const {
   recordInteraction,
+  setClaudeSessionId,
+  getClaudeSession,
+  clearUserSessions,
   userMessages,
   purgeOldInteractions,
   purgeUserData,
@@ -169,6 +172,53 @@ test(
     await pool.query(`DELETE FROM interactions WHERE user_id = $1`, [userId]);
     await pool.query(`DELETE FROM knowledge WHERE id = $1`, [kId]);
     await pool.query(`DELETE FROM admin_audit WHERE target_user_id = $1`, [userId]);
+  },
+);
+
+test(
+  "repository: clearUserSessions resets the target user's active-conversation sessions and only those (role change takes effect immediately)",
+  { skip },
+  async () => {
+    const userA = `${RUN}-cus-A`;
+    const userB = `${RUN}-cus-B`;
+    const convA1 = `${RUN}-cus-a1`; // A is active here
+    const convA2 = `${RUN}-cus-a2`; // A is active here too
+    const convB = `${RUN}-cus-b`; // only B is active here
+
+    // A talks in two conversations, B in a third. Each conversation has a live session.
+    for (const [conv, user] of [
+      [convA1, userA],
+      [convA2, userA],
+      [convB, userB],
+    ] as const) {
+      await recordInteraction({
+        platform: 'discord',
+        conversationId: conv,
+        userId: user,
+        role: 'member',
+        direction: 'inbound',
+        content: 'hi',
+      });
+      await setClaudeSessionId('discord', conv, `sess-${conv}`);
+    }
+
+    const cleared = await clearUserSessions('discord', userA);
+    assert.equal(cleared, 2, "only A's two conversation sessions are cleared");
+
+    assert.equal(await getClaudeSession('discord', convA1), null, "A's session in convA1 is reset");
+    assert.equal(await getClaudeSession('discord', convA2), null, "A's session in convA2 is reset");
+    const bSession = await getClaudeSession('discord', convB);
+    assert.equal(
+      bSession?.sessionId,
+      `sess-${convB}`,
+      "an unrelated user's session must be untouched — reset is scoped to the target's own conversations",
+    );
+
+    // Wrong platform is scoped out too.
+    assert.equal(await clearUserSessions('whatsapp', userA), 0, 'platform is part of the scope');
+
+    await pool.query(`DELETE FROM sessions WHERE conversation_id = ANY($1)`, [[convA1, convA2, convB]]);
+    await pool.query(`DELETE FROM interactions WHERE conversation_id = ANY($1)`, [[convA1, convA2, convB]]);
   },
 );
 


### PR DESCRIPTION
## The bug
`grant_admin`/`revoke_admin` update the role in the DB, but the target's live **conversation session** still carries the old-tier framing in its Claude history — so the model keeps acting on the old role until the session rolls over (`SESSION_MAX_TURNS` 30 / `SESSION_MAX_AGE_HOURS` 24).

Real case that surfaced it: a member was granted WhatsApp admin (grant committed, role resolves fresh per message to `admin`), but the group's active session kept refusing his image-generation requests and confabulating that it "still needs Chris's confirmation." Role/tools were actually correct — the *session context* was stale.

The revoke direction is worse: a **freshly-revoked admin** could keep being treated as an admin for up to a full session's worth of turns.

## The fix
- **`clearUserSessions(platform, userId)`** (repository): nulls `claude_session_id` for every conversation the user is active in on that platform — the same non-destructive primitive as the existing `clearClaudeSessionId` (only session *continuity* is cleared; stored interactions/memory are untouched and the next turn rebuilds from them). Scoped to the target's own conversations. Returns the count cleared.
- **`grant_admin` and `revoke_admin`** call it after a successful role change, via a best-effort `resetSessionsForRoleChange` helper — a reset failure is logged but never fails or reverses the already-committed grant.

Net effect: the new tier applies on the target's **very next message**.

## Notes / scope
- In a **group**, this resets that group's shared thread — the same fresh-start that happens on normal rollover; stored memory is retained, so it's low-impact.
- Scoped to `grant_admin`/`revoke_admin` (the admin-tier changes where this bites). `add_member`/`remove_member` could get the same treatment later if wanted.

## Tests
`clearUserSessions` resets the target's active-conversation sessions and **only** those — asserts an unrelated user's session is untouched and the wrong platform is scoped out. (DB-backed; runs in CI, skips locally without Postgres.)

Verified locally: format:check, lint, build, and the rbac/repository tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)