### PR TITLE
ci: fix the two failures blocking merges (Node-24 EPIPE exit-7 + community_info char cap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ for anything after ~noon NZST/NZDT). Get today's date with
 ## 2026-07-15
 
 ### Fixed
+- **`build` CI failure — `community_info` admin reply over its char cap**: the
+  admin capabilities text had grown 18 chars past its intentional 2800-char cap
+  (the `community_info: admin reply stays under a hard char cap` test, issue
+  #367), failing the `build` job deterministically on `main`. Trimmed two
+  non-load-bearing clarifiers (`" with reasons"`, `" (questions I couldn't
+  answer)"`) from `ADMIN_CAPABILITIES_TEXT` — neither is referenced by the
+  anti-drift coverage map, so every admin tool stays covered and the reply is
+  back under the cap. Honours the test's "keep it tight, don't grow into a wall
+  of text" discipline rather than bumping the cap.
 - **Intermittent `security-invariants` CI crash (`tsx --test` exit 7)**: the
   `security-invariants` gate runs the suite with **no** Postgres, so every
   `runAgentTurn`-driven test emits a burst of fail-open warn/error logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ is a NZ community, and the CI that opens most PRs runs in UTC (a day behind NZ
 for anything after ~noon NZST/NZDT). Get today's date with
 `TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
 
+## 2026-07-15
+
+### Fixed
+- **Intermittent `security-invariants` CI crash (`tsx --test` exit 7)**: the
+  `security-invariants` gate runs the suite with **no** Postgres, so every
+  `runAgentTurn`-driven test emits a burst of fail-open warn/error logs
+  (`ECONNREFUSED`, degraded-turn fallbacks, …). `pino` buffers those and flushes
+  to stdout asynchronously; under **Node 24** each test file runs in a child
+  process whose stdout is a pipe to the parent runner, and that trailing async
+  flush could land *after* the parent stopped reading — surfacing as
+  `write EPIPE`, an unhandled `'error'` on the stdout `Socket` that aborts the
+  child (exit 7, no failing assertion, output truncated mid-line, and
+  uninterceptable by any JS `uncaughtException`/`unhandledRejection` handler
+  because it is a stream-error abort, not a throw). It was deterministic on
+  Node 24 (reproduced 6/6 locally with a Node diagnostic report) but invisible
+  on Node 22. The `test:security` script now runs with `LOG_LEVEL=silent`
+  (override-able), so no test-run log output is buffered for a racy teardown
+  flush — fixing it for every affected file at once rather than per-file. Adds
+  `silent` as a valid `LOG_LEVEL` (a real `pino` level). The `build` job is
+  unaffected (it runs against a real Postgres, so log volume stays low and no
+  EPIPE occurs). Test/infra-only; no `SECURITY:` tests added or removed, so
+  `tests/security-floor.json` is unchanged.
+
 ## 2026-07-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "tsx --experimental-test-module-mocks --test tests/*.test.ts",
-    "test:security": "node scripts/check-security-test-count.mjs",
+    "test:security": "LOG_LEVEL=${LOG_LEVEL:-silent} node scripts/check-security-test-count.mjs",
     "test:security:fix": "node scripts/check-security-test-count.mjs --write",
     "changelog:check": "gh pr list --state merged --limit 150 --json number,title,mergedAt,body | node scripts/check-changelog-coverage.mjs",
     "migrate": "tsx src/storage/migrate.ts",

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -809,12 +809,12 @@ const MEMBER_CAPABILITIES_TEXT =
  */
 const ADMIN_CAPABILITIES_TEXT =
   'As an admin, you also have:\n' +
-  "- Moderate the community: warn, mute, kick, or remove a message, clear a member's warnings, archive a Discord thread that's gotten out of hand, review the moderation history log, pull one member's full warning history with reasons, or list everyone who's currently muted\n" +
+  "- Moderate the community: warn, mute, kick, or remove a message, clear a member's warnings, archive a Discord thread that's gotten out of hand, review the moderation history log, pull one member's full warning history, or list everyone who's currently muted\n" +
   "- Manage membership: add a new member, remove a member, link a member's cross-platform identity, or unlink a member's cross-platform identity\n" +
   '- Review flagged content reports and resolve each report, review suggestions members submit and resolve each suggestion, see how members rated my answers, and check which knowledge entries are rated poorly\n' +
   '- Post to the community: make an announcement, create a poll or end one poll early, open a Discord thread, or schedule/cancel an event\n' +
   '- Curate the knowledge base: save a new knowledge entry, browse knowledge entries, edit a knowledge entry, or delete a knowledge entry, and check for near-duplicate entries or conflicting entries\n' +
-  "- Review knowledge candidates surfaced from community digests, accept a candidate or decline a candidate, track knowledge gaps (questions I couldn't answer), recurring question clusters, and raw context digests\n" +
+  '- Review knowledge candidates surfaced from community digests, accept a candidate or decline a candidate, track knowledge gaps, recurring question clusters, and raw context digests\n' +
   '- See who is waiting for access, or who has joined or left the server\n' +
   "- Add a note about a member, review notes on a member, delete a note, or look up a member's history across conversations\n" +
   '- Set the community guidelines or the welcome message shown to new members\n' +

--- a/src/config.ts
+++ b/src/config.ts
@@ -642,7 +642,7 @@ const EnvSchema = z.object({
   // unauthenticated endpoint is NOT reachable off-box unless the operator
   // deliberately fronts it with a reverse proxy or sets 0.0.0.0 (issue #220).
   HEALTH_HOST: z.string().min(1).default('127.0.0.1'),
-  LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
+  LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'silent']).default('info'),
   LOG_PRETTY: z
     .string()
     .optional()


### PR DESCRIPTION
Fixes the two CI failures that block PRs from going green — including #506.

## 1. `security-invariants` exit-7 crash (Node 24 `write EPIPE`)

The `security-invariants` gate runs the suite with **no** Postgres, so every
`runAgentTurn`-driven test emits a burst of fail-open warn/error logs
(`ECONNREFUSED`, degraded-turn fallbacks). `pino` buffers those and flushes to
stdout **asynchronously**. Under **Node 24** (which CI uses) each test file runs
in a child process whose stdout is a **pipe** to the parent runner, and that
trailing async flush could land *after* the parent stopped reading — producing
`write EPIPE`, an unhandled `'error'` on the stdout `Socket` that aborts the
child (exit 7, no failing assertion, output truncated mid-line, uninterceptable
by any JS `uncaughtException`/`unhandledRejection`/`uncaughtExceptionMonitor`
handler because it's a stream-error abort, not a throw).

Root-caused via a Node diagnostic report (`--report-uncaught-exception`) after
reproducing under Node 24 locally: **deterministic 6/6 crashes on Node 24**,
invisible on Node 22 (which is why it wasn't reproducible until the runtime was
matched to CI).

**Fix:** run the `test:security` script with `LOG_LEVEL=silent` (override-able),
so no test-run log output is buffered for a racy teardown flush — fixing every
affected file at once. Adds `silent` as a valid `LOG_LEVEL` (a real `pino`
level). The plain `test` script (build job) is left unprefixed: it runs against
a real Postgres so log volume stays low and no EPIPE occurs, and prefixing it
would break `check-security-test-count.mjs`'s runner-flag derivation.

## 2. `build` failure — `community_info` admin reply over its char cap

Separately, the `build` job failed **deterministically** on the
`community_info: admin reply stays under a hard char cap` test (issue #367):
`ADMIN_CAPABILITIES_TEXT` had grown to 2818 chars, 18 over the intentional 2800
cap. Trimmed two non-load-bearing clarifiers (`" with reasons"`, `" (questions I
couldn't answer)"`) — neither referenced by the `ADMIN_CAPABILITY_COVERAGE`
anti-drift map, so all 44 admin tools stay covered and the reply is back under
the cap. Honours the test's "keep it tight" discipline rather than bumping the
cap.

## Security / privacy impact

None. Test/infra + admin-facing help-text only. No `SECURITY:`-prefixed tests
added or removed, so `tests/security-floor.json` is unchanged. No RBAC /
tool-gating / outbound-filtering / secret-redaction / SQL-scoping / confirm-flow
code touched. The member/guest `community_info` replies are untouched (only the
admin text was trimmed), so the tier-leak SECURITY test is unaffected. Adding
`silent` to `LOG_LEVEL` only widens an operator config option.

## How verified

- **EPIPE:** reproduced under Node 24 on clean `main` (gate crashes **6/6** with
  a `write EPIPE` diagnostic report); with the fix the gate is **clean across
  repeated runs (647/647)** under both Node 22 and Node 24.
- **community_info:** `tests/tools.test.ts` passes (cap test now under 2800; all
  coverage / anti-drift / tier-leak SECURITY tests green).
- `npm run typecheck`, `npm run lint`, `npm run format:check` all green.