### PR TITLE
Fold knowledge_gaps count into the weekly admin digest (Closes #246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 ## 2026-07-08
 
 ### Added
+- Weekly **admin digest** now includes a **knowledge-gaps** count (#246): the number of questions in your conversations that hit the knowledge base with no good answer this week, with a nudge to run `list_knowledge_gaps` — the one admin signal that was still pull-only is now pushed proactively like the rest. Conversation-scoped and off unless `ADMIN_DIGEST_ENABLED`; the DM carries only the count, never the questions or who asked.
 - `suggest_issue` (opt-in, `GITHUB_ISSUE_ENABLED`, off by default): a **super-admin** tool to file a GitHub issue on the repo straight from a Discord or WhatsApp message — an idea, bug, or feature request becomes tracked work without leaving chat. Requires confirmation (it creates a public artifact), is rate-capped per day, scrubs secrets out of the body before sending, and is audited like every privileged action. Filed issues default to the `community-feedback` label, so they feed the research pipeline as evidence rather than skipping review. It's the bot's only outward write capability, so it holds a **fine-grained token scoped to `Issues: write` on one repo** and nothing more (see docs/SECURITY.md + docs/DEPLOYMENT.md).
 
 ## 2026-07-07

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,11 +117,15 @@ memory**:
    access-request count and their own scoped open-report count, plus (issue
    #193) a guild-wide pending-suggestion count, plus (issue #199, off unless
    `KNOWLEDGE_STALE_DAYS` is set) a guild-wide count of knowledge entries
-   neither edited nor retrieved in that many days, all sourced from dedicated
-   `COUNT(*)` reads (`countAccessRequests`/`countOpenReports`/
-   `countPendingSuggestions`/`countStaleKnowledge`) so a backlog past
-   `list_access_requests`/`list_reports`/`list_suggestions`'s own list
-   `limit` is never understated. The DM sends when *any* of the five signals
+   neither edited nor retrieved in that many days, plus (issue #246) their own
+   scoped count of `knowledge_gaps` (below-floor `knowledge_search` misses, the
+   pull-only complement to `list_knowledge_gaps`) — conversation-scoped like the
+   open-report count because that table has a `conversation_id` — all sourced
+   from dedicated `COUNT(*)` reads (`countAccessRequests`/`countOpenReports`/
+   `countPendingSuggestions`/`countStaleKnowledge`/`countKnowledgeGaps`) so a
+   backlog past `list_access_requests`/`list_reports`/`list_suggestions`/
+   `list_knowledge_gaps`'s own list `limit` is never understated. The DM sends
+   when *any* of the six signals
    is non-zero, and sends nothing on a quiet week (all zero, no DM, no
    noise); a persistently untriaged queue re-appears every subsequent weekly
    tick until it's cleared. Super admins are not enrolled; they keep the

--- a/src/adminDigest.ts
+++ b/src/adminDigest.ts
@@ -2,6 +2,7 @@ import { config } from './config.js';
 import { logger } from './logger.js';
 import {
   countAccessRequests,
+  countKnowledgeGaps,
   countOpenReports,
   countPendingSuggestions,
   countStaleKnowledge,
@@ -43,13 +44,15 @@ export function buildAdminDigestMessage(
   pendingSuggestions: number,
   staleKnowledgeCount: number,
   knowledgeStaleDays: number,
+  knowledgeGapsCount: number = 0,
 ): string | null {
   if (
     clusters.length === 0 &&
     pendingAccessRequests === 0 &&
     openReports === 0 &&
     pendingSuggestions === 0 &&
-    staleKnowledgeCount === 0
+    staleKnowledgeCount === 0 &&
+    knowledgeGapsCount === 0
   )
     return null;
 
@@ -77,6 +80,13 @@ export function buildAdminDigestMessage(
     sections.push(
       `📚 ${staleKnowledgeCount} knowledge entr${staleKnowledgeCount === 1 ? 'y' : 'ies'} untouched for ` +
         `${knowledgeStaleDays}d+ — run \`list_knowledge\` to review.`,
+    );
+  }
+  if (knowledgeGapsCount > 0) {
+    // Bare integer only — no query_text / user_id ever reaches the DM (#246).
+    sections.push(
+      `🕳️ ${knowledgeGapsCount} unanswered question(s) in your conversations this week hit no ` +
+        'knowledge — run `list_knowledge_gaps` to see what to document.',
     );
   }
   return sections.join('\n');
@@ -138,14 +148,23 @@ export async function runAdminDigestOnce(adapters: readonly PlatformAdapter[]): 
         (i) => i.userId,
       );
       const knowledgeStaleDays = config.adminDigest.knowledgeStaleDays;
-      const [clusters, pendingAccessRequests, openReports, pendingSuggestions, staleKnowledgeCount] =
-        await Promise.all([
-          recentQuestionClusters(scope, FRESHNESS_DAYS, CLUSTER_LIMIT),
-          countAccessRequests(),
-          countOpenReports(scope, viewerIds),
-          countPendingSuggestions(),
-          knowledgeStaleDays > 0 ? countStaleKnowledge(knowledgeStaleDays) : Promise.resolve(0),
-        ]);
+      const [
+        clusters,
+        pendingAccessRequests,
+        openReports,
+        pendingSuggestions,
+        staleKnowledgeCount,
+        knowledgeGapsCount,
+      ] = await Promise.all([
+        recentQuestionClusters(scope, FRESHNESS_DAYS, CLUSTER_LIMIT),
+        countAccessRequests(),
+        countOpenReports(scope, viewerIds),
+        countPendingSuggestions(),
+        knowledgeStaleDays > 0 ? countStaleKnowledge(knowledgeStaleDays) : Promise.resolve(0),
+        // Conversation-scoped like openReports (knowledge_gaps has a
+        // conversation_id), over the same freshness window (#246).
+        countKnowledgeGaps(scope, FRESHNESS_DAYS),
+      ]);
       const message = buildAdminDigestMessage(
         clusters,
         pendingAccessRequests,
@@ -153,6 +172,7 @@ export async function runAdminDigestOnce(adapters: readonly PlatformAdapter[]): 
         pendingSuggestions,
         staleKnowledgeCount,
         knowledgeStaleDays,
+        knowledgeGapsCount,
       );
       if (!message) continue; // quiet week — no send, freshness row untouched
 

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -3081,6 +3081,26 @@ export async function countOpenReports(
 }
 
 /**
+ * Count knowledge-search gaps (#208) recorded in the given conversations within
+ * the last `days`, for the weekly admin digest (#246). **Conversation-scoped**
+ * — unlike the guild-wide stale/access/suggestion counts — because
+ * `knowledge_gaps` has a `conversation_id`, so an admin never sees gap volume
+ * from a conversation they don't participate in (mirrors `countOpenReports`'s
+ * scoping). A true `COUNT(*)`, never `.length` of a `LIMIT`-bounded list, so a
+ * backlog larger than `list_knowledge_gaps`' own limit is not understated.
+ */
+export async function countKnowledgeGaps(conversationIds: readonly string[], days: number): Promise<number> {
+  if (conversationIds.length === 0) return 0;
+  const { rows } = await pool.query(
+    `SELECT count(*) AS n FROM knowledge_gaps
+      WHERE conversation_id = ANY($1)
+        AND created_at >= now() - ($2 || ' days')::interval`,
+    [[...conversationIds], String(days)],
+  );
+  return Number(rows[0].n);
+}
+
+/**
  * Flip a report's status (resolve/dismiss) — non-destructive, no CONFIRM
  * needed (mirrors warn_user's low-blast-radius treatment). Optionally scoped
  * to `conversationIds` so an admin can only resolve reports from

--- a/tests/adminDigest.test.ts
+++ b/tests/adminDigest.test.ts
@@ -30,6 +30,7 @@ const {
   recordAccessRequest,
   clearAccessRequest,
   countAccessRequests,
+  countKnowledgeGaps,
   countPendingSuggestions,
   countStaleKnowledge,
   createContentReport,
@@ -167,6 +168,27 @@ test('buildAdminDigestMessage: all five signals non-zero -> all five lines prese
   assert.ok(message.includes('🚩'), 'open-report line present');
   assert.ok(message.includes('💡'), 'pending-suggestion line present');
   assert.ok(message.includes('📚'), 'stale-knowledge line present');
+});
+
+test('buildAdminDigestMessage: knowledge-gaps line appears only when count > 0, and all SIX signals zero -> null (issue #246)', () => {
+  assert.equal(
+    buildAdminDigestMessage([], 0, 0, 0, 0, 0, 0),
+    null,
+    'all six signals zero — including knowledge gaps — is a quiet week',
+  );
+
+  const message = buildAdminDigestMessage([], 0, 0, 0, 0, 0, 2);
+  assert.ok(message, 'a non-zero knowledge-gaps count alone still produces a DM');
+  const gapLines = message.split('\n').filter((l) => l.includes('🕳️'));
+  assert.equal(gapLines.length, 1, 'exactly one knowledge-gaps line');
+  assert.match(gapLines[0], /🕳️ 2 unanswered question\(s\).*`list_knowledge_gaps`/);
+  assert.ok(!message.includes('🔔'), 'no cluster line when there are no clusters');
+  assert.ok(!message.includes('📚'), 'no stale-knowledge line when that count is zero');
+
+  assert.ok(
+    !buildAdminDigestMessage([], 1, 0, 0, 0, 0, 0)!.includes('🕳️'),
+    'no knowledge-gaps line when the gap count is zero',
+  );
 });
 
 function fakeAdapter(opts: {
@@ -632,6 +654,84 @@ test(
     );
 
     await pool.query(`DELETE FROM content_reports WHERE id = $1`, [report.id]);
+    await pool.query(`DELETE FROM community_users WHERE platform = 'discord' AND platform_user_id = $1`, [
+      adminId,
+    ]);
+    await pool.query(`DELETE FROM admin_digest_sends WHERE platform_user_id = $1`, [adminId]);
+  },
+);
+
+test(
+  'SECURITY: countKnowledgeGaps is conversation-scoped, a true COUNT(*) (not LIMIT-bounded), and windowed (issue #246)',
+  { skip },
+  async () => {
+    const inScope = `${RUN}-c-gaps-in`;
+    const outOfScope = `${RUN}-c-gaps-out`;
+    const userId = `${RUN}-gaps-user`;
+    const insertGap = (conversationId: string, query: string, ageDays = 0) =>
+      pool.query(
+        `INSERT INTO knowledge_gaps (platform, conversation_id, user_id, query_text, created_at)
+         VALUES ('discord', $1, $2, $3, now() - ($4 || ' days')::interval)`,
+        [conversationId, userId, query, String(ageDays)],
+      );
+    // 12 recent in-scope (more than any list_knowledge_gaps limit), 3 recent
+    // out-of-scope, and 1 in-scope but older than the 7-day window.
+    for (let i = 0; i < 12; i++) await insertGap(inScope, `in-scope gap ${i}`);
+    for (let i = 0; i < 3; i++) await insertGap(outOfScope, `out-of-scope gap ${i}`);
+    await insertGap(inScope, 'stale in-scope gap', 30);
+
+    assert.equal(
+      await countKnowledgeGaps([inScope], 7),
+      12,
+      'SECURITY: a true COUNT(*) of the 12 recent in-scope rows — excludes the 3 out-of-scope rows and the 30-day-old one, and is not a LIMIT-bounded length',
+    );
+    assert.equal(
+      await countKnowledgeGaps([inScope, outOfScope], 7),
+      15,
+      'counting across both scopes returns the full 15 recent rows (the count is not capped)',
+    );
+    assert.equal(await countKnowledgeGaps([], 7), 0, 'an empty scope counts nothing');
+
+    await pool.query(`DELETE FROM knowledge_gaps WHERE conversation_id = ANY($1)`, [[inScope, outOfScope]]);
+  },
+);
+
+test(
+  'SECURITY: the digest knowledge-gaps line carries only the count — never a gap query_text or user id (issue #246)',
+  { skip },
+  async () => {
+    const adminId = `${RUN}-run-gaps-admin`;
+    const conversationId = `${RUN}-c-run-gaps`;
+    const gapUserId = `${RUN}-run-gaps-asker`;
+    const secretQuery = 'a very identifiable unanswered question that must never leak';
+    await upsertMember({ platform: 'discord', userId: adminId, role: 'admin', addedBy: `${RUN}-actor` });
+    await pool.query(
+      `INSERT INTO knowledge_gaps (platform, conversation_id, user_id, query_text)
+       VALUES ('discord', $1, $2, $3)`,
+      [conversationId, gapUserId, secretQuery],
+    );
+
+    const sent: Array<{ userId: string; text: string }> = [];
+    const adapter = fakeAdapter({ platform: 'discord', conversationIds: [conversationId], sent });
+
+    await runAdminDigestOnce([adapter]);
+
+    assert.equal(sent.length, 1, 'the in-scope knowledge gap triggers a digest');
+    assert.match(
+      sent[0].text,
+      /🕳️ \d+ unanswered question\(s\).*`list_knowledge_gaps`/,
+      'the knowledge-gaps line is present',
+    );
+    assert.ok(
+      !sent[0].text.includes(secretQuery),
+      'SECURITY: the raw query_text must never appear in the digest DM',
+    );
+    assert.ok(
+      !sent[0].text.includes(gapUserId),
+      'SECURITY: the asker user id must never appear in the digest DM',
+    );
+
+    await pool.query(`DELETE FROM knowledge_gaps WHERE conversation_id = $1`, [conversationId]);
     await pool.query(`DELETE FROM community_users WHERE platform = 'discord' AND platform_user_id = $1`, [
       adminId,
     ]);

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -1,5 +1,5 @@
 {
-  "adminDigest.test.ts": 4,
+  "adminDigest.test.ts": 6,
   "agentOptions.test.ts": 7,
   "ambientArchiving.test.ts": 5,
   "ambientArchivingOff.test.ts": 2,


### PR DESCRIPTION
Closes #246 — implemented by hand after the build worker stalled on it (the escalation opacity that produced this is fixed separately in #251).

## Summary
`knowledge_gaps` (#208) was the one digest-eligible admin signal still **pull-only** (only via `list_knowledge_gaps`). This folds it into the existing weekly admin digest as a sixth signal — matching how #133/#193/#199 already fold pending queues in.

- **`countKnowledgeGaps(conversationIds, days)`** in `repository.ts` — a dedicated `SELECT count(*)`, **conversation-scoped** (`conversation_id = ANY($1)`, windowed by `created_at`), a true `COUNT(*)` (not `.length` of a `LIMIT`-bounded query).
- Wired into `runAdminDigestOnce`'s existing `Promise.all` (scoped to the same per-admin `scope`, over `FRESHNESS_DAYS`) and `buildAdminDigestMessage` (new `knowledgeGapsCount` param, one line, extended zero-signal skip).
- No new tool, RBAC tier, input surface, or schema change; off unless `ADMIN_DIGEST_ENABLED`.

## Security / privacy
- **Conversation-scoped** is the property that matters: unlike the guild-wide stale/access/suggestion counts, `knowledge_gaps` has a `conversation_id`, so the count is scoped to the admin's own conversations exactly like `countOpenReports` — an admin never sees gap volume from a conversation they don't participate in.
- The DM carries a **bare integer** only — never a gap's `query_text` or `user_id`.

## Acceptance criteria (from the adversarial verdict)
All met, including both `SECURITY:` criteria:
- Unit: gap line present iff count > 0; all six signals zero ⇒ `null`.
- `SECURITY:` `countKnowledgeGaps` conversation-scoped + true-`COUNT(*)` (12 in-scope of 15+stale) + windowed.
- `SECURITY:` the emitted digest gap line excludes `query_text` and `user_id`.
- `docs/ARCHITECTURE.md` admin-digest paragraph extended to the sixth signal; `tests/security-floor.json` bumped in the same diff.

Verified locally: `tsc`, eslint, prettier, `check-security-test-count` static pass, full suite 0 fail (the two new SECURITY DB tests run in CI's Postgres job).