### PR TITLE
Fix update_knowledge citation test for the CONFIRM gate (un-break main CI)

### DIFF
--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2759,7 +2759,10 @@ test(
     )._registeredTools;
 
     // Content-only edit: leaves the citation untouched (no re-verify).
+    // update_knowledge is CONFIRM-gated (advisory E2), so the handler only
+    // registers a pending action — drive it to completion before asserting.
     await tools['update_knowledge'].handler({ id, content: 'Updated content, no citation change.' });
+    await takePendingAction('discord', caller.conversationId, caller.userId)?.execute();
     const afterContentEdit = await pool.query(`SELECT source_url, verified_at FROM knowledge WHERE id = $1`, [
       id,
     ]);
@@ -2773,6 +2776,7 @@ test(
     await new Promise((r) => setTimeout(r, 10));
     // Explicit sourceUrl re-supply: re-verifies (bumps verified_at).
     await tools['update_knowledge'].handler({ id, sourceUrl: 'https://example.com/updated' });
+    await takePendingAction('discord', caller.conversationId, caller.userId)?.execute();
     const afterSourceEdit = await pool.query(`SELECT source_url, verified_at FROM knowledge WHERE id = $1`, [
       id,
     ]);


### PR DESCRIPTION
## Problem

`main`'s `build` job is red (has been since #234 merged — `9bc2b46` and `c9df160` both failed CI, incl. reruns). The single failing test is `update_knowledge re-verifies the citation (bumps verified_at) only when sourceUrl/sourceTitle is explicitly supplied (issue #214)` in `tests/tools.test.ts`.

Root cause is a benign interaction between two changes that landed close together:
- **#233** CONFIRM-gated `update_knowledge` (advisory finding E2 — an in-place overwrite of trusted, member-facing knowledge must be confirmed).
- **#234** added citation fields (`sourceUrl`/`sourceTitle`/`verified_at`) and a test that calls `update_knowledge`'s handler and then reads the row back immediately.

Once both are on `main`, the handler only *registers a pending action*; the DB write happens at CONFIRM. The test never confirmed, so `verified_at`/`source_url` never changed and the assertions failed. It's DB-backed, so it skips without a local Postgres — which is why it passed the pre-merge local gate and only surfaced in CI's `build` job.

## Fix

Drive the pending action to completion after each `update_knowledge` call, via `takePendingAction('discord', caller.conversationId, caller.userId)?.execute()` — the exact pattern the other CONFIRM-gated tool tests (`grant_admin`, `redeploy_bot`) already use. **No production code change**; both the CONFIRM gate and the citation re-verify behaviour are unchanged and still asserted (a separate `SECURITY:` test already pins that `update_knowledge` registers the pending action rather than overwriting in place).

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build`, `npm run test:security` (189/189, floor unchanged — this test isn't `SECURITY:`-prefixed) all green locally. The failing test itself is DB-backed and Docker isn't available in my environment, so **CI's `build` job is the real verification** — the fix mirrors a proven pattern, but confirm the `build` job goes green here before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiKQQUJpZoDmdiYmBzFUJ4)_