### PR TITLE
ci(pipeline): reduce needs-human escalations (one-shot framing + diagnosable revise)

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -199,6 +199,13 @@ jobs:
             5. Do NOT merge — a human merges. If the proposal turns out infeasible or
                unsafe as specified, add the `needs-human` label and explain instead of
                forcing it.
+            EXECUTION MODEL — READ THIS FIRST: this is a SINGLE, non-interactive
+            batch run. There is NO wakeup, NO resume, and NO background
+            continuation — when your turn ends, this job ends. Run every command
+            (the gate, tests, git) synchronously to completion in THIS turn and
+            act on its result; NEVER end your turn to "wait" for a test/command
+            to finish or in the expectation of being resumed later. Running out
+            of turns without an open PR is a failure, not a pause.
             NEVER end without opening a PR AND leaving a trace: if for ANY reason you
             finish without a PR (a gate you can't make green, a genuine blocker, a
             refusal), you MUST first `gh issue comment` this issue explaining exactly

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -218,6 +218,17 @@ jobs:
                failure is not something you can safely fix, then just STOP
                without committing/pushing: a later step detects "no new commit"
                and escalates `needs-human` for you.
+
+            EXECUTION MODEL — READ THIS FIRST: this is a SINGLE, non-interactive
+            batch run. There is NO wakeup, NO resume, and NO background
+            continuation — when your turn ends, this job ends. Run every command
+            (the gate, tests, git) synchronously to completion in THIS turn and
+            act on its result; NEVER end your turn to "wait" for a test/command
+            to finish or in the expectation of being resumed later. Either push
+            your fix with `git push origin HEAD` in THIS turn, or (if it isn't
+            safely fixable here) stop deliberately so the no-new-commit
+            escalation hands it to a human. Running out of turns mid-fix is a
+            failure, not a pause.
           # Tool surface is least-privilege — defence in depth, NOT a hard
           # guarantee (the agent also has Edit/Write + node/npm code execution,
           # so it could rewrite .git/HEAD on disk; see the main-push note below):

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -379,6 +379,17 @@ jobs:
             `.github/workflows/` (you cannot push those — the token lacks the
             `workflows` scope), then just STOP without committing/pushing: a
             later step detects "no new commit" and escalates `needs-human`.
+
+            EXECUTION MODEL — READ THIS FIRST: this is a SINGLE, non-interactive
+            batch run. There is NO wakeup, NO resume, and NO background
+            continuation — when your turn ends, this job ends. Run every command
+            (the gate, tests, git) synchronously to completion in THIS turn and
+            act on its result; NEVER end your turn to "wait" for a test/command
+            to finish or in the expectation of being resumed later. Either push
+            the resolved branch with `git push origin HEAD` in THIS turn, or (if
+            the conflict isn't safely resolvable here) stop deliberately so the
+            no-new-commit escalation hands it to a human. Running out of turns
+            mid-resolution is a failure, not a pause.
           # Least-privilege tool surface (mirrors pipeline-pr-autofix.yml):
           #   * `gh` is READ-only (understand the PR) — no merge/close/create.
           #   * `git fetch`/`git merge` are pinned to the EXACT forms the prompt

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -245,6 +245,17 @@ jobs:
                post a short `gh pr comment` explaining exactly why, and STOP
                without committing/pushing. A later step detects "no new
                commit" and escalates `needs-human` so a maintainer decides.
+
+            EXECUTION MODEL — READ THIS FIRST: this is a SINGLE, non-interactive
+            batch run. There is NO wakeup, NO resume, and NO background
+            continuation — when your turn ends, this job ends. Run every command
+            (the gate, tests, git) synchronously to completion in THIS turn and
+            act on its result; NEVER end your turn to "wait" for a test/command
+            to finish or in the expectation of being resumed later. Before you
+            stop for ANY reason you must have EITHER pushed a revision with
+            `git push origin HEAD`, OR left the `gh pr comment` above explaining
+            why — ending with neither is exactly the opaque failure this loop
+            exists to avoid.
           # Least-privilege tool surface (mirrors pipeline-pr-autofix.yml).
           # Differences from autofix, both deliberate: `gh pr comment` is
           # allowed so a principled refusal is explained on the PR rather
@@ -274,6 +285,28 @@ jobs:
           fi
           echo "::error::Revise worker produced no new commit on PR #${PR_NUMBER}."
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label needs-human || true
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "${ESCALATE_MARKER}
-          🤖 Revise attempt ${{ steps.precheck.outputs.attempt }} pushed no revision — either it disagreed with the review (see its comment above), the change needs a \`.github/workflows/\` edit it can't push, or it wasn't safely fixable. Labelled \`needs-human\` for a maintainer. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Surface WHY (mirrors pipeline-build.yml's #251 escalation): pull the
+          # revise agent's own final summary from its execution log, so the
+          # escalation says what actually stopped it — a principled refusal, a
+          # `.github/workflows/` change it can't push, a gate it couldn't make
+          # green, or a run that flaked — instead of the three-way guess this
+          # comment used to make (which a maintainer then had to reverse-engineer
+          # from the run log). Best-effort: a silent no-op leaves no summary,
+          # which is itself the tell.
+          summary=""
+          exec_file="${{ steps.fix.outputs.execution_file }}"
+          if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
+            summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
+          fi
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            printf '%s\n🤖 Revise attempt %s pushed no revision — labelled `needs-human` for a maintainer. Run: %s\n' \
+              "${ESCALATE_MARKER}" "${{ steps.precheck.outputs.attempt }}" "${run_url}"
+            if [ -n "${summary}" ]; then
+              printf '\n<details><summary>Revise worker'\''s final summary (what it says stopped it)</summary>\n\n%s\n\n</details>\n' "${summary}"
+            else
+              printf '\n_No agent summary was captured — it ended without pushing **and** without a `gh pr comment`. That usually means a gate it could not make green, a `.github/workflows/` change it cannot push, or a disagreement with the review it did not voice. Check the run log above._\n'
+            fi
+          } | gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file - || true
           exit 1


### PR DESCRIPTION
Reduces `needs-human` escalations from the pipeline's PR-response agents.

> **Note:** the **build** worker's one-shot fix already landed on `main` (`7c3c8f0`, *"forbid the build worker ending its turn to 'wait' for a gate"*) while this was in flight. This PR now covers the **three workers `7c3c8f0` didn't touch** — revise, autofix, conflict — plus the revise-escalation diagnostics.

## A — Agents self-terminate mid-work (the #256 class, now extended to the other workers)

`7c3c8f0` fixed this for the build worker after #256's agent ended with *"I'll end this turn and resume once the test run completes or the wakeup fires"* — treating a one-shot Action as a resumable loop. The **revise, autofix, and conflict** workers have the identical exposure and had no such framing. This adds an `EXECUTION MODEL — READ THIS FIRST` block to each: no wakeup/resume/background continuation, run every command synchronously to completion this turn, never end to "wait". Tailored per worker — autofix and conflict can't `gh pr comment` (not in their allowlists), so their framing points at the no-new-commit escalation instead of telling them to comment.

## B — Opaque revise escalation (the #257 class)

On **#257** the revise worker pushed no commit on a mechanically-simple, reviewer-specified fix, then escalated with a three-way guess (*"disagreed / needs a workflows edit / not fixable"*). Mirrors the build worker's #251 diagnostics: extract the revise agent's own final summary from `steps.fix.outputs.execution_file` and put it in the `needs-human` comment, so a maintainer sees what actually stopped it.

## Scope / safety

- **No guardrail changed** — additive prompt framing + better diagnostics only. No change to allowlists, push discipline, the 2-attempt cap, branch protection, or the state machine.
- All three changed workflow files validated as parseable YAML.
- Deliberate follow-up (not here): one self-retry on a no-commit revise before escalating, and/or bumping the revise model — those change escalation *behaviour*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)