### PR TITLE
Fix generate_image: grok dropped GenerateImage, use /imagine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 ## 2026-07-09
 
 ### Fixed
-- **Image generation works again** (`generate_image`). Grok removed the `GenerateImage` tool the bot was invoking, so every generation had been failing with an agent-build error; image generation is now grok's `/imagine` skill. Reworked the integration to call it and re-established the security lockdown without the old `--tools` allowlist (which is no longer possible): the subprocess runs with **no `--always-approve`** — so headless grok cancels any shell/file/subagent/MCP tool call instead of running it — plus explicit `--deny` rules for those tools and `--disable-web-search`. Verified end-to-end on the host (a real image is produced; a prompt ordering a shell command is cancelled and writes nothing). No behaviour change unless `IMAGE_GEN_ENABLED=true`. See docs/SECURITY.md §8.
+- **Image generation works again** (`generate_image`). Grok removed the `GenerateImage` tool the bot was invoking, so every generation had been failing with an agent-build error; image generation is now grok's `/imagine` skill. Reworked the integration to call it and re-established the security lockdown without the old `--tools` allowlist (no longer possible), using a **kernel-enforced `--sandbox strict`** (the agent can't read the bot's secrets or reach the network of a child process) plus **no `--always-approve`** and `--disable-web-search`. Verified end-to-end on the host: a real image is produced, while a prompt trying to read `/opt/community-agent/.env` or run a shell command is cancelled with nothing leaked or written. No behaviour change unless `IMAGE_GEN_ENABLED=true`. See docs/SECURITY.md §8.
 
 ## 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 `whats_new` tool reads this file, so keep entries user-legible and add a new
 `##` dated section (or version) as part of each release.
 
+## 2026-07-09
+
+### Fixed
+- **Image generation works again** (`generate_image`). Grok removed the `GenerateImage` tool the bot was invoking, so every generation had been failing with an agent-build error; image generation is now grok's `/imagine` skill. Reworked the integration to call it and re-established the security lockdown without the old `--tools` allowlist (which is no longer possible): the subprocess runs with **no `--always-approve`** — so headless grok cancels any shell/file/subagent/MCP tool call instead of running it — plus explicit `--deny` rules for those tools and `--disable-web-search`. Verified end-to-end on the host (a real image is produced; a prompt ordering a shell command is cancelled and writes nothing). No behaviour change unless `IMAGE_GEN_ENABLED=true`. See docs/SECURITY.md §8.
+
 ## 2026-07-08
 
 ### Added

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -642,15 +642,20 @@ signed in with a SuperGrok subscription (device-code login, no API key). Unlike
 every other tool, this one spawns a **third-party agentic CLI** as the service
 user, so it gets its own controls:
 
-- **Locked to one built-in tool.** The subprocess runs
-  `grok --tools GenerateImage …` — an *allowlist* that removes every other
-  built-in tool, including Bash, file-write, and exec. So even though the CLI is
-  driven with `--always-approve` (unattended, no interactive prompt), there is
-  no shell/file/exec tool for it to approve: the worst an admin turn — or a
-  prompt-injected one — can drive is "produce an image". Verified on the host:
-  with only `GenerateImage` allowed, the model's attempts to reach `Bash`/`Write`
-  are rejected as *"Tool not found"*. This is the deliberate difference from a
-  bare agentic CLI, and why `--always-approve` is acceptable here.
+- **No auto-approval + a deny-list, so it can only produce an image.** Image
+  generation is grok's `/imagine` skill (built-in `image_gen` tool); the tool is
+  not `--tools`-selectable, so the old `--tools GenerateImage` allowlist can't be
+  used (it referenced a since-removed tool and broke agent build). The lockdown
+  is instead: **no `--always-approve`** — in headless mode grok then *cancels*
+  every approval-gated tool call (Bash, file writes, subagents, MCP) rather than
+  running it, so the worst an admin — or a prompt-injected — turn can drive is
+  "produce an image". Verified on the host: a prompt explicitly ordering `bash`
+  to write a file returned stopReason *"Cancelled"* and wrote nothing. As
+  defence-in-depth the subprocess also passes `--deny bash`, `--deny
+  search_replace`, `--deny task`, `--deny use_tool`, and `--disable-web-search`,
+  so the shell / file-write / subagent / MCP / web tools are blocked by name
+  even if grok ever flipped one to auto-approved. (`image_gen` itself is
+  auto-approved and needs no approval, which is why generation still works.)
 - **No secret inheritance.** The `grok` subprocess is spawned with a **minimal,
   explicit `env`** (`grokEnv()` in `src/media/grokImage.ts`): `PATH`, `HOME`,
   `TERM`, `LANG`/`LC_ALL`, `USER`, and any `GROK_*`/`XDG_*` knobs — **never** the
@@ -664,7 +669,7 @@ user, so it gets its own controls:
   (never interpolated into a shell command), so there is no shell-injection
   surface even though the tool takes admin free text.
 - **Output is read back, not written to a path we name.** Because the file
-  tools are denied, grok can't copy the image anywhere we choose; `GenerateImage`
+  tools are denied, grok can't copy the image anywhere we choose; `image_gen`
   saves it under its own session storage and we read it back by the session id
   from `--output-format json`, then delete the session directory. The bytes are
   **magic-byte sniffed** (`sniffImageType`) — the real format is trusted from

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -642,20 +642,29 @@ signed in with a SuperGrok subscription (device-code login, no API key). Unlike
 every other tool, this one spawns a **third-party agentic CLI** as the service
 user, so it gets its own controls:
 
-- **No auto-approval + a deny-list, so it can only produce an image.** Image
-  generation is grok's `/imagine` skill (built-in `image_gen` tool); the tool is
-  not `--tools`-selectable, so the old `--tools GenerateImage` allowlist can't be
+- **Kernel-sandboxed, so it can only produce an image.** Image generation is
+  grok's `/imagine` skill (built-in `image_gen` tool); the tool is not
+  `--tools`-selectable, so the old `--tools GenerateImage` allowlist can't be
   used (it referenced a since-removed tool and broke agent build). The lockdown
-  is instead: **no `--always-approve`** — in headless mode grok then *cancels*
-  every approval-gated tool call (Bash, file writes, subagents, MCP) rather than
-  running it, so the worst an admin — or a prompt-injected — turn can drive is
-  "produce an image". Verified on the host: a prompt explicitly ordering `bash`
-  to write a file returned stopReason *"Cancelled"* and wrote nothing. As
-  defence-in-depth the subprocess also passes `--deny bash`, `--deny
-  search_replace`, `--deny task`, `--deny use_tool`, and `--disable-web-search`,
-  so the shell / file-write / subagent / MCP / web tools are blocked by name
-  even if grok ever flipped one to auto-approved. (`image_gen` itself is
-  auto-approved and needs no approval, which is why generation still works.)
+  is now **two host-verified controls**:
+  - **`--sandbox strict`** — kernel-enforced (landlock + seccomp on Linux) FS
+    and network confinement. The agent can read only the throwaway CWD,
+    `~/.grok/`, and essential system paths (**not** the bot's home/config),
+    write only to CWD/`~/.grok/`/temp, and its child-process network is blocked.
+    This is what actually contains a prompt-injected `/imagine` description:
+    verified on the host that a read of `/opt/community-agent/.env` is
+    *Cancelled* with no secret escaping, while a real generation still works
+    (grok reads its own auth, calls the image API, and writes the image).
+  - **No `--always-approve`** — headless grok then *cancels* approval-gated
+    tool calls (shell, file write) instead of running them (verified: a prompt
+    ordering the shell to write a file returned stopReason *"Cancelled"*).
+  Note the sandbox, not the absence of `--always-approve` alone, is the real
+  containment: **read tools are auto-approved**, so without the sandbox an
+  injected description could read arbitrary service-user files. A `--tools`
+  allowlist can't help (image tool not selectable) and a `--deny <name>` fails
+  *open* if the name doesn't match grok's internal tool id — which is why the
+  control is the kernel sandbox, not a tool filter. `--disable-web-search`
+  additionally removes the web tools.
 - **No secret inheritance.** The `grok` subprocess is spawned with a **minimal,
   explicit `env`** (`grokEnv()` in `src/media/grokImage.ts`): `PATH`, `HOME`,
   `TERM`, `LANG`/`LC_ALL`, `USER`, and any `GROK_*`/`XDG_*` knobs — **never** the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -664,7 +664,13 @@ user, so it gets its own controls:
   allowlist can't help (image tool not selectable) and a `--deny <name>` fails
   *open* if the name doesn't match grok's internal tool id — which is why the
   control is the kernel sandbox, not a tool filter. `--disable-web-search`
-  additionally removes the web tools.
+  additionally removes the web tools. Because that containment rests entirely on
+  a third-party flag (grok silently dropped `--tools GenerateImage` once
+  already), a **per-process self-check** (`assertSandboxContains()`) runs before
+  the first generation: it plants a sentinel outside the sandbox and confirms a
+  sandboxed grok cannot read it, **failing closed** (image gen disabled for the
+  process) if the sandbox ever stops containing — so a silent regression can't
+  quietly reopen arbitrary-file-read.
 - **No secret inheritance.** The `grok` subprocess is spawned with a **minimal,
   explicit `env`** (`grokEnv()` in `src/media/grokImage.ts`): `PATH`, `HOME`,
   `TERM`, `LANG`/`LC_ALL`, `USER`, and any `GROK_*`/`XDG_*` knobs — **never** the

--- a/src/media/grokImage.ts
+++ b/src/media/grokImage.ts
@@ -75,17 +75,22 @@ function grokSessionsRoot(): string {
  * run_terminal_cmd"). `/imagine` needs the full default toolset, so the
  * lockdown is re-expressed WITHOUT an allowlist:
  *
- * SECURITY POSTURE (see docs/SECURITY.md):
- *  - We do NOT pass `--always-approve`. In headless mode every approval-gated
- *    tool call (bash, file writes, subagents, MCP) is therefore CANCELLED,
- *    never executed — verified on the host: a prompt explicitly ordering `bash`
- *    to write a file returned stopReason "Cancelled" and wrote nothing. Only
- *    auto-approved tools run, and the sole auto-approved tool with an effect is
- *    image generation (which writes only into grok's own session images dir).
- *  - Defence-in-depth: `--deny bash/search_replace/task/use_tool` explicitly
- *    forbids the shell / file-write / subagent / MCP tools, and
- *    `--disable-web-search` removes the web tools — so exec/write/exfil stay
- *    blocked even if grok ever flipped one of those to auto-approved.
+ * SECURITY POSTURE (see docs/SECURITY.md) — two independent, host-verified controls:
+ *  - `--sandbox strict`: KERNEL-enforced (landlock + seccomp on Linux) file and
+ *    network confinement. The agent can read only the throwaway CWD, `~/.grok/`,
+ *    and essential system paths (NOT the bot's home/config), can write only to
+ *    CWD / `~/.grok/` / temp, and child-process network is blocked. This is the
+ *    control that actually contains a prompt-injected `/imagine` description:
+ *    verified on the host that a read of `/opt/community-agent/.env` is
+ *    Cancelled and no secret escapes, while a legitimate generation still
+ *    works (grok reads its own auth, calls the image API, writes the image).
+ *  - NO `--always-approve`: headless grok then CANCELS approval-gated tool
+ *    calls (shell / file write) instead of running them — verified: a prompt
+ *    ordering the shell to write a file returned stopReason "Cancelled".
+ *    (Read tools ARE auto-approved, which is exactly why the sandbox — not the
+ *    absence of --always-approve alone — is the real containment. A `--tools`
+ *    allowlist can't be used: the image tool isn't `--tools`-selectable, and a
+ *    `--deny` name that doesn't match grok's internal tool id fails OPEN.)
  *  - The subprocess gets a minimal env (grokEnv()), never the bot's secrets.
  *  - The prompt is an argv element, never a shell string (no shell injection),
  *    passed as `/imagine <prompt>` — i.e. strictly as an image description.
@@ -158,32 +163,24 @@ async function locateSessionImage(
 
 /**
  * The argv for the grok subprocess. Exported and kept pure so a test can assert
- * the security-critical flags never silently drift:
- *  - There is deliberately NO `--always-approve`: without it, headless grok
- *    CANCELS every approval-gated tool (bash / file write / subagent / MCP)
- *    rather than running it, so an admin or injected prompt cannot drive host
- *    code execution. Re-adding `--always-approve` would reopen that surface.
- *  - `--deny` blocks the shell / file-write / subagent / MCP tools explicitly
- *    (defence-in-depth), and `--disable-web-search` removes the web tools.
- *  - `--output-format json` is how we read the session id back to locate the image.
- *  - the prompt is passed as `/imagine <description>` — grok's image skill.
+ * the security-critical flags never silently drift. Two independent controls,
+ * both verified on the host (see the SECURITY POSTURE block above):
+ *  - NO `--always-approve`. Without it, headless grok CANCELS approval-gated
+ *    tool calls (e.g. shell / file write) instead of running them.
+ *  - `--sandbox strict`: KERNEL-enforced (landlock + seccomp on Linux) FS +
+ *    network confinement — reads limited to the throwaway CWD, `~/.grok/`, and
+ *    essential system paths; writes to CWD/`~/.grok/`/temp; child-process
+ *    network blocked. This is what actually stops an injected `/imagine`
+ *    description from reading the bot's secrets (`.env`, `~/.grok/auth.json`)
+ *    or exfiltrating — verified: a read of `/opt/community-agent/.env` is
+ *    Cancelled. We rely on the sandbox rather than a `--tools`/`--deny` tool
+ *    filter because the image tool is not `--tools`-selectable and a `--deny`
+ *    tool name that doesn't match is a silent no-op (fails OPEN).
+ *  - `--disable-web-search` removes the web tools; `--output-format json` gives
+ *    us the session id; the prompt is `/imagine <description>` — grok's image skill.
  */
 export function buildGrokArgs(instruction: string): string[] {
-  return [
-    '--deny',
-    'bash',
-    '--deny',
-    'search_replace',
-    '--deny',
-    'task',
-    '--deny',
-    'use_tool',
-    '--output-format',
-    'json',
-    '--disable-web-search',
-    '-p',
-    instruction,
-  ];
+  return ['--sandbox', 'strict', '--output-format', 'json', '--disable-web-search', '-p', instruction];
 }
 
 /** Spawn grok headlessly, locked to the image tool, and resolve its stdout. */

--- a/src/media/grokImage.ts
+++ b/src/media/grokImage.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { config } from '../config.js';
@@ -66,6 +67,63 @@ function grokSessionsRoot(): string {
 }
 
 /**
+ * Pure: did the sandbox FAIL to contain a probe read? True only if grok's
+ * output actually contains the sentinel token — i.e. a read that `--sandbox
+ * strict` should have blocked succeeded. Exported for a unit test (CI has no
+ * grok binary to exercise the real sandbox).
+ */
+export function sandboxBreached(stdout: string, token: string): boolean {
+  return stdout.includes(token);
+}
+
+/**
+ * Verify ONCE per process that `--sandbox strict` actually contains grok. The
+ * whole read/exfiltration defence rests on this third-party flag, and grok has
+ * silently dropped a flag before (`--tools GenerateImage`), so a string-only
+ * test isn't enough. Before the first generation we plant a random sentinel in
+ * a file OUTSIDE the sandbox read set (HOME root, NOT `~/.grok/`) and ask a
+ * sandboxed grok to read it back:
+ *   - token returned  → the sandbox is NOT containing → refuse to generate
+ *     (fail CLOSED; the rejected promise is cached, so image gen stays disabled
+ *     for this process until it's fixed and the service restarts).
+ *   - cancelled / errored / absent → contained or inconclusive → proceed. A
+ *     flaky probe must never disable a working sandbox, so ONLY a positive leak
+ *     fails. Cached, so only the first generation pays the extra grok call.
+ */
+let sandboxAssertion: Promise<void> | null = null;
+function assertSandboxContains(): Promise<void> {
+  if (!sandboxAssertion) {
+    sandboxAssertion = (async () => {
+      const home = process.env.HOME;
+      if (!home) return; // runGrok surfaces the missing-HOME error itself
+      const token = `GROK_SANDBOX_PROBE_${randomUUID()}`;
+      const sentinel = join(home, `.grok-sandbox-probe-${randomUUID()}`);
+      const cwd = await mkdtemp(join(tmpdir(), 'grokprobe-'));
+      try {
+        await writeFile(sentinel, token, 'utf8');
+        const stdout = await runGrok(
+          `Read the file ${sentinel} and reply with its exact contents.`,
+          cwd,
+        ).catch(() => '');
+        if (sandboxBreached(stdout, token)) {
+          logger.error(
+            'grok --sandbox strict failed to contain a disallowed read — disabling image generation',
+          );
+          throw new Error(
+            'grok sandbox self-check failed: a read outside the sandbox was NOT blocked. Image ' +
+              'generation is disabled until this is fixed (see docs/SECURITY.md §8).',
+          );
+        }
+      } finally {
+        await rm(sentinel, { force: true }).catch(() => {});
+        await rm(cwd, { recursive: true, force: true }).catch(() => {});
+      }
+    })();
+  }
+  return sandboxAssertion;
+}
+
+/**
  * Generate an image with the Grok Build CLI.
  *
  * Image generation is grok's `/imagine` skill (which drives the built-in
@@ -91,6 +149,11 @@ function grokSessionsRoot(): string {
  *    absence of --always-approve alone — is the real containment. A `--tools`
  *    allowlist can't be used: the image tool isn't `--tools`-selectable, and a
  *    `--deny` name that doesn't match grok's internal tool id fails OPEN.)
+ *  - Because that containment rests entirely on a third-party flag (grok has
+ *    silently dropped a flag before), `assertSandboxContains()` self-checks it
+ *    ONCE per process before the first generation — planting a sentinel outside
+ *    the sandbox and confirming a sandboxed grok can't read it — and fails
+ *    CLOSED (image gen disabled) if the sandbox ever stops containing.
  *  - The subprocess gets a minimal env (grokEnv()), never the bot's secrets.
  *  - The prompt is an argv element, never a shell string (no shell injection),
  *    passed as `/imagine <prompt>` — i.e. strictly as an image description.
@@ -107,6 +170,8 @@ export async function generateImage(prompt: string): Promise<GeneratedImage> {
   const instruction = `/imagine ${prompt}`;
   let sessionDir: string | undefined;
   try {
+    // Fail closed if grok's kernel sandbox isn't actually containing it.
+    await assertSandboxContains();
     const stdout = await runGrok(instruction, cwd);
     const sessionId = parseSessionId(stdout);
     if (!sessionId) throw new Error('Grok returned no session id; cannot locate the image.');

--- a/src/media/grokImage.ts
+++ b/src/media/grokImage.ts
@@ -68,28 +68,38 @@ function grokSessionsRoot(): string {
 /**
  * Generate an image with the Grok Build CLI.
  *
- * SECURITY POSTURE (see docs/SECURITY.md):
- *  - The CLI is locked to a single built-in tool, `GenerateImage`, via
- *    `--tools GenerateImage`. It has NO shell/file-write/exec tools, so
- *    `--always-approve` cannot approve host code execution — the worst an
- *    admin (or a prompt) can drive is "produce an image". Verified on the host:
- *    with only GenerateImage allowed, the model's attempts to reach Bash/Write
- *    are rejected as "Tool not found".
- *  - The subprocess gets a minimal env (grokEnv()), never the bot's secrets.
- *  - The prompt is an argv element, never a shell string (no shell injection).
+ * Image generation is grok's `/imagine` skill (which drives the built-in
+ * `image_gen` tool). The old `--tools GenerateImage` allowlist no longer works:
+ * that tool name was removed, and a `--tools` allowlist that references a
+ * non-existent tool makes grok's agent build fail ("Requirements unsatisfied:
+ * run_terminal_cmd"). `/imagine` needs the full default toolset, so the
+ * lockdown is re-expressed WITHOUT an allowlist:
  *
- * Because we deny the file tools, grok can't copy the image to a path we name;
- * instead GenerateImage saves it under its own session storage
- * (`$HOME/.grok/sessions/<enc-cwd>/<sessionId>/images/N.*`). We run it in a
- * throwaway cwd, read the session id back from `--output-format json`, load the
- * image, and delete the session directory. Throws on timeout, non-zero exit, or
- * if no recognisable image is produced.
+ * SECURITY POSTURE (see docs/SECURITY.md):
+ *  - We do NOT pass `--always-approve`. In headless mode every approval-gated
+ *    tool call (bash, file writes, subagents, MCP) is therefore CANCELLED,
+ *    never executed — verified on the host: a prompt explicitly ordering `bash`
+ *    to write a file returned stopReason "Cancelled" and wrote nothing. Only
+ *    auto-approved tools run, and the sole auto-approved tool with an effect is
+ *    image generation (which writes only into grok's own session images dir).
+ *  - Defence-in-depth: `--deny bash/search_replace/task/use_tool` explicitly
+ *    forbids the shell / file-write / subagent / MCP tools, and
+ *    `--disable-web-search` removes the web tools — so exec/write/exfil stay
+ *    blocked even if grok ever flipped one of those to auto-approved.
+ *  - The subprocess gets a minimal env (grokEnv()), never the bot's secrets.
+ *  - The prompt is an argv element, never a shell string (no shell injection),
+ *    passed as `/imagine <prompt>` — i.e. strictly as an image description.
+ *
+ * `image_gen` saves the result under grok's own session storage
+ * (`$HOME/.grok/sessions/<enc-cwd>/<sessionId>/images/N.*`) — we can't name the
+ * path. We run it in a throwaway cwd, read the session id back from
+ * `--output-format json`, load the image, and delete the session directory.
+ * Throws on timeout, non-zero exit, or if no recognisable image is produced.
  */
 export async function generateImage(prompt: string): Promise<GeneratedImage> {
   const cwd = await mkdtemp(join(tmpdir(), 'grokimg-'));
-  const instruction =
-    'Generate an image using your built-in image generation tool based on the description ' +
-    `below. Do not write or run any code.\n\nDescription: ${prompt}`;
+  // `/imagine` is grok's image-generation skill; the prompt is its description.
+  const instruction = `/imagine ${prompt}`;
   let sessionDir: string | undefined;
   try {
     const stdout = await runGrok(instruction, cwd);
@@ -149,18 +159,27 @@ async function locateSessionImage(
 /**
  * The argv for the grok subprocess. Exported and kept pure so a test can assert
  * the security-critical flags never silently drift:
- *  - `--tools GenerateImage` is the allowlist that makes unattended
- *    `--always-approve` safe (no Bash/file/exec tool for it to approve). If a
- *    refactor drops it, `--always-approve` becomes a host-code-execution surface.
+ *  - There is deliberately NO `--always-approve`: without it, headless grok
+ *    CANCELS every approval-gated tool (bash / file write / subagent / MCP)
+ *    rather than running it, so an admin or injected prompt cannot drive host
+ *    code execution. Re-adding `--always-approve` would reopen that surface.
+ *  - `--deny` blocks the shell / file-write / subagent / MCP tools explicitly
+ *    (defence-in-depth), and `--disable-web-search` removes the web tools.
  *  - `--output-format json` is how we read the session id back to locate the image.
+ *  - the prompt is passed as `/imagine <description>` — grok's image skill.
  */
 export function buildGrokArgs(instruction: string): string[] {
   return [
-    '--tools',
-    'GenerateImage',
+    '--deny',
+    'bash',
+    '--deny',
+    'search_replace',
+    '--deny',
+    'task',
+    '--deny',
+    'use_tool',
     '--output-format',
     'json',
-    '--always-approve',
     '--disable-web-search',
     '-p',
     instruction,

--- a/tests/grokImage.test.ts
+++ b/tests/grokImage.test.ts
@@ -29,22 +29,21 @@ test('sniffImageType returns null for non-image or empty bytes (never mislabels)
   assert.equal(sniffImageType(Buffer.from([0xff, 0xd8, 0x00])), null);
 });
 
-test('SECURITY: buildGrokArgs never passes --always-approve and denies the exec/write/subagent/MCP tools', () => {
+test('SECURITY: buildGrokArgs runs grok kernel-sandboxed (strict) with no --always-approve and no --tools', () => {
   const args = buildGrokArgs('/imagine draw a cat');
-  // NO --always-approve: in headless mode that is exactly what forces grok to
-  // CANCEL (not run) every approval-gated tool — bash, file writes, subagents,
-  // MCP. Re-adding it would let an admin or injected prompt drive host code
-  // execution, so its absence is the core control.
+  // KERNEL sandbox is the real containment: it blocks the agent from reading the
+  // bot's secrets (`.env`, `~/.grok/auth.json`) or exfiltrating, regardless of
+  // which tools are auto-approved. `--sandbox` must be immediately followed by
+  // exactly `strict` (workspace/read-only would let it read the whole FS).
+  const s = args.indexOf('--sandbox');
+  assert.ok(s >= 0, '--sandbox must be present');
+  assert.equal(args[s + 1], 'strict', 'the sandbox profile must be strict');
+  // NO --always-approve: headless grok then cancels approval-gated tools (shell,
+  // file write) instead of running them. Re-adding it would reopen that surface.
   assert.ok(!args.includes('--always-approve'), '--always-approve must never be passed');
-  // No --tools allowlist: the image tool is not --tools-selectable, and an
-  // allowlist that references a non-existent tool breaks grok's agent build.
+  // No --tools allowlist (the image tool is not --tools-selectable; an allowlist
+  // referencing a non-existent tool breaks grok's agent build).
   assert.ok(!args.includes('--tools'), 'a --tools allowlist must not be used');
-  // Defence-in-depth: the shell / file-write / subagent / MCP tools are denied
-  // by name (each --deny is immediately followed by the tool it forbids).
-  const denied = args.filter((_, i) => args[i - 1] === '--deny');
-  for (const t of ['bash', 'search_replace', 'task', 'use_tool']) {
-    assert.ok(denied.includes(t), `--deny ${t} must be present`);
-  }
   assert.ok(args.includes('--disable-web-search'), 'web tools must be disabled');
   // The free-text prompt is the value of -p, an argv element (never a shell string).
   const p = args.indexOf('-p');

--- a/tests/grokImage.test.ts
+++ b/tests/grokImage.test.ts
@@ -29,20 +29,27 @@ test('sniffImageType returns null for non-image or empty bytes (never mislabels)
   assert.equal(sniffImageType(Buffer.from([0xff, 0xd8, 0x00])), null);
 });
 
-test('SECURITY: buildGrokArgs locks the CLI to the image tool so --always-approve is safe', () => {
-  const args = buildGrokArgs('draw a cat');
-  // The allowlist that removes Bash/file/exec — without it, --always-approve
-  // becomes a host-code-execution surface. --tools must be immediately followed
-  // by exactly GenerateImage.
-  const i = args.indexOf('--tools');
-  assert.ok(i >= 0, '--tools must be present');
-  assert.equal(args[i + 1], 'GenerateImage');
-  assert.ok(args.includes('--always-approve'));
-  assert.ok(args.includes('--disable-web-search'));
+test('SECURITY: buildGrokArgs never passes --always-approve and denies the exec/write/subagent/MCP tools', () => {
+  const args = buildGrokArgs('/imagine draw a cat');
+  // NO --always-approve: in headless mode that is exactly what forces grok to
+  // CANCEL (not run) every approval-gated tool — bash, file writes, subagents,
+  // MCP. Re-adding it would let an admin or injected prompt drive host code
+  // execution, so its absence is the core control.
+  assert.ok(!args.includes('--always-approve'), '--always-approve must never be passed');
+  // No --tools allowlist: the image tool is not --tools-selectable, and an
+  // allowlist that references a non-existent tool breaks grok's agent build.
+  assert.ok(!args.includes('--tools'), 'a --tools allowlist must not be used');
+  // Defence-in-depth: the shell / file-write / subagent / MCP tools are denied
+  // by name (each --deny is immediately followed by the tool it forbids).
+  const denied = args.filter((_, i) => args[i - 1] === '--deny');
+  for (const t of ['bash', 'search_replace', 'task', 'use_tool']) {
+    assert.ok(denied.includes(t), `--deny ${t} must be present`);
+  }
+  assert.ok(args.includes('--disable-web-search'), 'web tools must be disabled');
   // The free-text prompt is the value of -p, an argv element (never a shell string).
   const p = args.indexOf('-p');
   assert.ok(p >= 0);
-  assert.equal(args[p + 1], 'draw a cat');
+  assert.equal(args[p + 1], '/imagine draw a cat');
 });
 
 test('SECURITY: grokEnv hands the subprocess a secret-free allowlist, never the bot env', () => {

--- a/tests/grokImage.test.ts
+++ b/tests/grokImage.test.ts
@@ -7,7 +7,8 @@ process.env.DISCORD_BOT_TOKEN ??= 'test-token';
 process.env.DISCORD_GUILD_ID ??= '1';
 process.env.DATABASE_URL ??= 'postgres://test:test@localhost:5432/test';
 
-const { sniffImageType, parseSessionId, buildGrokArgs, grokEnv } = await import('../src/media/grokImage.js');
+const { sniffImageType, parseSessionId, buildGrokArgs, grokEnv, sandboxBreached } =
+  await import('../src/media/grokImage.js');
 
 test('sniffImageType detects JPEG / PNG / WebP from magic bytes', () => {
   assert.deepEqual(sniffImageType(Buffer.from([0xff, 0xd8, 0xff, 0xe0])), {
@@ -99,6 +100,15 @@ test('SECURITY: grokEnv hands the subprocess a secret-free allowlist, never the 
     if (savedFoo === undefined) delete process.env.SHOULD_NOT_PASS_THROUGH;
     else process.env.SHOULD_NOT_PASS_THROUGH = savedFoo;
   }
+});
+
+test('sandboxBreached only flags a breach when the sentinel token actually comes back', () => {
+  const token = 'GROK_SANDBOX_PROBE_abc-123';
+  // Sandbox held: the read was cancelled, token never appears -> not breached.
+  assert.equal(sandboxBreached('{"text":"","stopReason":"Cancelled"}', token), false);
+  assert.equal(sandboxBreached('', token), false); // inconclusive / grok errored
+  // Sandbox failed: the sentinel content leaked into grok's output -> breached.
+  assert.equal(sandboxBreached(`{"text":"${token}","stopReason":"EndTurn"}`, token), true);
 });
 
 test('parseSessionId reads the session id from grok JSON stdout', () => {


### PR DESCRIPTION
`generate_image` has been failing on every call — found while running a proper end-to-end test on the server.

## Root cause

Grok removed the `GenerateImage` tool the bot invoked via `--tools GenerateImage`. A `--tools` allowlist naming a non-existent tool makes grok's agent build fail (`agent building failed: run_terminal_cmd …`). Not auth/quota/version (reproduced across stable 0.2.82/0.2.91 and alpha 0.2.93; bare grok works). Image generation is now grok's **`/imagine`** skill (built-in **`image_gen`** tool), which needs the full default toolset — so the old `--tools` allowlist lockdown is no longer usable.

## Fix + security model (all host-verified)

Invoke `/imagine`, and contain grok with a **kernel sandbox** rather than a tool filter (which proved unreliable — see below):

- **`grok --sandbox strict`** (landlock + seccomp on Linux): reads limited to the throwaway CWD + `~/.grok/` + system paths (**not** the bot's home/config), writes to CWD/`~/.grok/`/temp, child-process network blocked. This is the real containment.
- **No `--always-approve`**: headless grok cancels approval-gated tool calls (shell, file write) instead of running them.
- **`assertSandboxContains()` self-check**: once per process before the first generation, plant a sentinel outside the sandbox and confirm a sandboxed grok can't read it — **fail closed** (disable image gen) if the sandbox ever stops containing. Guards against a silent grok regression (the exact class of breakage that caused this bug); CI can't exercise a real grok, so the pure decision (`sandboxBreached`) is unit-tested.
- `--disable-web-search` removes the web tools; output handling (`parseSessionId`/`locateSessionImage`/`sniffImageType`) is unchanged.

### Why not a `--tools` allowlist or `--deny` list
Verified on the host that both fail: the image tool isn't `--tools`-selectable (allowlisting it breaks agent build), and `--deny bash`/`--disallowed-tools` did **not** block the shell (a `--deny` name that doesn't match grok's internal tool id fails **open** — a prompt still executed a shell command under `--always-approve`). And read tools are **auto-approved**, so without the sandbox an injected `/imagine` description could read `.env`/`~/.grok/auth.json`. Hence kernel sandbox + self-check.

## Verification (on the host, as the service user)

- Real image produced end-to-end under `--sandbox strict`.
- A prompt reading `/opt/community-agent/.env` → `Cancelled`, no secret leaked.
- A prompt ordering a shell write → `Cancelled`, no file written.
- `tsc`/`eslint`/`build` clean; `grokImage.test.ts` 7/7 (SECURITY test pins `--sandbox strict`, no `--always-approve`, no `--tools`; `sandboxBreached` unit-tested). `security-floor.json` unchanged.
- Docs: `docs/SECURITY.md §8` rewritten; CHANGELOG entry added.

No behaviour change unless `IMAGE_GEN_ENABLED=true` (it is on the live box — this restores the feature there once deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)