### PR TITLE
De-flake the repeat-question ordering test (deterministic in-flight signal)

### DIFF
--- a/tests/repeatQuestionShortcutRouter.test.ts
+++ b/tests/repeatQuestionShortcutRouter.test.ts
@@ -371,13 +371,24 @@ test('ordering: a repeat-question shortcut reply is enqueued behind an in-flight
   const secondTurn = new Promise<AgentReply>((resolve) => {
     resolveSecond = resolve;
   });
+  // Resolved the instant the SECOND turn's handler is entered — a deterministic
+  // "this turn now holds the conversation's enqueue chain" signal (its `enqueue`
+  // registered before the task ran), so the repeat fired next is guaranteed to
+  // queue BEHIND it. Previously the test gated on a typing-indicator proxy plus
+  // a fixed `sleep`, which raced on loaded CI runners and flaked the ordering
+  // assertion (the #304/#314 build failures).
+  let secondEntered!: () => void;
+  const secondEnteredP = new Promise<void>((resolve) => {
+    secondEntered = resolve;
+  });
   let calls = 0;
   const router = new Router(async () => {
     calls++;
     if (calls === 1) return { text: `${RUN} first answer`, ok: true };
+    secondEntered();
     return secondTurn;
   }, 20);
-  const { adapter, sent, typingCalls, trigger } = makeAdapter();
+  const { adapter, sent, trigger } = makeAdapter();
   router.register(adapter);
 
   // Prime the cache with a first successful turn.
@@ -386,12 +397,9 @@ test('ordering: a repeat-question shortcut reply is enqueued behind an in-flight
 
   // Fire a second, DIFFERENT question that hangs (in flight)...
   const secondDone = trigger(makeMessage({ text: `${RUN} different slow question`, conversationId }));
-  const deadline = Date.now() + 3000;
-  while (typingCalls.length < 1 && Date.now() < deadline) await sleep(5);
-  assert.ok(
-    typingCalls.length >= 1,
-    'the second real turn must already be in flight before the repeat fires',
-  );
+  // Deterministically wait until that turn is executing and holds the enqueue
+  // chain before firing the repeat — no wall-clock guess.
+  await secondEnteredP;
 
   // ...then, without waiting, resend the FIRST (now-cached) text.
   const repeatDone = trigger(makeMessage({ text: cachedText, conversationId }));


### PR DESCRIPTION
## The problem

The `ordering: a repeat-question shortcut reply … never overtaking it` test has been **flaking on CI and blocking unrelated PRs** — it failed the `build` job on #304 (twice) and #314 (twice), neither of which touches this file.

## Root cause

The test fired the repeat message after gating on a **typing-indicator proxy + a fixed `sleep(5)` poll**, then asserted a strict `sent[]` order. `sendMessage` pushes to `sent` synchronously, so send order follows the per-conversation `enqueue` chain exactly — the *only* nondeterminism was **when** the repeat was fired relative to the second turn acquiring that chain. On a loaded CI runner the wall-clock waits raced, the repeat occasionally didn't queue behind the in-flight turn, and the ordering assertion flaked.

## Fix (test-only)

Replace the proxy+sleep with a **deterministic signal**: the mock agent resolves `secondEnteredP` the instant the second turn's handler is entered (by which point its `enqueue` has already registered on the chain), and the test `await`s that before firing the repeat. The repeat is now *guaranteed* to queue behind the in-flight turn. No router behaviour change.

## Verification

`typecheck`, `eslint`, `prettier` clean; ordering test 15/15 locally; full file 9 tests / 0 fail (1 DB test skips without Postgres). The real proof is a green `build` here (the flake was CI-load-only and doesn't reproduce locally).

Once merged, #314 (and any future PR) stops being blocked by this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)