### PR TITLE
Harden and tidy the CI/pipeline automations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps the SHA-pinned actions in .github/workflows/ fresh (Dependabot bumps
+# the pin and its trailing version comment together) and batches npm updates.
+#
+# Interplay with the pipeline (docs/PIPELINE.md): Dependabot PRs are same-repo
+# bot PRs, so the PR-review worker reviews each one — a shared-Max-pool cost,
+# which is why npm updates are grouped into one monthly PR instead of a stream
+# of singles. They carry no `Closes #<n>` body, so the autofix and
+# conflict-resolver loops deliberately ignore them, and a human merges as
+# always.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      npm-all:
+        patterns:
+          - '*'

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -35,6 +35,7 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt < 2
     runs-on: ubuntu-latest
+    timeout-minutes: 5 # a single gh call; don't let a hung runner sit for the 6 h default
     steps:
       - name: Re-run the failed jobs once
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
 
+# Rapid pushes to a PR would otherwise stack redundant full CI runs (each with
+# its own pgvector service). Supersede-and-cancel applies to PR runs ONLY —
+# pushes to main always run to completion. A superseded run concludes
+# `cancelled`, not `failure`, so ci-retry / pipeline-pr-autofix (both keyed on
+# failure) ignore it.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,8 +40,13 @@ jobs:
       WHATSAPP_PROVIDER: disabled
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # persist-credentials:false everywhere in this repo's workflows: no CI
+      # step needs a git credential after checkout, and `npm test` executes
+      # PR code, so the job token must not sit readable in .git/config.
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -45,8 +59,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -71,8 +87,10 @@ jobs:
       DISCORD_GUILD_ID: ci-dummy-guild
       WHATSAPP_PROVIDER: disabled
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/pipeline-build-retry.yml
+++ b/.github/workflows/pipeline-build-retry.yml
@@ -39,6 +39,7 @@ jobs:
       github.event.workflow_run.event == 'issues' &&
       github.event.workflow_run.run_attempt < 3
     runs-on: ubuntu-latest
+    timeout-minutes: 5 # a single gh call; don't let a hung runner sit for the 6 h default
     steps:
       - name: Re-run the failed build
         env:

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -118,8 +118,17 @@ jobs:
         if: env.HAS_TOKEN == 'true'
         run: echo "STARTED_AT=$(date -u +%s)" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         if: env.HAS_TOKEN == 'true'
+        with:
+          # Do NOT leave the job's GITHUB_TOKEN in .git/config: the build agent
+          # processes (potentially adversarial) issue content and can read the
+          # file via `cat`/Read or an npm script, then exfiltrate it — and this
+          # job's token carries contents+issues+PR write. Same threat model and
+          # fix as pipeline-pr-autofix / pipeline-pr-conflict: the agent gets
+          # its git/gh auth from the action's App token, and the verify step
+          # uses GH_TOKEN env, so no persisted credential is needed anywhere.
+          persist-credentials: false
 
       # Create the base schema deterministically BEFORE the agent runs, so its
       # `npm test` sees a migrated DB. Leaving migration to the agent's prose
@@ -144,7 +153,7 @@ jobs:
         id: build
         if: env.HAS_TOKEN == 'true'
         continue-on-error: true # never let a mid-run failure hide the outcome; the verify step below is the source of truth
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@81be147df53fcd867cac5c68e80f40ba7b29c2b6 # v1.0.165
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -11,7 +11,13 @@ name: Pipeline PR autofix
 #   * Same-repo PRs only. workflow_run carries secrets even for fork PRs, so
 #     running a fix on fork-controlled code would be an injection vector — the
 #     `if` below hard-requires head_repository == this repo.
-#   * Bot-authored PRs only (the build worker). Human PRs are left alone.
+#   * Bot-authored BUILD-WORKER PRs only, identified by their `Closes #<n>`
+#     body — the build worker's contract, the same signal the conflict
+#     resolver's discover filter keys on. Human PRs and unrelated same-repo
+#     bot PRs (e.g. a Dependabot bump) are left alone.
+#   * PRs already labelled `needs-human` are SKIPPED — that label is the stop
+#     (same policy as the conflict resolver), so a cap-escalated PR never gets
+#     further agent runs or duplicate escalation comments.
 #   * Hard cap of 2 attempts per PR, counted via marker comments. After that it
 #     STOPS and escalates `needs-human` — without this it could fix→fail→fix in
 #     a loop that drains the weekly token pool.
@@ -83,7 +89,7 @@ jobs:
         if: env.HAS_TOKEN != 'true'
         run: echo "CLAUDE_CODE_OAUTH_TOKEN not set — PR autofix worker is inert."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         if: env.HAS_TOKEN == 'true'
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -102,7 +108,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          pr_json="$(gh pr list --head "$HEAD_BRANCH" --state open --json number,author,isCrossRepository --limit 1)"
+          pr_json="$(gh pr list --head "$HEAD_BRANCH" --state open --json number,author,isCrossRepository,labels,body --limit 1)"
           number="$(jq -r '.[0].number // empty' <<<"$pr_json")"
           if [ -z "$number" ]; then
             echo "No open PR for branch $HEAD_BRANCH — nothing to autofix."
@@ -110,8 +116,12 @@ jobs:
           fi
           is_bot="$(jq -r '.[0].author.is_bot // false' <<<"$pr_json")"
           xrepo="$(jq -r '.[0].isCrossRepository // false' <<<"$pr_json")"
-          if [ "$is_bot" != "true" ] || [ "$xrepo" = "true" ]; then
-            echo "PR #$number is not an eligible (same-repo, bot-authored) PR — skipping."
+          # Build-worker PRs only (`Closes #<n>` body) and not already escalated
+          # (`needs-human` is the stop label) — see the header guardrails.
+          is_build="$(jq -r '(.[0].body // "") | test("[Cc]loses #[0-9]+")' <<<"$pr_json")"
+          escalated="$(jq -r '[.[0].labels[]?.name] | index("needs-human") != null' <<<"$pr_json")"
+          if [ "$is_bot" != "true" ] || [ "$xrepo" = "true" ] || [ "$is_build" != "true" ] || [ "$escalated" = "true" ]; then
+            echo "PR #$number is not an eligible (same-repo, bot-authored, build-worker, not needs-human) PR — skipping."
             exit 0
           fi
           # Prior autofix attempts = number of ATTEMPT_MARKER comments (only).
@@ -171,7 +181,7 @@ jobs:
         id: fix
         if: env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
         continue-on-error: true # the verify step below is the source of truth
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@81be147df53fcd867cac5c68e80f40ba7b29c2b6 # v1.0.165
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
           DISCORD_BOT_TOKEN: ci-dummy-token

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -289,7 +289,7 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         if: steps.precheck.outputs.proceed == 'true'
         with:
           # The branch precheck derived from the PR number via the API — NEVER
@@ -336,7 +336,7 @@ jobs:
         if: steps.precheck.outputs.proceed == 'true'
         id: fix
         continue-on-error: true # the verify step below is the source of truth
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@81be147df53fcd867cac5c68e80f40ba7b29c2b6 # v1.0.165
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/community_agent_test
           DISCORD_BOT_TOKEN: ci-dummy-token

--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -44,8 +44,14 @@ jobs:
         if: env.HAS_TOKEN != 'true'
         run: echo "CLAUDE_CODE_OAUTH_TOKEN not set — PR review worker is inert. Add the secret + install the Claude GitHub App to enable."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         if: env.HAS_TOKEN == 'true'
+        with:
+          # The review agent reads untrusted PR content and its final text is
+          # posted publicly, so don't leave the job's GITHUB_TOKEN readable in
+          # .git/config; nothing here needs a persisted git credential (the
+          # post step uses GH_TOKEN env).
+          persist-credentials: false
 
       # Read-only review: produce the verdict as the FINAL text message. Only
       # read tools are allowed, so there are no permission denials. The model is
@@ -58,7 +64,7 @@ jobs:
       - id: analyze
         if: env.HAS_TOKEN == 'true'
         continue-on-error: true # a bad run must still reach the post step below
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@81be147df53fcd867cac5c68e80f40ba7b29c2b6 # v1.0.165
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The build worker opens its PRs as the `claude[bot]` GitHub App, and
@@ -90,8 +96,12 @@ jobs:
             - A one-line verdict: "LGTM, looks good and ready for a human to merge",
               or "Changes requested", or "Needs a human decision".
             - Then the findings as short bullets, or "No issues found." if clean.
+          # --model pinned explicitly (like every other agent workflow here)
+          # so the reviewer matches the documented model plan in
+          # docs/PIPELINE.md instead of floating on the action's default.
           claude_args: |
             --max-turns 60
+            --model sonnet
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,TodoWrite"
 
       # Deterministic: extract the review text from the action's execution log

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -15,7 +15,9 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false # the script uses GH_TOKEN env, not git
       - name: Create labels
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,12 @@ ownership rules:
 - **Only the build loop** writes code or opens PRs. PR-review comments only;
   research & adversarial touch issues only. One exception: the **autofix loop**
   (`pipeline-pr-autofix.yml`) may push fixes to an existing build-worker PR
-  branch when its CI fails — bounded to 2 attempts, same-repo bot PRs only,
-  and only from CI `run_attempt` ≥ 2 (the ci-retry loop below gets one free
-  machine rerun first, so agents never chase one-off flakes), then it
-  escalates `needs-human`. It never opens or merges PRs.
+  branch when its CI fails — bounded to 2 attempts; same-repo bot PRs with a
+  `Closes #` body only (unrelated bot PRs like Dependabot bumps and PRs
+  already labelled `needs-human` are skipped); and only from CI
+  `run_attempt` ≥ 2 (the ci-retry loop below gets one free machine rerun
+  first, so agents never chase one-off flakes), then it escalates
+  `needs-human`. It never opens or merges PRs.
 - The **conflict-resolver loop** (`pipeline-pr-conflict.yml`) may push a
   `main`-merge to an existing build-worker PR branch when that PR is
   CONFLICTING. It is two-hop: a `discover` job (triggered on every push to

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -42,8 +42,11 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
 - **Only the build loop** writes code / opens PRs. PR-review comments only;
   research & adversarial touch issues only (no files ⇒ no git conflicts). One
   exception: the **autofix loop** (`pipeline-pr-autofix.yml`) may push fixes to
-  an existing build-worker PR branch when its CI fails — same-repo bot PRs only,
-  capped at 2 attempts, and only from CI `run_attempt` ≥ 2 (**ci-retry.yml**
+  an existing build-worker PR branch when its CI fails — same-repo bot PRs
+  with a `Closes #` body only (the build worker's contract; unrelated bot PRs
+  like Dependabot bumps are ignored, as are PRs already labelled
+  `needs-human`), capped at 2 attempts, and only from CI `run_attempt` ≥ 2
+  (**ci-retry.yml**
   gives every failed CI run one blind machine rerun first, so transient
   npm-registry/runner flakes recover for zero agent cost), then it escalates
   `needs-human`. It never opens or merges PRs. Do not misflag its pushes as an
@@ -285,8 +288,11 @@ sessions:
 
 - `.github/workflows/pipeline-build.yml` — fires on `issues.labeled ==
   status:approved`, implements on a branch, opens a PR "Closes #N", relabels
-  `status:built`. `concurrency` serialises builds (WIP=1); `--max-turns 40` +
-  a 45-min job timeout bound a run.
+  `status:built`. Builds run **per-issue** (each issue its own `concurrency`
+  group — distinct issues in parallel, no cross-eviction); `--max-turns 300` +
+  a 120-min job timeout bound a run, sized generously so a pool-contended
+  build finishes slowly instead of being killed mid-gate (see the WIP-caps
+  bullet above).
 - `.github/workflows/pipeline-pr-review.yml` — fires on `pull_request`
   events; reviews the diff (security-focused), comments/approves, never merges.
 


### PR DESCRIPTION
## Summary

Fixes from a review of all eight workflows: `pipeline-build.yml`'s checkout now sets `persist-credentials: false` (the build agent processes potentially adversarial issue content with a contents+issues+PR-write `GITHUB_TOKEN` persisted in `.git/config` — the exact hole its autofix/conflict siblings already close; the same flag is added to the pr-review, setup-labels, and CI checkouts). Autofix eligibility is tightened to build-worker PRs only (`Closes #` body, same contract the conflict resolver keys on) and skips `needs-human`-labelled PRs, so Dependabot-style bot PRs never get agent pushes and escalation can't repeat. All third-party actions are pinned to full commit SHAs (`checkout` v6.0.3, `setup-node` v6.4.0, `claude-code-action` v1.0.165) with a new `.github/dependabot.yml` (weekly `github-actions`, grouped monthly npm) to keep pins fresh. Doc drift in `docs/PIPELINE.md`'s build-worker bullet is corrected (per-issue concurrency / 300 turns / 120 min), and CLAUDE.md + PIPELINE.md now state the tightened autofix contract. Tidies: `ci.yml` per-ref concurrency cancelling superseded PR runs only, `--model sonnet` pinned in the review worker, `timeout-minutes: 5` on both retry workflows.

## Security / privacy impact

Strictly tightening: removes a persisted write-scoped `GITHUB_TOKEN` from four checkouts where agent steps read untrusted content; narrows the autofix push surface from "any same-repo bot PR" to build-worker PRs not already escalated; and replaces mutable action tags with SHA pins in jobs holding `CLAUDE_CODE_OAUTH_TOKEN` and App push rights. No change to app auth, tool gating, outbound filtering, or data access. Note: the CI concurrency change cancels only superseded *pull_request* runs — a cancelled run concludes `cancelled`, not `failure`, so ci-retry/autofix are unaffected and main pushes always run to completion.

## How verified

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` (451 tests, 0 failures; 123 DB tests skipped as designed without `DATABASE_URL`), `npm run build`, and `npm run test:security` (123/123 against the manifest) all green. All nine YAML files parse. The new autofix eligibility jq logic was unit-tested against seven payload shapes (build-worker, Dependabot-style, escalated, human, fork, null/missing labels). Pin SHAs were taken from `git ls-remote` against each upstream repo, not from memory. The checkout/setup-node pins are also major bumps (v4 → v6, need the node24 runner that `ubuntu-latest` provides) — CI on this PR exercises them directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4)_