### PR TITLE
ci: hourly conflict resolver, now covering maintainer PRs

### DIFF
--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -27,11 +27,16 @@ name: Pipeline PR conflict resolver
 #
 # Guardrails (mirrors pipeline-pr-autofix.yml — this spends the shared Max pool
 # and pushes code, so they matter):
-#   * Same-repo, bot-authored PRs only. workflow-triggered secrets + a push
-#     tool must never run against human- or fork-controlled branches, so the
-#     discover filter hard-requires author.is_bot && !isCrossRepository.
-#   * PRs already labelled `needs-human` are SKIPPED — that label is the stop.
-#     A failed resolution labels `needs-human`, so each conflict gets exactly
+#   * Same-repo PRs only (never a fork — workflow-triggered secrets + a push
+#     tool must never run against fork-controlled branches; the discover filter
+#     hard-requires !isCrossRepository). Author must be EITHER the build-worker
+#     bot (with a `Closes #` body) OR a trusted maintainer in MAINTAINER_LOGINS
+#     (the repo owner's own human PRs — main churn otherwise leaves them stuck
+#     CONFLICTING with no responder). Fork/external-human PRs stay excluded.
+#   * PRs labelled `needs-human` OR `no-auto-resolve` are SKIPPED — the former
+#     is the failed-attempt stop; the latter lets anyone pin a PR out (e.g.
+#     while actively editing it).
+#   * A failed resolution labels `needs-human`, so each conflict gets exactly
 #     ONE attempt and the loop will not thrash on every subsequent push to main
 #     (which would otherwise drain the weekly token pool re-fighting the same
 #     unresolvable conflict).
@@ -66,7 +71,7 @@ on:
   # Backstop sweep for anything the event triggers missed (e.g. a discover run
   # superseded by concurrency, or a fork-PR trigger that couldn't dispatch).
   schedule:
-    - cron: '23 */6 * * *'
+    - cron: '23 * * * *'
   workflow_dispatch:
     inputs:
       resolve_matrix:
@@ -94,6 +99,15 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write # claude-code-action mints its GitHub App token via OIDC
+
+env:
+  # Human maintainers whose OWN same-repo PRs this resolver may also un-stick
+  # (space-separated GitHub logins). Bot build-worker PRs are covered by the
+  # is_bot + `Closes #` path; these are the trusted humans (the repo owner)
+  # who have opted their branches into auto-resolution. Fork PRs are NEVER
+  # eligible regardless (isCrossRepository guard). Any PR — bot or human — can
+  # be pinned OUT with the `no-auto-resolve` label (e.g. while you're mid-edit).
+  MAINTAINER_LOGINS: 'swampratnz'
 
 jobs:
   # Find open same-repo bot PRs that are CONFLICTING against main, and
@@ -140,19 +154,28 @@ jobs:
             exit 0
           fi
 
-          # Eligible = open, same-repo (not a fork), bot-authored, a BUILD-WORKER
-          # PR (its body references `Closes #<issue>` — the build worker's
-          # contract, the same signal pipeline-build.yml's own verify step keys
-          # on), and NOT already escalated to needs-human (that label is the
-          # one-attempt stop). The `Closes #` test scopes this to pipeline output
-          # so an unrelated same-repo bot PR (e.g. a Dependabot bump) is not
-          # given an automated main-merge + full-gate push.
+          # Eligible = open, same-repo (never a fork), NOT labelled needs-human
+          # or no-auto-resolve, AND either:
+          #   (a) a BUILD-WORKER PR — bot-authored with a `Closes #<issue>` body
+          #       (the build worker's contract; the `Closes #` test keeps an
+          #       unrelated bot PR like a Dependabot bump out), OR
+          #   (b) a MAINTAINER PR — authored by a login in MAINTAINER_LOGINS
+          #       (the repo owner's own human PRs, which main churn otherwise
+          #       leaves stuck CONFLICTING with no responder).
+          maint="$(jq -cn --arg s "$MAINTAINER_LOGINS" '$s | split(" ") | map(select(length > 0))')"
           candidates="$(gh pr list --repo "${{ github.repository }}" --state open --limit 100 \
             --json number,headRefName,author,isCrossRepository,labels,body \
-            --jq '[.[] | select((.isCrossRepository | not) and (.author.is_bot == true) and (((.body // "") | test("[Cc]loses #[0-9]+")) and ([.labels[].name] | index("needs-human") | not)))]')"
+            | jq -c --argjson maint "$maint" '[.[] | select(
+                (.isCrossRepository | not)
+                and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-resolve") | not))
+                and (
+                  ((.author.is_bot == true) and ((.body // "") | test("[Cc]loses #[0-9]+")))
+                  or (.author.login as $l | ($maint | index($l)) != null)
+                )
+              )]')"
 
           count="$(jq 'length' <<<"$candidates")"
-          echo "Found ${count} candidate bot PR(s); checking mergeability…"
+          echo "Found ${count} candidate PR(s) (bot + maintainer); checking mergeability…"
 
           include='[]'
           for i in $(seq 0 $(( count - 1 )) ); do
@@ -184,7 +207,7 @@ jobs:
           echo "Conflicting PRs to resolve: ${matrix}"
 
           if [ "$(jq 'length' <<<"$include")" -eq 0 ]; then
-            echo "No conflicting bot PRs — done."
+            echo "No conflicting eligible PRs — done."
             exit 0
           fi
 
@@ -270,13 +293,16 @@ jobs:
             [ "$mergeable" != 'UNKNOWN' ] && break
             sleep 3
           done
-          eligible="$(jq -r '
+          maint="$(jq -cn --arg s "$MAINTAINER_LOGINS" '$s | split(" ") | map(select(length > 0))')"
+          eligible="$(jq -r --argjson maint "$maint" '
             (.state == "OPEN")
             and (.mergeable == "CONFLICTING")
             and (.isCrossRepository | not)
-            and (.author.is_bot == true)
-            and ((.body // "") | test("[Cc]loses #[0-9]+"))
-            and ([.labels[].name] | index("needs-human") | not)
+            and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-resolve") | not))
+            and (
+              ((.author.is_bot == true) and ((.body // "") | test("[Cc]loses #[0-9]+")))
+              or (.author.login as $l | ($maint | index($l)) != null)
+            )
           ' <<<"$info")"
           branch="$(jq -r '.headRefName' <<<"$info")"
           if [ "$eligible" = 'true' ]; then
@@ -364,7 +390,12 @@ jobs:
                truly overlap, integrate them. Edit the conflicted files
                directly (or use `git restore --ours`/`--theirs <path>` to take
                one whole side); `git checkout` is intentionally NOT available.
-               Then `git add` the resolved files and complete the merge commit.
+               For an ADDITIVE count manifest like tests/security-floor.json,
+               neither side's number is correct — set each conflicting per-file
+               entry to the TRUE count in the merged test file (re-count that
+               file's `SECURITY:` test declarations), because both sides added
+               tests. Then `git add` the resolved files and complete the merge
+               commit.
             3. A pgvector Postgres is available at DATABASE_URL, so run the FULL
                gate and make EVERY check green before pushing:
                npm run typecheck && npm run lint && npm run format:check &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,17 +69,19 @@ ownership rules:
   first, so agents never chase one-off flakes), then it escalates
   `needs-human`. It never opens or merges PRs.
 - The **conflict-resolver loop** (`pipeline-pr-conflict.yml`) may push a
-  `main`-merge to an existing build-worker PR branch when that PR is
+  `main`-merge to an existing PR branch when that PR is
   CONFLICTING. It is two-hop: a `discover` job (triggered on every push to
   `main`, on PR opened/ready-for-review — a PR can be *born* conflicted — and
-  on a 6-hourly backstop sweep) finds conflicting same-repo bot PRs and
+  on an **hourly** backstop sweep) finds conflicting same-repo PRs and
   self-dispatches the `resolve` job via `workflow_dispatch`, because
   claude-code-action won't run under a `push` event. The dispatch payload
   carries PR **numbers only**; resolve re-derives the branch from the API and
-  re-verifies the full eligibility contract (same-repo, bot-authored,
-  `Closes #`, no `needs-human`, still CONFLICTING) before checkout, so a
-  hand-crafted dispatch can't aim it at an arbitrary branch, and a superseded
-  duplicate run no-ops instead of mislabelling. One attempt per conflict: a
+  re-verifies the full eligibility contract before checkout: same-repo (never a
+  fork), not `needs-human`/`no-auto-resolve`, still CONFLICTING, and **either** a
+  bot PR with `Closes #` **or** a maintainer PR whose author is in the
+  `MAINTAINER_LOGINS` allowlist. So a hand-crafted dispatch can't aim it at an
+  arbitrary branch, and a superseded duplicate run no-ops instead of
+  mislabelling. One attempt per conflict: a
   failed resolution escalates `needs-human`, and the eligibility filter skips
   `needs-human` PRs so it never thrashes. Same push guardrails as autofix
   (read-only `gh`, exact `git push origin HEAD`). It never opens or merges

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -61,11 +61,15 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   ownership violation.
 - A second exception: the **conflict-resolver loop**
   (`pipeline-pr-conflict.yml`) may push a `main`-merge to an existing
-  build-worker PR branch that is CONFLICTING — same-repo bot PRs only,
-  one attempt per conflict, then it escalates `needs-human` (and skips
+  same-repo PR branch that is CONFLICTING — either a **bot** build-worker PR
+  (`Closes #`) or a **maintainer** PR whose author is in the workflow's
+  `MAINTAINER_LOGINS` allowlist (the repo owner's own human PRs, which `main`
+  churn would otherwise leave stuck with no responder). Fork / external-human
+  PRs are never eligible, and any PR can be pinned out with a `no-auto-resolve`
+  label. One attempt per conflict, then it escalates `needs-human` (and skips
   `needs-human` PRs thereafter). It is two-hop: `discover` (on push to `main`,
   on PR opened/ready-for-review — a PR whose build started before an unrelated
-  merge can be *born* conflicted — and on a 6-hourly sweep) self-dispatches
+  merge can be *born* conflicted — and on an **hourly** sweep) self-dispatches
   `resolve` via `workflow_dispatch`, since claude-code-action won't run under a
   `push` event. The dispatch payload carries PR numbers only; `resolve`
   re-derives the branch and re-verifies the whole eligibility contract from the

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -22,6 +22,7 @@ label "status:rejected" "E11D21" "Failed adversarial review"
 label "status:building" "5319E7" "Claimed by the build loop (WIP=1)"
 label "status:built"    "0052CC" "PR open, awaiting review/merge"
 label "needs-human"     "D93F0B" "Escalated: a human must decide"
+label "no-auto-resolve" "FBCA04" "Pin a PR out of the hourly conflict resolver (e.g. while editing it)"
 label "community-feedback" "0E8A16" "A real member/admin request; input for research proposals"
 
 # Theme areas (VISION.md) — one per proposal, so the memoryless research loop can


### PR DESCRIPTION
Makes the existing conflict resolver run **hourly** and cover **your own (maintainer) PRs**, not just the build worker's bot PRs.

## Why

`pipeline-pr-conflict.yml` already merges `main` into a conflicting PR, resolves it, runs the full gate, and pushes — with solid guardrails. But it was scoped to **bot build-worker PRs only** (`author.is_bot == true` + `Closes #`), and its scheduled sweep was **every 6h**. So when `main` churn flipped one of *your* human PRs to `CONFLICTING`, nothing auto-resolved it — GitHub won't run CI on a conflicting PR, so it sat blocked until a manual `main` merge. That happened repeatedly on #257 / #262 / #272 this week.

## Changes (all in `pipeline-pr-conflict.yml`)

- **Hourly**: `cron: '23 */6 * * *'` → `'23 * * * *'`. The `discover` job is seconds long and only spawns a resolve agent when a PR *actually* conflicts, so hourly is cheap.
- **Covers maintainer PRs**: eligibility (in **both** `discover` and the `resolve` precheck) is now `open + same-repo + not needs-human + not no-auto-resolve`, AND *either* a bot PR with a `Closes #` body *or* an author in a new `MAINTAINER_LOGINS` allowlist (default `swampratnz`). **Fork / external-human PRs stay excluded** (`isCrossRepository` guard is untouched).
- **`no-auto-resolve` opt-out label**: pin any PR out of the resolver (e.g. while you're mid-edit). Added to `setup-labels.sh` and created live.
- **Resolve-prompt hardening**: the one merge an LLM gets subtly wrong — an additive count manifest (`tests/security-floor.json`) — must be re-counted to the true merged value, not taken from one side. (That was the only conflict type that bit me manually.)

## Safety

The only relaxation is the deliberate maintainer opt-in. Everything else holds: the full gate (typecheck/lint/format/migrate/test/build/test:security against real Postgres) must pass **before** any push; push is the exact `git push origin HEAD` (no force, no other ref); it **never merges the PR** (only merges `main` *into* the branch); branch protection remains the hard stop; one attempt then `needs-human`. Note it still can't push `.github/workflows/*` (App token lacks the scope), so a conflict inside a workflow file will be commented and left for you.

## Validation

- Workflow YAML parses.
- The new jq eligibility predicate was tested against 7 sample PRs (bot+Closes ✓, maintainer ✓, other-human ✗, bot-without-Closes ✗, `no-auto-resolve` ✗, fork ✗, `needs-human` ✗) → correctly selects only the first two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)