### PR TITLE
Build worker: grant gh issue view so the agent can read its proposal

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -162,6 +162,13 @@ jobs:
 
             Read CLAUDE.md (conventions + security posture you must not regress) and
             docs/PIPELINE.md (ownership rules) first, then:
+            0. Read the FULL proposal before anything else:
+               `gh issue view ${{ github.event.issue.number }}` and
+               `gh issue view ${{ github.event.issue.number }} --comments`.
+               The adversarial-review verdict comment often amends or
+               supersedes the body's acceptance criteria — implement against
+               the final agreed criteria, not just the body. Do not start (or
+               claim) the issue until you have read both.
             1. Relabel this issue `status:building` and comment that you've claimed it.
             2. Implement the approved proposal on a new branch (create it with
                `git checkout -b <branch>`). When you push, use EXACTLY
@@ -225,9 +232,17 @@ jobs:
           #     bar and closes the force-push / arbitrary-refspec / other-branch
           #     holes, but does not replace branch protection.
           #   * `gh`: exactly the writes a build needs (`issue edit`, `issue
-          #     comment`, `pr create`) plus reads (`pr list/view/diff`, `run
-          #     view`). No `gh pr merge`, no `gh api`, no `gh repo edit`, no
-          #     `gh workflow run`.
+          #     comment`, `pr create`) plus reads (`issue view`, `pr
+          #     list/view/diff`, `run view`). No `gh pr merge`, no `gh api`,
+          #     no `gh repo edit`, no `gh workflow run`.
+          #     `gh issue view` is REQUIRED, not a nicety: the agent must read
+          #     the proposal it is implementing (body + the adversarial
+          #     verdict's amended acceptance criteria), and the action's
+          #     automatic issue-context injection does not reach the agent in
+          #     this prompt-mode setup — its absence made every build on
+          #     2026-07-06 (#167/#169/#174/#176) fail with "cannot read the
+          #     issue, refusing to guess" and escalate needs-human after 3
+          #     attempts each.
           # Turn-cap history: 40 died at turn 41 on a small 4-file proposal
           # (issue #27); 80 died at turn 81 on a repo-wide job (issue #41,
           # ESLint+Prettier — formatting sweeps and lint-fix iteration eat
@@ -238,7 +253,7 @@ jobs:
           claude_args: |
             --max-turns 300
             --model sonnet
-            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git rm:*),Bash(git checkout -b:*),Bash(git switch -c:*),Bash(git rev-parse:*),Bash(git fetch origin:*),Bash(git merge origin/main),Bash(git push -u origin HEAD),Bash(git push origin HEAD),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(npm:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git rm:*),Bash(git checkout -b:*),Bash(git switch -c:*),Bash(git rev-parse:*),Bash(git fetch origin:*),Bash(git merge origin/main),Bash(git push -u origin HEAD),Bash(git push origin HEAD),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(npm:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
       - name: Verify a PR was produced (else escalate + fail loudly)
         if: always() && env.HAS_TOKEN == 'true'


### PR DESCRIPTION
## Summary

Unblocks the four wedged proposals (#167, #169, #174, #176). Every build attempt on them failed identically: the build agent's `--allowedTools` allowlist had `gh issue edit`/`gh issue comment` (writes) but no read path for the issue it was implementing, and the action's automatic issue-context injection doesn't reach the agent in this prompt-mode setup — so each agent correctly refused to guess at an approved proposal's scope and escalated `needs-human` after 3 attempts, producing zero PRs. This adds `Bash(gh issue view:*)` to the allowlist and a step-0 prompt instruction to read the issue body **and** comments before claiming (the adversarial verdict comment often amends the body's acceptance criteria). This is the fix the orchestrator's sweep comment on #167 called for.

## Security / privacy impact

Strictly a read grant: `gh issue view` is read-only, matching the existing `gh pr view`/`gh pr diff` read entries and the allowlist's least-privilege discipline. No new write form, no `gh api`, no change to the push pinning, merge prohibition, or any app-code surface.

## How verified

Workflow YAML parses; `npm run format:check` green (only a workflow file changed — `typecheck`/`test`/`build` were verified green on this base by CI on `main`). The real verification is operational: after merge, re-toggling `status:approved` on one of the four issues should produce a build run where the agent reads the proposal and reaches implementation instead of escalating at step 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4)_