### PR TITLE
test: fix agentCoreFailureFallbacks* exit-7 crash (onnxruntime teardown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ is a NZ community, and the CI that opens most PRs runs in UTC (a day behind NZ
 for anything after ~noon NZST/NZDT). Get today's date with
 `TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
 
+## 2026-07-15
+
+### Fixed
+- **Intermittent `security-invariants` CI crash (exit 7)**: the four
+  `agentCoreFailureFallbacks*` test files drove the real `runAgentTurn`, whose
+  memory-recall step (`searchMemory` → `embed`) loads the `onnxruntime-node`
+  embedding model. In the no-Postgres `security-invariants` job, under
+  full-suite CPU load, that native inference session's teardown could race the
+  child test process's exit and abort it via Node's fatal-error path —
+  `tsx --test` exit 7, no failing assertion, output truncated mid-flush, and
+  (confirmed) uninterceptable by any JS `unhandledRejection`/`uncaughtException`
+  handler, even a `prependListener`'d one. The four files now mock
+  `searchMemory` so the embedding model never loads (they never assert on
+  recalled memory — `query()` is mocked, so prompt content is moot), removing
+  the fault entirely. They additionally stub `src/storage/db.js`'s `pool` with
+  a resolve-empty double (installed before the `repository.js` import so the
+  binding is fixed at module-evaluation time) so the remaining light DB reads
+  open no socket and emit no `ECONNREFUSED` noise. Test-only change; no
+  `SECURITY:` tests added or removed, so `tests/security-floor.json` is
+  unchanged.
+
 ## 2026-07-14
 
 ### Added

--- a/tests/agentCoreFailureFallbacksMi.test.ts
+++ b/tests/agentCoreFailureFallbacksMi.test.ts
@@ -59,10 +59,45 @@ async function core(t: { mock: { module: (specifier: string, opts: unknown) => v
   if (!corePromise) {
     const realSdk = await import('@anthropic-ai/claude-agent-sdk');
     t.mock.module('@anthropic-ai/claude-agent-sdk', { namedExports: { ...realSdk, query: mockQuery } });
+    // These are pure unit tests for runAgentTurn's failure-fallback
+    // substitution; they must do no real I/O. Two isolations, both required to
+    // keep the security-invariants CI job (which runs with NO Postgres) stable:
+    //
+    // 1. Mock searchMemory (below) so embed()/onnxruntime-node never loads. Its
+    //    native inference-session teardown, racing the child test process's
+    //    exit under full-suite CPU load, was the real cause of the intermittent
+    //    `tsx --test` exit-7 crash — a fatal-path abort with no failing
+    //    assertion, output truncated mid-flush, that NO JS unhandledRejection
+    //    / uncaughtException handler can intercept (confirmed: even a
+    //    prependListener'd handler never fired). Not loading the model at all
+    //    removes the fault entirely, and these tests never assert on recalled
+    //    memory anyway (query() is mocked, so the prompt content is moot).
+    // 2. Stub db.js's pool (resolve-empty) so the remaining light DB reads
+    //    (getCodeAnswersPolicy, getClaudeSession, setClaudeSessionId, ...) open
+    //    no socket: this file forces a dummy DATABASE_URL to satisfy config.ts's
+    //    import-time validation, which would otherwise make repository.ts create
+    //    a real pg.Pool. Installed BEFORE the realRepo import below so
+    //    repository.ts binds this stub `pool` at module-evaluation time; it must
+    //    RESOLVE (never throw) so no rejection can ever surface from it.
+    const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+    t.mock.module('../src/storage/db.js', {
+      namedExports: {
+        pool: {
+          query: async () => emptyResult,
+          connect: async () => ({ query: async () => emptyResult, release: () => {} }),
+          on: () => {},
+          end: async () => {},
+        },
+        healthcheck: async () => {},
+        closeDb: async () => {},
+      },
+    });
     const realRepo = await import('../src/storage/repository.js');
     t.mock.module('../src/storage/repository.js', {
       namedExports: {
         ...realRepo,
+        // Never load embed()/onnxruntime (see the isolation note above).
+        searchMemory: async () => [],
         getLanguagePreference: async () => {
           if (langBehavior.mode === 'throw') throw new Error('language-preference lookup exploded');
           return langBehavior.value;

--- a/tests/agentCoreFailureFallbacksMiAlertEnabled.test.ts
+++ b/tests/agentCoreFailureFallbacksMiAlertEnabled.test.ts
@@ -41,9 +41,46 @@ async function core(t: { mock: { module: (specifier: string, opts: unknown) => v
   if (!corePromise) {
     const realSdk = await import('@anthropic-ai/claude-agent-sdk');
     t.mock.module('@anthropic-ai/claude-agent-sdk', { namedExports: { ...realSdk, query: mockQuery } });
+    // These are pure unit tests for runAgentTurn's failure-fallback
+    // substitution; they must do no real I/O. Two isolations, both required to
+    // keep the security-invariants CI job (which runs with NO Postgres) stable:
+    //
+    // 1. Mock searchMemory (below) so embed()/onnxruntime-node never loads. Its
+    //    native inference-session teardown, racing the child test process's
+    //    exit under full-suite CPU load, was the real cause of the intermittent
+    //    `tsx --test` exit-7 crash — a fatal-path abort with no failing
+    //    assertion, output truncated mid-flush, that NO JS unhandledRejection
+    //    / uncaughtException handler can intercept (confirmed: even a
+    //    prependListener'd handler never fired). Not loading the model at all
+    //    removes the fault entirely, and these tests never assert on recalled
+    //    memory anyway (query() is mocked, so the prompt content is moot).
+    // 2. Stub db.js's pool (resolve-empty) so the remaining light DB reads
+    //    (getCodeAnswersPolicy, getClaudeSession, setClaudeSessionId, ...) open
+    //    no socket: this file forces a dummy DATABASE_URL to satisfy config.ts's
+    //    import-time validation, which would otherwise make repository.ts create
+    //    a real pg.Pool. Installed BEFORE the realRepo import below so
+    //    repository.ts binds this stub `pool` at module-evaluation time; it must
+    //    RESOLVE (never throw) so no rejection can ever surface from it.
+    const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+    t.mock.module('../src/storage/db.js', {
+      namedExports: {
+        pool: {
+          query: async () => emptyResult,
+          connect: async () => ({ query: async () => emptyResult, release: () => {} }),
+          on: () => {},
+          end: async () => {},
+        },
+        healthcheck: async () => {},
+        closeDb: async () => {},
+      },
+    });
     const realRepo = await import('../src/storage/repository.js');
     t.mock.module('../src/storage/repository.js', {
-      namedExports: { ...realRepo, getLanguagePreference: async () => langBehavior },
+      namedExports: {
+        ...realRepo,
+        searchMemory: async () => [],
+        getLanguagePreference: async () => langBehavior,
+      },
     });
     corePromise = import('../src/agent/core.js');
   }

--- a/tests/agentCoreFailureFallbacksPlain.test.ts
+++ b/tests/agentCoreFailureFallbacksPlain.test.ts
@@ -61,10 +61,45 @@ async function core(t: { mock: { module: (specifier: string, opts: unknown) => v
   if (!corePromise) {
     const realSdk = await import('@anthropic-ai/claude-agent-sdk');
     t.mock.module('@anthropic-ai/claude-agent-sdk', { namedExports: { ...realSdk, query: mockQuery } });
+    // These are pure unit tests for runAgentTurn's failure-fallback
+    // substitution; they must do no real I/O. Two isolations, both required to
+    // keep the security-invariants CI job (which runs with NO Postgres) stable:
+    //
+    // 1. Mock searchMemory (below) so embed()/onnxruntime-node never loads. Its
+    //    native inference-session teardown, racing the child test process's
+    //    exit under full-suite CPU load, was the real cause of the intermittent
+    //    `tsx --test` exit-7 crash — a fatal-path abort with no failing
+    //    assertion, output truncated mid-flush, that NO JS unhandledRejection
+    //    / uncaughtException handler can intercept (confirmed: even a
+    //    prependListener'd handler never fired). Not loading the model at all
+    //    removes the fault entirely, and these tests never assert on recalled
+    //    memory anyway (query() is mocked, so the prompt content is moot).
+    // 2. Stub db.js's pool (resolve-empty) so the remaining light DB reads
+    //    (getCodeAnswersPolicy, getClaudeSession, setClaudeSessionId, ...) open
+    //    no socket: this file forces a dummy DATABASE_URL to satisfy config.ts's
+    //    import-time validation, which would otherwise make repository.ts create
+    //    a real pg.Pool. Installed BEFORE the realRepo import below so
+    //    repository.ts binds this stub `pool` at module-evaluation time; it must
+    //    RESOLVE (never throw) so no rejection can ever surface from it.
+    const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+    t.mock.module('../src/storage/db.js', {
+      namedExports: {
+        pool: {
+          query: async () => emptyResult,
+          connect: async () => ({ query: async () => emptyResult, release: () => {} }),
+          on: () => {},
+          end: async () => {},
+        },
+        healthcheck: async () => {},
+        closeDb: async () => {},
+      },
+    });
     const realRepo = await import('../src/storage/repository.js');
     t.mock.module('../src/storage/repository.js', {
       namedExports: {
         ...realRepo,
+        // Never load embed()/onnxruntime (see the isolation note above).
+        searchMemory: async () => [],
         getLanguagePreference: async () => {
           if (langBehavior.mode === 'throw') throw new Error('language-preference lookup exploded');
           return langBehavior.value;

--- a/tests/agentCoreFailureFallbacksPlainAlertEnabled.test.ts
+++ b/tests/agentCoreFailureFallbacksPlainAlertEnabled.test.ts
@@ -42,10 +42,45 @@ async function core(t: { mock: { module: (specifier: string, opts: unknown) => v
   if (!corePromise) {
     const realSdk = await import('@anthropic-ai/claude-agent-sdk');
     t.mock.module('@anthropic-ai/claude-agent-sdk', { namedExports: { ...realSdk, query: mockQuery } });
+    // These are pure unit tests for runAgentTurn's failure-fallback
+    // substitution; they must do no real I/O. Two isolations, both required to
+    // keep the security-invariants CI job (which runs with NO Postgres) stable:
+    //
+    // 1. Mock searchMemory (below) so embed()/onnxruntime-node never loads. Its
+    //    native inference-session teardown, racing the child test process's
+    //    exit under full-suite CPU load, was the real cause of the intermittent
+    //    `tsx --test` exit-7 crash — a fatal-path abort with no failing
+    //    assertion, output truncated mid-flush, that NO JS unhandledRejection
+    //    / uncaughtException handler can intercept (confirmed: even a
+    //    prependListener'd handler never fired). Not loading the model at all
+    //    removes the fault entirely, and these tests never assert on recalled
+    //    memory anyway (query() is mocked, so the prompt content is moot).
+    // 2. Stub db.js's pool (resolve-empty) so the remaining light DB reads
+    //    (getCodeAnswersPolicy, getClaudeSession, setClaudeSessionId, ...) open
+    //    no socket: this file forces a dummy DATABASE_URL to satisfy config.ts's
+    //    import-time validation, which would otherwise make repository.ts create
+    //    a real pg.Pool. Installed BEFORE the realRepo import below so
+    //    repository.ts binds this stub `pool` at module-evaluation time; it must
+    //    RESOLVE (never throw) so no rejection can ever surface from it.
+    const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+    t.mock.module('../src/storage/db.js', {
+      namedExports: {
+        pool: {
+          query: async () => emptyResult,
+          connect: async () => ({ query: async () => emptyResult, release: () => {} }),
+          on: () => {},
+          end: async () => {},
+        },
+        healthcheck: async () => {},
+        closeDb: async () => {},
+      },
+    });
     const realRepo = await import('../src/storage/repository.js');
     t.mock.module('../src/storage/repository.js', {
       namedExports: {
         ...realRepo,
+        // Never load embed()/onnxruntime (see the isolation note above).
+        searchMemory: async () => [],
         getLanguagePreference: async () => langBehavior,
         getResponseStyle: async () => styleBehavior,
       },


### PR DESCRIPTION
## Summary

Fixes the intermittent `security-invariants` CI crash (`tsx --test` exit code 7,
no failing assertion) that has sporadically blocked otherwise-green PRs.

**Root cause (corrected after on-CI diagnosis).** The four
`agentCoreFailureFallbacks*` test files drove the real `runAgentTurn`, whose
memory-recall step (`searchMemory` → `embed`) loads the `onnxruntime-node`
embedding model. In the no-Postgres `security-invariants` job, under full-suite
CPU load, that **native inference session's teardown could race the child test
process's exit and abort it via Node's fatal-error path**: exit 7, no failing
assertion, log output truncated mid-flush. Crucially it is **uninterceptable by
any JS `unhandledRejection`/`uncaughtException` handler** — I confirmed on CI
that even a `process.prependListener`'d handler (ahead of node:test's own) never
fired. That's why it read as a mysterious infra failure, was near-deterministic
on the contended CI runner, and did not reproduce across ~19 local full-gate
runs (the sandbox's different load never hit the teardown race).

An earlier revision of this PR assumed the cause was a fire-and-forget DB
`ECONNREFUSED` rejection and stubbed the pool. That removed the connection noise
but **not** the crash — the on-CI diagnostic rounds (since squashed out) proved
the fault survived with zero `ECONNREFUSED`, pointing to the native path above.

## The fix

- **Mock `searchMemory` in all four files** so the embedding model never loads —
  removing the native component entirely. These tests never assert on recalled
  memory (`query()` is mocked, so prompt content is moot), so this is behaviour-
  preserving for what they actually verify.
- **Also stub `src/storage/db.js`'s `pool`** with a resolve-empty double
  (installed before the `repository.js` import so `repository.ts` binds it at
  module-evaluation time), so the remaining light DB reads
  (`getCodeAnswersPolicy`, `getClaudeSession`, …) open no socket and emit no
  `ECONNREFUSED` noise. Resolve-empty (never throwing) so it can surface no
  rejection of its own.

## Security / privacy impact

None. Test-only change. No `SECURITY:`-prefixed tests were added or removed, so
`tests/security-floor.json` is unchanged (manifest total stays 647 across 87
files). No RBAC / tool-gating / outbound-filtering / secret-redaction /
SQL-scoping / confirm-flow code is touched. The `SECURITY:`-tagged fail-open
assertions in these files exercise the same substitution paths and are
unaffected by the mocks.

## How verified

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build`
  — all green.
- Against a dead DB port, the four files now load **no** embedding model
  (0 "Loading embedding model") and open **no** socket (0 `ECONNREFUSED`), and
  pass.
- `npm run test:security` runs clean across repeated runs (exit 0, 647/647)
  where the same gate previously crashed exit-7.