### PR TITLE
Docs ingest: scope out SDK-reference sections (DOCS_INGEST_EXCLUDE_PATHS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,12 @@ DOCS_INGEST_MAX_PAGES=2500
 DOCS_INGEST_MAX_CHUNKS=20000
 # Concurrent page fetches — small, to be polite to the docs host.
 DOCS_INGEST_CONCURRENCY=5
+# Doc-path prefixes to EXCLUDE (comma-separated). The default drops the
+# auto-generated per-language SDK/CLI reference — ~90% of the corpus by volume
+# and near-useless for a chat bot — keeping the conceptual guides + core API.
+# Set empty to ingest the whole corpus. Tune to taste (e.g. drop api/go but keep
+# api/python by removing it from this list).
+DOCS_INGEST_EXCLUDE_PATHS=api/go,api/csharp,api/java,api/python,api/typescript,api/ruby,api/php,api/cli,api/compliance
 # Anonymised community-context export, regenerated after each producing
 # builder run so the research loop can ground proposals in real community
 # need. Aggregate-only + k-floored + PII-scrubbed in code. K=3 default: small

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 ## 2026-07-05
 
 ### Changed
+- Docs ingest now **scopes out low-value sections** (`DOCS_INGEST_EXCLUDE_PATHS`): the default drops the auto-generated per-language SDK/CLI reference (`api/go`, `api/python`, `api/typescript`, …), which was ~90% of the corpus by volume (~24k of ~29k chunks) and near-useless for a chat bot, while keeping the conceptual guides + core API. Excluded pages are neither fetched nor counted as in-index, so their previously-ingested chunks are pruned on the next run. Result: a focused few-thousand-chunk KB of the docs people actually ask about, instead of drowning them in SDK method reference. Tune via the env var (empty = ingest everything).
 - Docs ingest chunks **coarser** (splits at H2 only, folding `###` subheadings inline) so API-reference pages no longer explode into thousands of one-parameter fragments — the full corpus now fits well under the (raised) chunk cap instead of truncating to the first ~16%. Pruning is now **index-based**: a `docs` chunk is removed only when its page drops out of the upstream index, not when a fetch fails — so the ~157 habitually-404 URLs in the index no longer disable cleanup. (Changing the chunking means a one-time `docs` wipe + re-ingest on the deploy that enables this.)
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,13 @@ const EnvSchema = z.object({
   DOCS_INGEST_MAX_CHUNKS: z.coerce.number().int().positive().max(60000).default(20000),
   // Concurrent page fetches — kept small to be polite to the docs host.
   DOCS_INGEST_CONCURRENCY: z.coerce.number().int().positive().max(16).default(5),
+  // Doc-path prefixes to EXCLUDE from ingest (comma-separated, matched against
+  // the page path, e.g. "api/go"). Default drops the auto-generated per-language
+  // SDK/CLI reference — ~90% of the corpus by volume and near-useless for a chat
+  // bot — keeping the conceptual guides + core API. Set empty to ingest all.
+  DOCS_INGEST_EXCLUDE_PATHS: z
+    .string()
+    .default('api/go,api/csharp,api/java,api/python,api/typescript,api/ruby,api/php,api/cli,api/compliance'),
   // Anonymised community-context export (issue #53): render digests into a
   // file the research loop can read. Off by default. The export applies its
   // own k-floor and PII scrub — see src/context/export.ts and SECURITY.md for
@@ -430,6 +437,7 @@ export const config = {
     maxPages: env.DOCS_INGEST_MAX_PAGES,
     maxChunks: env.DOCS_INGEST_MAX_CHUNKS,
     concurrency: env.DOCS_INGEST_CONCURRENCY,
+    excludePaths: csv(env.DOCS_INGEST_EXCLUDE_PATHS),
   },
   contextCandidates: {
     enabled: env.CONTEXT_CANDIDATES_ENABLED ?? false,

--- a/src/context/docsIngest.ts
+++ b/src/context/docsIngest.ts
@@ -65,14 +65,32 @@ export function parseDocIndex(indexText: string, allowedOrigin: string): string[
   return [...urls];
 }
 
-/** A short, stable, human-readable title from a page URL, e.g. "docs: api/messages". */
-export function titleForUrl(url: string): string {
-  const path = url
+/** The normalised doc path of a page URL, e.g. "api/messages" (drops host, .md, and the docs/en prefix). */
+export function docPathOf(url: string): string {
+  return url
     .replace(/^https?:\/\/[^/]+\//, '')
     .replace(/\.md$/, '')
     .replace(/^docs\/en\//, '')
     .replace(/^en\//, '');
-  return `docs: ${path}`;
+}
+
+/** A short, stable, human-readable title from a page URL, e.g. "docs: api/messages". */
+export function titleForUrl(url: string): string {
+  return `docs: ${docPathOf(url)}`;
+}
+
+/**
+ * Drop page URLs whose doc path is at or under any excluded prefix
+ * (config.docsIngest.excludePaths). Applied to the FULL index list so excluded
+ * pages are neither fetched NOR counted as "in the index" — which means their
+ * chunks are also pruned on the next run if they were previously ingested.
+ */
+export function filterExcludedUrls(urls: string[], excludePaths: readonly string[]): string[] {
+  if (excludePaths.length === 0) return urls;
+  return urls.filter((u) => {
+    const path = docPathOf(u);
+    return !excludePaths.some((p) => path === p || path.startsWith(`${p}/`));
+  });
 }
 
 /**
@@ -231,7 +249,10 @@ export async function runDocsIngest(
   // we fetch this run. Keeping these separate means a page we simply didn't
   // fetch (because it's past the cap) is never mistaken for a removed page and
   // deleted — it's still listed upstream.
-  const allUrls = parseDocIndex(indexText, allowedOrigin);
+  // Drop excluded sections (e.g. the per-language SDK reference) from the FULL
+  // list, so they're neither fetched nor treated as still-in-the-index (their
+  // previously-ingested chunks get pruned below).
+  const allUrls = filterExcludedUrls(parseDocIndex(indexText, allowedOrigin), config.docsIngest.excludePaths);
   const urls = allUrls.slice(0, config.docsIngest.maxPages);
   result.pages = urls.length;
   if (urls.length === 0) {

--- a/tests/docsIngest.test.ts
+++ b/tests/docsIngest.test.ts
@@ -18,8 +18,15 @@ const skip = hasDb
 
 const { pool, closeDb } = await import('../src/storage/db.js');
 const { config } = await import('../src/config.js');
-const { parseDocIndex, titleForUrl, chunkMarkdown, shouldRunDocsIngest, runDocsIngest, DOCS_PROVENANCE } =
-  await import('../src/context/docsIngest.js');
+const {
+  parseDocIndex,
+  titleForUrl,
+  filterExcludedUrls,
+  chunkMarkdown,
+  shouldRunDocsIngest,
+  runDocsIngest,
+  DOCS_PROVENANCE,
+} = await import('../src/context/docsIngest.js');
 
 after(async () => {
   if (hasDb) {
@@ -50,6 +57,24 @@ test('SECURITY: parseDocIndex keeps only SAME-ORIGIN .md URLs — a third-party 
 
 test('titleForUrl derives a short stable title', () => {
   assert.equal(titleForUrl('https://platform.claude.com/docs/en/api/messages.md'), 'docs: api/messages');
+});
+
+test('filterExcludedUrls drops pages at/under an excluded prefix, keeps everything else (and prefix boundaries are respected)', () => {
+  const base = 'https://platform.claude.com/docs/en';
+  const urls = [
+    `${base}/api/messages.md`,
+    `${base}/api/python.md`, // the section index page itself
+    `${base}/api/python/client.md`, // under it
+    `${base}/api/pythonic/thing.md`, // NOT under api/python (boundary)
+    `${base}/build-with-claude/tool-use.md`,
+  ];
+  const kept = filterExcludedUrls(urls, ['api/python', 'api/go']);
+  assert.deepEqual(kept, [
+    `${base}/api/messages.md`,
+    `${base}/api/pythonic/thing.md`,
+    `${base}/build-with-claude/tool-use.md`,
+  ]);
+  assert.equal(filterExcludedUrls(urls, []).length, urls.length, 'empty exclude list keeps everything');
 });
 
 test('chunkMarkdown splits at H2 only (### folds inline), prefixes the page title, and caps long sections', () => {


### PR DESCRIPTION
The live full re-ingest exposed that the docs corpus is **~90% auto-generated per-language SDK/CLI reference**:

| api/go | api/csharp | api/java | api/python | api/typescript | api/cli | api/ruby |
|---|---|---|---|---|---|---|
| 2453 | 2029 | 1841 | 1774 | 1760 | 1732 | 1710 |

~24k of ~29k chunks — which **drowns and truncates** the genuinely useful conceptual docs (build-with-claude, agents-and-tools, core Messages API = 139). So the fix is to **scope down, not scale the cap up** (more SDK reference makes retrieval worse).

## Change
- **`DOCS_INGEST_EXCLUDE_PATHS`** (comma-separated doc-path prefixes). Default drops the SDK/CLI reference + `api/compliance`, keeps the conceptual guides + core API. Empty = ingest everything; tune per-language to taste (e.g. drop `api/go` but keep `api/python`).
- `filterExcludedUrls` is applied to the **full** index list, so excluded pages are neither fetched nor treated as in-index — meaning their previously-ingested chunks are **pruned on the next run** (self-cleaning, no manual delete needed).

## Result
A focused **few-thousand-chunk** KB of the docs people actually ask about, no truncation, faster search.

## Tests
`filterExcludedUrls` drops at/under a prefix, respects boundaries (`api/pythonic` is not under `api/python`), and an empty list keeps everything.

Verified: format:check, typecheck, lint, build, pure tests pass; DB tests run in CI. I'll deploy + wipe + re-ingest to land the scoped corpus after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)