### PR TITLE
docs(changelog): date sections by Pacific/Auckland (NZ) day, not UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/). The agent's
 `whats_new` tool reads this file, so keep entries user-legible and add a new
 `##` dated section (or version) as part of each release.
 
+Dates are the **Pacific/Auckland (New Zealand)** calendar day, not UTC — this
+is a NZ community, and the CI that opens most PRs runs in UTC (a day behind NZ
+for anything after ~noon NZST/NZDT). Get today's date with
+`TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
+
 ## 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,11 @@ ownership rules:
 - Never commit secrets. `.env` is git-ignored; `whatsapp-auth/` and `src/auth/`
   are distinct — the latter is source and must stay tracked.
 - Do not put model identifiers in commits, PR bodies, or code.
+- `CHANGELOG.md` `##` section dates are the **Pacific/Auckland (NZ)** calendar
+  day, not UTC. The build worker runs in a UTC CI shell, so use
+  `TZ='Pacific/Auckland' date +%F` for "today" — a bare `date` is a day behind
+  NZ after ~noon local. Reuse the existing top section if it's already today's
+  NZ date rather than opening a duplicate.
 - Human-facing conventions (style, test expectations, commit/PR rules) are
   also written up in `docs/STANDARDS.md` — keep the two in sync if either
   changes.


### PR DESCRIPTION
## Summary

The CHANGELOG's `## YYYY-MM-DD` section dates are **hand-written** — the build worker adds them as part of each change (the only script, `check-changelog-coverage.mjs`, checks *coverage*, not dates). That worker runs in a **UTC** CI shell, so a bare `date` stamps the UTC calendar day, which is a day behind NZ for anything merged after ~noon NZST/NZDT (NZ is UTC+12/+13). For a NZ community, entries should carry the NZ day.

This documents the convention where the author actually sees it, so future entries use the right day:

- **`CHANGELOG.md` header** — states dates are the Pacific/Auckland day and to get "today" with `TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
- **`CLAUDE.md` Conventions** — same, plus a reminder to reuse today's NZ section instead of opening a duplicate one.

## Scope

Going-forward convention only. **Existing historical dates are left as-is** — re-dating them accurately would need each entry's merge timestamp, and sections that group several PRs merged across a UTC/NZ day boundary have no single unambiguous NZ date, so a bulk rewrite would be guesswork that could introduce errors rather than fix them. If you do want a retroactive pass, say so and I'll do it from the git history of `CHANGELOG.md` with the caveats called out per section.

## Security / privacy impact

None — documentation only (`CHANGELOG.md` + `CLAUDE.md`). No code, workflow, or runtime behaviour changes.

## How verified

`prettier --check` clean on both files; diff is +10 lines of prose across the two docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_