### PR TITLE
ci(build): forbid the build worker ending its turn to "wait" for a gate

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -25,6 +25,17 @@ name: Pipeline build worker
 # tools a build needs so there is zero denial thrash, and (b) verify the
 # outcome deterministically: if no open PR closing this issue exists, relabel
 # `needs-human`, comment, and fail the job loudly.
+#
+# WHY the prompt forbids ending the turn to "wait": issue #256 (run
+# 28917783004) finished conclusion=success (60 turns) but produced no PR — its
+# captured final summary was "I'll end this turn and resume once the test run
+# completes or the wakeup fires." The agent ran the gate in the background and
+# yielded, expecting an interactive-style async resume. In a one-shot CI job
+# there is none — ending the turn exits the process, so it terminated mid-gate
+# with nothing committed. This is deterministic, not a flake, so all 3 blind
+# retries reproduced it. The prompt now states plainly that this is a single,
+# non-resumable execution and the agent must run every gate synchronously to
+# completion in the same turn.
 
 on:
   issues:
@@ -199,6 +210,16 @@ jobs:
             5. Do NOT merge — a human merges. If the proposal turns out infeasible or
                unsafe as specified, add the `needs-human` label and explain instead of
                forcing it.
+            This is a SINGLE, NON-RESUMABLE execution — a one-shot CI job, not an
+            interactive session. There is NO wakeup, scheduled resume, or "continue
+            later": the instant you end your turn, this process exits and everything
+            still in flight is lost. So NEVER end your turn to "wait" for anything —
+            do not kick off `npm test` (or any gate) in the background and yield
+            expecting to be re-invoked when it finishes. Run every command to
+            completion synchronously and read its result within this same turn. You
+            are only finished once the PR is open (or you have posted a blocker
+            comment per below) — not when work is "in progress" or a run is "still
+            going".
             NEVER end without opening a PR AND leaving a trace: if for ANY reason you
             finish without a PR (a gate you can't make green, a genuine blocker, a
             refusal), you MUST first `gh issue comment` this issue explaining exactly


### PR DESCRIPTION
## Summary

The build worker for issue #256 ([run 28917783004](https://github.com/swampratnz/community-agent/actions/runs/28917783004/job/85790356821)) finished `conclusion=success` (60 turns, `is_error: false`) but produced **no PR**, failing the verify gate on the final retry and escalating `needs-human`. Its captured final summary was the tell: *"I'll end this turn and resume once the test run completes or the wakeup fires."* The agent ran the CI gate in the background and **yielded its turn expecting an interactive-style async resume** — a wakeup/continuation that a one-shot `claude-code-action` job never delivers. Ending the turn exits the process, so it terminated mid-gate with nothing committed or pushed. This is deterministic, not a flake, which is why all 3 blind retries reproduced the identical no-PR outcome (same failure class as #246, whose diagnostics surfacing in #251 is what let us read the cause this time).

The retry loop is correctly designed for *transient* failures and can't recover a deterministic yield, so this fixes it at the source — the worker prompt:

- Adds an explicit directive that the build is a **single, non-resumable execution**: never end the turn to "wait" for anything, never background a gate (`npm test` etc.) and yield expecting re-invocation, run every command to completion synchronously and read its result within the same turn, and treat "finished" as strictly PR-open-or-blocker-comment-posted.
- Documents the failure mode in the header comment alongside the file's other recorded regressions (the permission-denial and missing-issue-context histories).

Prompt/comment-only change to `.github/workflows/pipeline-build.yml`; no job steps, tools, or verify logic altered.

## Security / privacy impact

None. This changes only the build worker's natural-language prompt and an explanatory comment. The `allowedTools` allowlist, permissions block, credential handling (`persist-credentials: false`, no persisted token), and the deterministic verify/escalate step are all unchanged — the security posture is untouched.

## How verified

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"` → OK).
- Diff is confined to prompt text and a comment block; no executable workflow logic, tool grants, or gate steps changed. No code paths in the app are touched, so `typecheck`/`test`/`build` are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_