### PR TITLE
Add serialized auto-merge loop for vetted build-worker PRs

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -154,6 +154,25 @@ jobs:
               echo "::endgroup::"; continue
             fi
 
+            # --- Governance / CI / config paths are ALWAYS human-merged --------
+            # A PR that changes CI or any workflow (including THIS loop's own
+            # gates), the check machinery (npm scripts, the security-gate script,
+            # lint/format/typecheck config), or the governance docs could weaken
+            # what "green"/"eligible" even means for auto-merge — and because
+            # `pull_request` CI runs the workflow version FROM THE PR BRANCH, a PR
+            # could neuter a check and still show that named check "passing".
+            # Auto-merging such a PR on an LLM `LGTM` would let the pipeline
+            # rewrite its own guardrails unattended. Route ANY PR touching these
+            # paths to a mandatory human merge, regardless of LGTM/green.
+            # (Deliberately NOT including tests/security-floor.json or CHANGELOG.md
+            # — those are per-PR DATA nearly every PR touches; excluding them
+            # would merge nothing. This list is the files that change the RULES.)
+            files="$(gh pr view "$n" --repo "$REPO" --json files --jq '.files[].path')"
+            if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/SECURITY\.md$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
+              echo "PR #$n: touches a governance/CI/config path (workflows, check machinery, or governance docs) — requires human merge, skip."
+              echo "::endgroup::"; continue
+            fi
+
             # Only NOW (structurally eligible) resolve the state GitHub computes
             # asynchronously: `mergeable` reads UNKNOWN until it settles, so poll
             # a bounded number of times, then defer to a later tick rather than

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -87,11 +87,16 @@ jobs:
       # review) posts ONE marker-guarded note explaining the likely cause,
       # rather than silently doing nothing every tick.
       BLOCKED_MARKER: '<!-- pipeline-automerge-blocked -->'
-      # Safety valve for rollout: set repository variable AUTOMERGE_DRY_RUN=true
-      # (Settings → Secrets and variables → Actions → Variables) to LOG the PR
-      # it would merge each run without merging, so the eligibility logic can be
-      # watched against real PRs first. Unset/anything-else = live merges.
-      DRY_RUN: ${{ vars.AUTOMERGE_DRY_RUN }}
+      # OPT-IN mode gate (repository variable AUTOMERGE_MODE — Settings → Secrets
+      # and variables → Actions → Variables). The default (unset) is INERT, so
+      # merging this workflow onto `main` never auto-merges anything until an
+      # operator has deliberately turned it on — no zero-observation live merge
+      # on the first tick. Three states:
+      #   unset / anything else → inert (does nothing)
+      #   dry-run               → evaluates + logs the PR it WOULD merge, no merge
+      #   live                  → actually merges
+      # Roll out by setting it to `dry-run`, watching a few ticks, then `live`.
+      MODE: ${{ vars.AUTOMERGE_MODE }}
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -101,6 +106,13 @@ jobs:
         if: env.HAS_TOKEN == 'true'
         run: |
           set -euo pipefail
+
+          # Opt-in gate: do nothing at all unless an operator has set the mode.
+          if [ "$MODE" != 'dry-run' ] && [ "$MODE" != 'live' ]; then
+            echo "AUTOMERGE_MODE is '${MODE:-<unset>}' — auto-merge is OFF (default). Set the AUTOMERGE_MODE repository variable to 'dry-run' or 'live' to enable."
+            exit 0
+          fi
+          echo "AUTOMERGE_MODE=$MODE"
 
           # Candidates: open, oldest-first. All eligibility is re-checked per PR
           # below from authoritative fields; this list is just the scan order.
@@ -116,18 +128,11 @@ jobs:
           for n in $candidates; do
             echo "::group::Evaluating PR #$n"
 
-            # `mergeable` is computed asynchronously by GitHub and reads UNKNOWN
-            # until it settles — poll a bounded number of times, then defer to a
-            # later tick rather than guessing (same policy as the conflict
-            # resolver's discover job).
-            info='{}'; mergeable='UNKNOWN'
-            for _ in $(seq 1 8); do
-              info="$(gh pr view "$n" --repo "$REPO" \
-                --json number,isDraft,isCrossRepository,mergeable,author,labels,body,headRefOid,statusCheckRollup)"
-              mergeable="$(jq -r '.mergeable' <<<"$info")"
-              [ "$mergeable" != 'UNKNOWN' ] && break
-              sleep 3
-            done
+            # CHEAP structural filter FIRST (a single view, no polling) so a
+            # draft / human / fork / stop-labelled / non-`Closes #` PR is skipped
+            # before spending any mergeable-poll time on it.
+            struct="$(gh pr view "$n" --repo "$REPO" \
+              --json isDraft,isCrossRepository,author,labels,body)"
 
             # --- Structural contract: build-worker PR, not pinned/escalated ----
             # Pin to the EXACT build-worker identity (`claude[bot]`, the App the
@@ -143,11 +148,26 @@ jobs:
               and (.author.login == "claude[bot]")
               and ((.body // "") | test("[Cc]loses #[0-9]+"))
               and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-merge") | not))
-            ' <<<"$info")"
+            ' <<<"$struct")"
             if [ "$eligible" != 'true' ]; then
               echo "PR #$n: not an eligible build-worker PR (draft/fork/not claude[bot]/no Closes #/stop-labelled) — skip."
               echo "::endgroup::"; continue
             fi
+
+            # Only NOW (structurally eligible) resolve the state GitHub computes
+            # asynchronously: `mergeable` reads UNKNOWN until it settles, so poll
+            # a bounded number of times, then defer to a later tick rather than
+            # guessing (same policy as the conflict resolver's discover job).
+            # This fetch also carries headRefOid + statusCheckRollup for the
+            # gates below.
+            info='{}'; mergeable='UNKNOWN'
+            for _ in $(seq 1 8); do
+              info="$(gh pr view "$n" --repo "$REPO" \
+                --json mergeable,headRefOid,statusCheckRollup)"
+              mergeable="$(jq -r '.mergeable' <<<"$info")"
+              [ "$mergeable" != 'UNKNOWN' ] && break
+              sleep 3
+            done
 
             # --- Mergeable (no conflict) ---------------------------------------
             if [ "$mergeable" != 'MERGEABLE' ]; then
@@ -218,8 +238,8 @@ jobs:
             fi
 
             # --- All gates passed ---------------------------------------------
-            if [ "$DRY_RUN" = 'true' ]; then
-              echo "PR #$n: DRY RUN — fully eligible; would merge (method: $MERGE_METHOD) but AUTOMERGE_DRY_RUN=true. No merge performed."
+            if [ "$MODE" != 'live' ]; then
+              echo "PR #$n: DRY RUN (AUTOMERGE_MODE=$MODE) — fully eligible; would merge (method: $MERGE_METHOD, head $head_sha). No merge performed."
               echo "::endgroup::"
               exit 0
             fi

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -116,9 +116,17 @@ jobs:
 
           # Candidates: open, oldest-first. All eligibility is re-checked per PR
           # below from authoritative fields; this list is just the scan order.
-          candidates="$(gh pr list --repo "$REPO" --state open --limit 50 \
-            --json number,createdAt \
-            | jq -r 'sort_by(.createdAt) | .[].number')"
+          # `--limit 100` (gh's per-page max) with a truncation warning: since we
+          # merge OLDEST-first and gh returns newest-first, a silent cap could
+          # hide exactly the oldest PRs we most want to act on. 100 is far above
+          # the pipeline's WIP caps, so truncation should never happen — but warn
+          # loudly rather than silently skip if it ever does.
+          LIST_CAP=100
+          raw="$(gh pr list --repo "$REPO" --state open --limit "$LIST_CAP" --json number,createdAt)"
+          if [ "$(jq 'length' <<<"$raw")" -ge "$LIST_CAP" ]; then
+            echo "::warning::Open-PR list hit the --limit $LIST_CAP cap; PRs beyond the newest $LIST_CAP are not evaluated this run (unexpected given WIP caps — investigate)."
+          fi
+          candidates="$(jq -r 'sort_by(.createdAt) | .[].number' <<<"$raw")"
 
           if [ -z "$candidates" ]; then
             echo "No open PRs — nothing to merge."
@@ -299,22 +307,30 @@ jobs:
               exit 0
             fi
 
-            # Merge refused. Distinguish a TRANSIENT head-moved race (a push
-            # landed between the gate snapshot and the merge — --match-head-commit
-            # failed closed exactly as intended) from a PERSISTENT block (branch
-            # protection). A moved head just defers to the next tick, silently;
-            # only a genuine block posts the explanatory note.
-            current_head="$(gh pr view "$n" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+            # Merge refused. Distinguish TRANSIENT races (defer silently, the
+            # next tick re-evaluates) from a PERSISTENT block (branch protection,
+            # post the explanatory note). Two transient shapes: the PR head moved
+            # (--match-head-commit failed closed), OR `main` advanced so the PR is
+            # no longer MERGEABLE (base conflict) — both are re-fetched here so the
+            # note isn't a misleading "branch protection" for a mere race.
+            after="$(gh pr view "$n" --repo "$REPO" --json headRefOid,mergeable)"
+            current_head="$(jq -r '.headRefOid' <<<"$after")"
+            current_mergeable="$(jq -r '.mergeable' <<<"$after")"
             if [ "$current_head" != "$head_sha" ]; then
               echo "PR #$n: head moved ($head_sha -> $current_head) between the gate and the merge — fail-closed, no merge; a later tick re-evaluates the new head."
               echo "::endgroup::"
               exit 0
             fi
-            # Head unchanged, yet the merge was refused — almost always branch
-            # protection (e.g. a required human approving review, which the
-            # automated verdict is not). Post ONE marker-guarded note so it's
-            # visible without spamming every tick, and stop (do not fall through
-            # to merge a different PR under the same blocked policy).
+            if [ "$current_mergeable" != 'MERGEABLE' ]; then
+              echo "PR #$n: base advanced — no longer MERGEABLE (now $current_mergeable) between the gate and the merge — deferring; the conflict resolver will rebase it."
+              echo "::endgroup::"
+              exit 0
+            fi
+            # Head unchanged and still mergeable, yet the merge was refused —
+            # almost always branch protection (e.g. a required human approving
+            # review, which the automated verdict is not). Post ONE marker-guarded
+            # note so it's visible without spamming every tick, and stop (do not
+            # fall through to merge a different PR under the same blocked policy).
             echo "::warning::gh pr merge refused for PR #$n with head unchanged — likely branch protection."
             already_noted="$(gh pr view "$n" --repo "$REPO" --json comments \
               | jq -r --arg m "$BLOCKED_MARKER" '[.comments[].body] | any(startswith($m))')"

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -225,8 +225,15 @@ jobs:
             fi
 
             # --- Merge exactly this one, then stop ----------------------------
-            echo "PR #$n: green + mergeable + fresh LGTM — merging (method: $MERGE_METHOD)."
-            if gh pr merge "$n" --repo "$REPO" "--$MERGE_METHOD" --delete-branch; then
+            # PIN THE HEAD COMMIT: every gate above (mergeable, checks-green,
+            # fresh-LGTM) was evaluated against `head_sha`. `--match-head-commit`
+            # makes GitHub refuse the merge if the branch has moved since — so a
+            # push landing in the window (autofix/revise/conflict-resolver, or a
+            # maintainer) can NEVER slip an ungated commit through this gate; the
+            # merge fails closed and the next tick re-evaluates the new head.
+            echo "PR #$n: green + mergeable + fresh LGTM — merging (method: $MERGE_METHOD, head $head_sha)."
+            if gh pr merge "$n" --repo "$REPO" "--$MERGE_METHOD" \
+              --match-head-commit "$head_sha" --delete-branch; then
               echo "Merged PR #$n."
               # main advanced — rebase whatever now conflicts. A GITHUB_TOKEN
               # merge does NOT itself trigger the resolver's push-to-main
@@ -239,12 +246,23 @@ jobs:
               exit 0
             fi
 
-            # Merge refused — almost always branch protection (e.g. a required
-            # human approving review, which the automated verdict is not). Post
-            # ONE marker-guarded note so it's visible without spamming every
-            # tick, and stop (do not fall through to merge a different PR under
-            # the same blocked policy).
-            echo "::warning::gh pr merge refused for PR #$n — likely branch protection."
+            # Merge refused. Distinguish a TRANSIENT head-moved race (a push
+            # landed between the gate snapshot and the merge — --match-head-commit
+            # failed closed exactly as intended) from a PERSISTENT block (branch
+            # protection). A moved head just defers to the next tick, silently;
+            # only a genuine block posts the explanatory note.
+            current_head="$(gh pr view "$n" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+            if [ "$current_head" != "$head_sha" ]; then
+              echo "PR #$n: head moved ($head_sha -> $current_head) between the gate and the merge — fail-closed, no merge; a later tick re-evaluates the new head."
+              echo "::endgroup::"
+              exit 0
+            fi
+            # Head unchanged, yet the merge was refused — almost always branch
+            # protection (e.g. a required human approving review, which the
+            # automated verdict is not). Post ONE marker-guarded note so it's
+            # visible without spamming every tick, and stop (do not fall through
+            # to merge a different PR under the same blocked policy).
+            echo "::warning::gh pr merge refused for PR #$n with head unchanged — likely branch protection."
             already_noted="$(gh pr view "$n" --repo "$REPO" --json comments \
               | jq -r --arg m "$BLOCKED_MARKER" '[.comments[].body] | any(startswith($m))')"
             if [ "$already_noted" != 'true' ]; then

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -171,8 +171,17 @@ jobs:
             # The review worker posts a comment beginning "PR review (automated):"
             # with a one-line verdict. Take the LATEST such comment; a no-output
             # review posts a DIFFERENT first line, so it is naturally excluded.
+            #
+            # CRITICAL — match on the comment AUTHOR, not just the body. The
+            # verdict phrasing is fully public (it's on every prior PR), so a
+            # body-text-only filter would accept a comment from ANY user who can
+            # comment on the PR as a "fresh LGTM" and force an unreviewed merge.
+            # The real verdict is posted by pipeline-pr-review.yml via `gh pr
+            # comment` under the GITHUB_TOKEN, i.e. as `github-actions[bot]` — an
+            # identity a normal user CANNOT post as, so requiring it closes the
+            # forgery gap that text matching alone leaves open.
             latest_review="$(gh pr view "$n" --repo "$REPO" --json comments \
-              --jq '[.comments[] | select(.body | test("^PR review \\(automated\\):"))] | last // empty')"
+              --jq '[.comments[] | select(.author.login == "github-actions[bot]" and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
             if [ -z "$latest_review" ]; then
               echo "PR #$n: no automated review verdict yet — skip."
               echo "::endgroup::"; continue

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -130,15 +130,22 @@ jobs:
             done
 
             # --- Structural contract: build-worker PR, not pinned/escalated ----
+            # Pin to the EXACT build-worker identity (`claude[bot]`, the App the
+            # build worker opens PRs as), NOT merely `.author.is_bot == true`.
+            # The fix/resolve/revise loops can accept any bot because a bad
+            # match there is reversible (a wrong rebase/nudge); here a bad match
+            # merges to `main`, so at these stakes the identity check must admit
+            # only the build worker, not any other bot account with same-repo
+            # write access (e.g. Dependabot).
             eligible="$(jq -r '
               (.isDraft | not)
               and (.isCrossRepository | not)
-              and (.author.is_bot == true)
+              and (.author.login == "claude[bot]")
               and ((.body // "") | test("[Cc]loses #[0-9]+"))
               and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-merge") | not))
             ' <<<"$info")"
             if [ "$eligible" != 'true' ]; then
-              echo "PR #$n: not an eligible build-worker PR (draft/fork/non-bot/no Closes #/stop-labelled) — skip."
+              echo "PR #$n: not an eligible build-worker PR (draft/fork/not claude[bot]/no Closes #/stop-labelled) — skip."
               echo "::endgroup::"; continue
             fi
 

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -256,6 +256,20 @@ jobs:
               echo "::endgroup::"; continue
             fi
 
+            # --- FINAL gate: re-check the stop labels right before merging ----
+            # The structural label check ran from the initial `struct` fetch,
+            # BEFORE the mergeable poll (~24s of retries) and the review/freshness
+            # API calls. A human adding `needs-human`/`no-auto-merge` during that
+            # window — the very interrupt this loop relies on — must still stop
+            # the merge. (`--match-head-commit` catches a moved head, not a label
+            # change, so this re-check is the label equivalent of that pin.)
+            has_stop="$(gh pr view "$n" --repo "$REPO" --json labels \
+              --jq '[.labels[].name] | any(. == "needs-human" or . == "no-auto-merge")')"
+            if [ "$has_stop" = 'true' ]; then
+              echo "PR #$n: a stop label (needs-human/no-auto-merge) appeared during evaluation — aborting before merge."
+              echo "::endgroup::"; continue
+            fi
+
             # --- All gates passed ---------------------------------------------
             if [ "$MODE" != 'live' ]; then
               echo "PR #$n: DRY RUN (AUTOMERGE_MODE=$MODE) — fully eligible; would merge (method: $MERGE_METHOD, head $head_sha). No merge performed."

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -1,0 +1,242 @@
+name: Pipeline PR auto-merge
+
+# Serialized AUTO-MERGE loop (see docs/PIPELINE.md). Drains the build-worker PR
+# backlog by merging ONE fully-vetted bot PR at a time, so a queue of green,
+# review-approved PRs doesn't sit waiting on a human — the throughput
+# bottleneck that let ~10 PRs pile up and pairwise-conflict on the shared
+# CHANGELOG.md / security-floor.json append points.
+#
+# This is a DELIBERATE, tightly-gated reversal of the pipeline's original
+# "no loop merges — a human merges" rule (docs/PIPELINE.md). It is safe to
+# automate ONLY because every merge is deterministic and multiply-gated:
+#
+#   * NO LLM / NO agent / NO Max-pool spend. Pure shell + `gh`. It reads
+#     untrusted PR content (titles/bodies/comments) only as jq DATA, never as
+#     instructions, and executes no PR-controlled code — so unlike the fix/
+#     resolve loops there is no prompt-injection or code-exec surface here.
+#   * BUILD-WORKER PRs ONLY: same-repo (never a fork), bot-authored, with a
+#     `Closes #<n>` body — the build worker's contract, the same signal the
+#     autofix / conflict / revise loops key on. Human PRs and unrelated bot
+#     PRs (e.g. a Dependabot bump) are left for a human to merge.
+#   * GREEN + APPROVED + CLEAN: every check on the PR head must be passing,
+#     the PR must be `MERGEABLE` (no conflict), and the LATEST automated
+#     review verdict must be "LGTM" AND newer than the head commit (a stale
+#     approval from before a later push never counts).
+#   * STOP LABELS: `needs-human` (any loop's escalation) and `no-auto-merge`
+#     (pin a PR out by hand) both exclude a PR — same policy shape as the
+#     conflict resolver's `no-auto-resolve`.
+#   * SERIALIZED: at most ONE merge per run, oldest PR first. After it merges,
+#     `main` has advanced, so the run dispatches the conflict resolver to
+#     rebase whatever it now conflicts with; those PRs re-run CI + re-review
+#     and only become eligible again once they are green against the NEW main.
+#     A PR is therefore never merged except against the exact `main` its checks
+#     last passed on for a conflicting change — the next one waits its turn.
+#   * ENFORCEABLE BACKSTOP: branch protection on `main` is the real guarantee
+#     (required checks + who may merge), exactly as it is for the push-based
+#     loops. This workflow raises the bar deterministically; it does not
+#     replace that setting. See docs/SECURITY.md.
+#
+# PREREQUISITE (until then inert): the same CLAUDE_CODE_OAUTH_TOKEN gate the
+# rest of the pipeline uses — with the pipeline off there are no automated
+# review verdicts, so nothing could pass the LGTM gate anyway; the explicit
+# inert check just makes "disabled" unambiguous. Branch protection must also
+# allow the GITHUB_TOKEN / Actions identity to merge (i.e. not require a human
+# approving REVIEW — the automated verdict is a comment, not a review). If it
+# doesn't, `gh pr merge` fails loudly and the PR is left untouched.
+
+on:
+  # Primary driver: a slow sweep. Every tick is a few seconds of shell, so a
+  # short interval is cheap; 15 min bounds how long an approved PR waits.
+  schedule:
+    - cron: '*/15 * * * *'
+  # Responsiveness: react as soon as a PR's CI or its review finishes (e.g. a
+  # freshly-rebased PR going green), instead of only on the next sweep. The job
+  # re-scans ALL open PRs regardless of which run woke it, so the trigger source
+  # never matters — it always picks the current oldest-eligible PR.
+  workflow_run:
+    workflows: ['CI', 'Pipeline PR review worker']
+    types: [completed]
+  workflow_dispatch:
+
+# Never run two merges at once: they would race on "which PR is oldest-eligible"
+# and could merge two PRs against the same pre-merge `main`, defeating the
+# serialization. cancel-in-progress:false so a queued tick waits rather than
+# being dropped.
+concurrency:
+  group: pipeline-automerge
+  cancel-in-progress: false
+
+permissions:
+  contents: write # merge the PR (push the merge commit to main)
+  pull-requests: write # merge/comment/label
+  actions: write # dispatch the conflict resolver to rebase the rest after a merge
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      # Merge-commit to match the existing `main` history ("Merge pull request
+      # #N …"). Change to `squash`/`rebase` only alongside the branch-protection
+      # "allowed merge methods" setting.
+      MERGE_METHOD: merge
+      # A merge blocked by branch protection (e.g. it requires a human approving
+      # review) posts ONE marker-guarded note explaining the likely cause,
+      # rather than silently doing nothing every tick.
+      BLOCKED_MARKER: '<!-- pipeline-automerge-blocked -->'
+      # Safety valve for rollout: set repository variable AUTOMERGE_DRY_RUN=true
+      # (Settings → Secrets and variables → Actions → Variables) to LOG the PR
+      # it would merge each run without merging, so the eligibility logic can be
+      # watched against real PRs first. Unset/anything-else = live merges.
+      DRY_RUN: ${{ vars.AUTOMERGE_DRY_RUN }}
+    steps:
+      - name: Inert notice (token not set)
+        if: env.HAS_TOKEN != 'true'
+        run: echo "CLAUDE_CODE_OAUTH_TOKEN not set — PR auto-merge loop is inert (no automated review verdicts exist to gate on)."
+
+      - name: Merge the oldest fully-eligible bot PR (at most one)
+        if: env.HAS_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+
+          # Candidates: open, oldest-first. All eligibility is re-checked per PR
+          # below from authoritative fields; this list is just the scan order.
+          candidates="$(gh pr list --repo "$REPO" --state open --limit 50 \
+            --json number,createdAt \
+            | jq -r 'sort_by(.createdAt) | .[].number')"
+
+          if [ -z "$candidates" ]; then
+            echo "No open PRs — nothing to merge."
+            exit 0
+          fi
+
+          for n in $candidates; do
+            echo "::group::Evaluating PR #$n"
+
+            # `mergeable` is computed asynchronously by GitHub and reads UNKNOWN
+            # until it settles — poll a bounded number of times, then defer to a
+            # later tick rather than guessing (same policy as the conflict
+            # resolver's discover job).
+            info='{}'; mergeable='UNKNOWN'
+            for _ in $(seq 1 8); do
+              info="$(gh pr view "$n" --repo "$REPO" \
+                --json number,isDraft,isCrossRepository,mergeable,author,labels,body,headRefOid,statusCheckRollup)"
+              mergeable="$(jq -r '.mergeable' <<<"$info")"
+              [ "$mergeable" != 'UNKNOWN' ] && break
+              sleep 3
+            done
+
+            # --- Structural contract: build-worker PR, not pinned/escalated ----
+            eligible="$(jq -r '
+              (.isDraft | not)
+              and (.isCrossRepository | not)
+              and (.author.is_bot == true)
+              and ((.body // "") | test("[Cc]loses #[0-9]+"))
+              and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-merge") | not))
+            ' <<<"$info")"
+            if [ "$eligible" != 'true' ]; then
+              echo "PR #$n: not an eligible build-worker PR (draft/fork/non-bot/no Closes #/stop-labelled) — skip."
+              echo "::endgroup::"; continue
+            fi
+
+            # --- Mergeable (no conflict) ---------------------------------------
+            if [ "$mergeable" != 'MERGEABLE' ]; then
+              echo "PR #$n: mergeable=$mergeable (conflicting or still unknown) — skip; the conflict resolver handles CONFLICTING."
+              echo "::endgroup::"; continue
+            fi
+
+            # --- Every check on the head is green ------------------------------
+            # Pass = at least one check AND every check COMPLETED with a
+            # non-failing conclusion (SUCCESS/NEUTRAL/SKIPPED). Any PENDING /
+            # QUEUED / IN_PROGRESS / FAILURE / CANCELLED / TIMED_OUT fails the
+            # gate, so an in-flight or red run defers the PR to a later tick.
+            checks_green="$(jq -r '
+              [ .statusCheckRollup[]?
+                | if (.__typename == "CheckRun")
+                  then (if .status == "COMPLETED" then (.conclusion // "PENDING") else "PENDING" end)
+                  else (.state // "PENDING") end
+              ] as $s
+              | (($s | length) > 0)
+                and ($s | all(. == "SUCCESS" or . == "NEUTRAL" or . == "SKIPPED"))
+            ' <<<"$info")"
+            if [ "$checks_green" != 'true' ]; then
+              echo "PR #$n: not all checks are green yet — skip."
+              echo "::endgroup::"; continue
+            fi
+
+            # --- Latest automated review verdict is LGTM, and is FRESH ---------
+            # The review worker posts a comment beginning "PR review (automated):"
+            # with a one-line verdict. Take the LATEST such comment; a no-output
+            # review posts a DIFFERENT first line, so it is naturally excluded.
+            latest_review="$(gh pr view "$n" --repo "$REPO" --json comments \
+              --jq '[.comments[] | select(.body | test("^PR review \\(automated\\):"))] | last // empty')"
+            if [ -z "$latest_review" ]; then
+              echo "PR #$n: no automated review verdict yet — skip."
+              echo "::endgroup::"; continue
+            fi
+            review_body="$(jq -r '.body' <<<"$latest_review")"
+            review_at="$(jq -r '.createdAt' <<<"$latest_review")"
+
+            # Verdict = first 4 lines minus bullet lines, so a phrase inside a
+            # finding can't be misread as the verdict (the exact parse the
+            # review worker uses to route). Require an explicit LGTM and the
+            # absence of the two non-approving verdicts.
+            verdict="$(printf '%s' "$review_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
+            if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
+               || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
+              echo "PR #$n: latest review verdict is not an LGTM approval — skip."
+              echo "::endgroup::"; continue
+            fi
+
+            # Freshness: the approval must be NEWER than the head commit, else a
+            # later push (e.g. an autofix/revise commit) invalidated it and the
+            # PR is awaiting re-review.
+            head_sha="$(jq -r '.headRefOid' <<<"$info")"
+            head_at="$(gh api "repos/$REPO/commits/$head_sha" --jq '.commit.committer.date')"
+            if [ "$(date -d "$review_at" +%s)" -lt "$(date -d "$head_at" +%s)" ]; then
+              echo "PR #$n: the LGTM review predates the current head commit — awaiting re-review, skip."
+              echo "::endgroup::"; continue
+            fi
+
+            # --- All gates passed ---------------------------------------------
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo "PR #$n: DRY RUN — fully eligible; would merge (method: $MERGE_METHOD) but AUTOMERGE_DRY_RUN=true. No merge performed."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            # --- Merge exactly this one, then stop ----------------------------
+            echo "PR #$n: green + mergeable + fresh LGTM — merging (method: $MERGE_METHOD)."
+            if gh pr merge "$n" --repo "$REPO" "--$MERGE_METHOD" --delete-branch; then
+              echo "Merged PR #$n."
+              # main advanced — rebase whatever now conflicts. A GITHUB_TOKEN
+              # merge does NOT itself trigger the resolver's push-to-main
+              # trigger, so dispatch its discover run explicitly (empty input =
+              # discover). Best-effort; the resolver's hourly sweep is the
+              # backstop if this dispatch is unavailable.
+              gh workflow run pipeline-pr-conflict.yml --repo "$REPO" \
+                || echo "::warning::Could not dispatch the conflict resolver; its hourly sweep will rebase the rest."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            # Merge refused — almost always branch protection (e.g. a required
+            # human approving review, which the automated verdict is not). Post
+            # ONE marker-guarded note so it's visible without spamming every
+            # tick, and stop (do not fall through to merge a different PR under
+            # the same blocked policy).
+            echo "::warning::gh pr merge refused for PR #$n — likely branch protection."
+            already_noted="$(gh pr view "$n" --repo "$REPO" --json comments \
+              | jq -r --arg m "$BLOCKED_MARKER" '[.comments[].body] | any(startswith($m))')"
+            if [ "$already_noted" != 'true' ]; then
+              gh pr comment "$n" --repo "$REPO" --body "${BLOCKED_MARKER}
+          🤖 Auto-merge found this PR fully eligible (green, mergeable, review-approved) but \`gh pr merge\` was refused — most likely branch protection requires a human approving *review* (the automated verdict is a comment, not a review), or the Actions identity isn't allowed to merge. A maintainer can merge it directly, or adjust branch protection. See docs/PIPELINE.md (auto-merge loop)."
+            fi
+            echo "::endgroup::"
+            exit 0
+          done
+
+          echo "No fully-eligible PR to merge this run."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,12 @@ ownership rules:
   authored by the build worker (`claude[bot]` — the exact identity, not merely
   any bot), `Closes #`, has all checks green, is `MERGEABLE`, and whose
   LATEST automated review verdict is an `LGTM` (from `github-actions[bot]`,
-  the review worker's identity) newer than the head commit —
-  never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
+  the review worker's identity) newer than the head commit, and does NOT touch
+  any governance/CI/config path (`.github/`, `scripts/`, `package.json`,
+  typecheck/lint/format config, `CLAUDE.md`, `docs/PIPELINE.md`,
+  `docs/SECURITY.md`) — those always require a human merge, so the loop can
+  never auto-merge a change to its own guardrails or to what "green" means.
+  Never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to
   rebase the rest, and the next PR only re-qualifies once it is green against
   the new `main`. Branch protection on `main` is the enforceable backstop, as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,10 @@ ownership rules:
   (it reads PR titles/bodies/comments only as jq data, never as instructions,
   and runs no PR-controlled code — so it has none of the fix/resolve loops'
   injection/code-exec surface). It merges the OLDEST PR that is same-repo,
-  bot-authored, `Closes #`, has all checks green, is `MERGEABLE`, and whose
-  LATEST automated review verdict is an `LGTM` newer than the head commit —
+  authored by the build worker (`claude[bot]` — the exact identity, not merely
+  any bot), `Closes #`, has all checks green, is `MERGEABLE`, and whose
+  LATEST automated review verdict is an `LGTM` (from `github-actions[bot]`,
+  the review worker's identity) newer than the head commit —
   never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to
   rebase the rest, and the next PR only re-qualifies once it is green against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,24 @@ ownership rules:
   migrate, test against a real pgvector Postgres, build, test:security) BEFORE
   opening a PR, so "green locally" matches CI. Keep it that way when editing
   either `pipeline-build.yml` or `ci.yml` — they must run the same checks.
-- **No loop merges PRs** — a human merges.
+- The **auto-merge loop** (`pipeline-pr-automerge.yml`) merges fully-vetted
+  build-worker PRs, one at a time, so a backlog of green + approved PRs doesn't
+  stall on a human. It is a **deterministic, no-LLM, no-Max-pool** shell loop
+  (it reads PR titles/bodies/comments only as jq data, never as instructions,
+  and runs no PR-controlled code — so it has none of the fix/resolve loops'
+  injection/code-exec surface). It merges the OLDEST PR that is same-repo,
+  bot-authored, `Closes #`, has all checks green, is `MERGEABLE`, and whose
+  LATEST automated review verdict is an `LGTM` newer than the head commit —
+  never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
+  afterwards `main` has advanced, so it dispatches the conflict resolver to
+  rebase the rest, and the next PR only re-qualifies once it is green against
+  the new `main`. Branch protection on `main` is the enforceable backstop, as
+  for every other loop (see docs/SECURITY.md). Pin a PR out with
+  `no-auto-merge`.
+- **No loop OPENS or force-pushes over a human's PR, and no loop merges a
+  human PR** — only the deterministic auto-merge loop above merges, and only
+  its own build-worker PRs under the gate described there. A human still
+  merges anything that loop won't touch.
 - WIP caps: ≤3 open `status:draft`. Builds run **per-issue** (each issue its own
   `concurrency` group, so distinct issues run in parallel and none evicts
   another — a single shared group would silently *cancel* queued builds, and

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -417,8 +417,17 @@ To go live:
 Until both exist the workflows are inert (they log a notice and skip). Fork PRs
 never receive the secret, so the review worker won't run on untrusted forks.
 
-The **auto-merge loop** has two extra rollout knobs:
+The **auto-merge loop** is **OFF by default** and has two rollout knobs:
 
+- **Opt in with `AUTOMERGE_MODE` (repository variable** — Settings → Secrets and
+  variables → Actions → Variables). Unset (the default) ⇒ the loop is inert, so
+  merging this workflow onto `main` never auto-merges anything until you
+  deliberately turn it on. Set it to **`dry-run`** to have each run LOG the PR it
+  *would* merge (no merge) so you can confirm the eligibility logic picks the
+  right PRs against real traffic; then set it to **`live`** to actually merge.
+  Pin any individual PR out at any time with the `no-auto-merge` label. This
+  opt-in default is deliberate: it guarantees an observation window before any
+  live merge, given this is the first loop allowed to write to `main`.
 - **Branch protection on `main` must let the Actions identity merge.** It merges
   with the `GITHUB_TOKEN`, and the automated review verdict is a *comment*, not
   a GitHub approving review — so if protection requires a human approving
@@ -426,13 +435,9 @@ The **auto-merge loop** has two extra rollout knobs:
   comment). Configure protection to require the *checks* (build, lint,
   security-invariants, review) rather than a human review, and to allow the
   Actions/bot identity to merge. Required-checks protection is also the
-  enforceable backstop that the loop's own gating supplements, not replaces.
-- **Dry run first (optional):** set repository **variable**
-  `AUTOMERGE_DRY_RUN=true` (Settings → Secrets and variables → Actions →
-  Variables) to have each run LOG the PR it would merge, without merging, so you
-  can confirm the eligibility logic picks the right PRs against real traffic.
-  Unset it (or set anything else) to go live. Pin any individual PR out at any
-  time with the `no-auto-merge` label.
+  enforceable backstop that the loop's own gating supplements, not replaces. See
+  docs/SECURITY.md's Operational checklist for the security posture this trades
+  off (a human merge is the backstop against a prompt-injected review LLM).
 
 **Cost caution:** every run draws on the same Max 5-hour/weekly pool as the
 production bot serving real members. Keep an eye on `/usage`; if the pipeline

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -114,11 +114,19 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   forge an approval) **newer than the head commit** (a stale approval from
   before a later push never counts) — and is not labelled
   `needs-human` or `no-auto-merge` (pin a PR out by hand, same shape as
-  `no-auto-resolve`). It merges **exactly one PR per run**: afterwards `main`
-  has advanced, so it dispatches the conflict resolver to rebase whatever now
-  conflicts, and the next PR only re-qualifies once it is green against the new
-  `main` — so a PR is never merged except against the exact `main` its checks
-  last passed on. Branch protection on `main` (required checks + who may merge)
+  `no-auto-resolve`). Crucially, it **routes any PR touching a governance/CI/
+  config path to a human merge** — `.github/**` (workflows/CI, including this
+  loop itself), `scripts/**` (the check machinery), `package.json`,
+  typecheck/lint/format config, and the `CLAUDE.md`/`docs/PIPELINE.md`/
+  `docs/SECURITY.md` governance docs — so the pipeline can never auto-merge a
+  change to its own guardrails or to what "green" means (and since
+  `pull_request` CI runs the workflow version from the PR branch, a PR could
+  otherwise weaken a check and still show it "passing"). It merges **exactly one
+  PR per run**: afterwards `main` has advanced, so it dispatches the conflict
+  resolver to rebase whatever now conflicts, and the next PR only re-qualifies
+  once it is green against the new `main` — so a PR is never merged except
+  against the exact `main` its checks last passed on. Branch protection on
+  `main` (required checks + who may merge)
   is the enforceable backstop, exactly as for the push-based loops; if it
   requires a human approving *review* the merge is refused and the PR is left
   for a human, since the automated verdict is a comment, not a review.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -105,10 +105,14 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   Max-pool spend**: pure shell + `gh` that reads PR titles/bodies/comments only
   as jq DATA (never as instructions) and runs no PR-controlled code, so it has
   none of the fix/resolve/revise loops' prompt-injection or code-execution
-  surface. It merges the OLDEST PR that is same-repo, bot-authored, `Closes #`,
-  has every check green, is `MERGEABLE` (no conflict), and whose LATEST
-  automated review verdict is an `LGTM` **newer than the head commit** (a stale
-  approval from before a later push never counts) — and is not labelled
+  surface. It merges the OLDEST PR that is same-repo, authored by the build
+  worker (`claude[bot]` — the exact identity, not merely any bot, since a bad
+  match here merges to `main`), `Closes #`, has every check green, is
+  `MERGEABLE` (no conflict), and whose LATEST automated review verdict is an
+  `LGTM` from `github-actions[bot]` (the review worker's identity — matched on
+  author, not just body text, so a public copy of the verdict phrasing can't
+  forge an approval) **newer than the head commit** (a stale approval from
+  before a later push never counts) — and is not labelled
   `needs-human` or `no-auto-merge` (pin a PR out by hand, same shape as
   `no-auto-resolve`). It merges **exactly one PR per run**: afterwards `main`
   has advanced, so it dispatches the conflict resolver to rebase whatever now

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -95,11 +95,37 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   guardrails as autofix (`gh` read-only except `gh pr comment` so a
   principled refusal is explained on the PR). It never opens or merges PRs.
   Do not misflag its pushes as an ownership violation either.
-- **No loop merges PRs.** A human merges — especially important for this
-  security-sensitive bot. This is enforced structurally, not just by prompt:
-  the build worker's `--allowedTools` in `pipeline-build.yml` grants no blanket
-  `git:*`/`gh:*`/`npx:*`/`node:*` and no form of `gh pr merge` or `gh api`
-  (matching the autofix worker's least-privilege standard, #107).
+- A fourth exception: the **auto-merge loop** (`pipeline-pr-automerge.yml`)
+  merges fully-vetted build-worker PRs — a deliberate, tightly-gated reversal
+  of the original "a human merges everything" rule, added because throughput,
+  not correctness, had become the bottleneck: a backlog of green + approved
+  PRs sat waiting on a human and pairwise-conflicted on the shared
+  `CHANGELOG.md` / `security-floor.json` append points the longer they waited.
+  It is safe to automate because it is **deterministic — no LLM, no agent, no
+  Max-pool spend**: pure shell + `gh` that reads PR titles/bodies/comments only
+  as jq DATA (never as instructions) and runs no PR-controlled code, so it has
+  none of the fix/resolve/revise loops' prompt-injection or code-execution
+  surface. It merges the OLDEST PR that is same-repo, bot-authored, `Closes #`,
+  has every check green, is `MERGEABLE` (no conflict), and whose LATEST
+  automated review verdict is an `LGTM` **newer than the head commit** (a stale
+  approval from before a later push never counts) — and is not labelled
+  `needs-human` or `no-auto-merge` (pin a PR out by hand, same shape as
+  `no-auto-resolve`). It merges **exactly one PR per run**: afterwards `main`
+  has advanced, so it dispatches the conflict resolver to rebase whatever now
+  conflicts, and the next PR only re-qualifies once it is green against the new
+  `main` — so a PR is never merged except against the exact `main` its checks
+  last passed on. Branch protection on `main` (required checks + who may merge)
+  is the enforceable backstop, exactly as for the push-based loops; if it
+  requires a human approving *review* the merge is refused and the PR is left
+  for a human, since the automated verdict is a comment, not a review.
+- **No loop OPENS PRs but the build worker, and no loop merges a HUMAN or
+  non-build-worker PR.** A human still merges everything the auto-merge loop
+  won't touch. The build worker itself still cannot merge — enforced
+  structurally, not just by prompt: its `--allowedTools` in `pipeline-build.yml`
+  grants no blanket `git:*`/`gh:*`/`npx:*`/`node:*` and no form of
+  `gh pr merge` or `gh api` (matching the autofix worker's least-privilege
+  standard, #107). Only the deterministic auto-merge loop merges, and only its
+  own gated build-worker PRs.
 - **WIP caps:** ≤3 open `status:draft`. Builds run **per-issue** (each issue its
   own `concurrency` group — distinct issues in parallel, no cross-eviction; a
   single shared group would silently *cancel* queued builds, which aren't
@@ -262,9 +288,12 @@ and exits. Consequences to respect:
 | orchestrator | Routine (fresh session) | every ~6h | Haiku 4.5 |
 | build | **GitHub Action** on `issues.labeled == status:approved` (Routine hourly as fallback) | event | Sonnet 5 |
 | pr-review | **GitHub Action** on `pull_request` events (Routine hourly as fallback) | event | Sonnet 5 |
+| auto-merge | **GitHub Action** on a 15-min schedule + CI/review completion | event | — (deterministic, no model) |
 
 Event-driven Actions cost nothing when idle and need no live session — the
 right fit for the two code loops. Routines suit the time-driven discovery loops.
+The auto-merge loop is deterministic shell (no model), so it costs nothing but
+GitHub Actions minutes.
 
 ### Setup
 
@@ -364,8 +393,16 @@ sessions:
   worker; addresses a Changes-requested review on the build-worker PR's own
   branch and pushes (2 attempts per PR, then `needs-human`). See the third
   ownership-rule exception above.
+- `.github/workflows/pipeline-pr-automerge.yml` — deterministic (no model)
+  shell loop on a 15-min schedule + CI/review completion; merges the oldest
+  fully-vetted build-worker PR (green + `MERGEABLE` + fresh `LGTM`, not
+  `needs-human`/`no-auto-merge`), one per run, then dispatches the conflict
+  resolver to rebase the rest. See the fourth ownership-rule exception above.
+  Unlike the loops below it uses **only the `GITHUB_TOKEN`** (no
+  claude-code-action, no Max pool) — it stays inert until the pipeline token is
+  set because until then no automated review verdict exists to gate on.
 
-All of these use `anthropics/claude-code-action` with **subscription auth** via the
+The agent loops below use `anthropics/claude-code-action` with **subscription auth** via the
 `CLAUDE_CODE_OAUTH_TOKEN` secret (from `claude setup-token`) — same Max pool as
 the bot, not a metered key.
 
@@ -375,6 +412,23 @@ To go live:
 
 Until both exist the workflows are inert (they log a notice and skip). Fork PRs
 never receive the secret, so the review worker won't run on untrusted forks.
+
+The **auto-merge loop** has two extra rollout knobs:
+
+- **Branch protection on `main` must let the Actions identity merge.** It merges
+  with the `GITHUB_TOKEN`, and the automated review verdict is a *comment*, not
+  a GitHub approving review — so if protection requires a human approving
+  review, the merge is refused (the PR is left for a human, with one explanatory
+  comment). Configure protection to require the *checks* (build, lint,
+  security-invariants, review) rather than a human review, and to allow the
+  Actions/bot identity to merge. Required-checks protection is also the
+  enforceable backstop that the loop's own gating supplements, not replaces.
+- **Dry run first (optional):** set repository **variable**
+  `AUTOMERGE_DRY_RUN=true` (Settings → Secrets and variables → Actions →
+  Variables) to have each run LOG the PR it would merge, without merging, so you
+  can confirm the eligibility logic picks the right PRs against real traffic.
+  Unset it (or set anything else) to go live. Pin any individual PR out at any
+  time with the `no-auto-merge` label.
 
 **Cost caution:** every run draws on the same Max 5-hour/weekly pool as the
 production bot serving real members. Keep an eye on `/usage`; if the pipeline

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1794,16 +1794,33 @@ number could reach an unrelated person).
       for per-user requests; `INTERACTION_RETENTION_DAYS` for age-based purge).
 - [ ] `journalctl -u community-agent` reviewed for redaction leaks.
 - [ ] **Branch protection on `main`** blocks direct and force pushes (require a
-      PR + review). This is the **enforceable** guarantee for the pipeline's
-      write-scoped automation — the build, autofix, and conflict-resolver workers
-      each hold a `contents: write` token and run an agent with code execution
-      (`node`/`npm`, needed to run the gate). Their `git push origin HEAD`
-      allowlist and withheld `checkout`/`branch` raise the bar, but an agent with
-      code execution could still rewrite `.git/HEAD` on disk to retarget a push,
-      so the tool restrictions are defence-in-depth, not the guarantee. Branch
-      protection (server-side) is what actually guarantees nothing reaches `main`
-      without a human merge even if a worker is prompt-injected. Enable it before
-      relying on these loops.
+      PR + passing required checks). This is the **enforceable** guarantee for the
+      pipeline's write-scoped automation — the build, autofix, and
+      conflict-resolver workers each hold a `contents: write` token and run an
+      agent with code execution (`node`/`npm`, needed to run the gate). Their
+      `git push origin HEAD` allowlist and withheld `checkout`/`branch` raise the
+      bar, but an agent with code execution could still rewrite `.git/HEAD` on
+      disk to retarget a push, so the tool restrictions are defence-in-depth, not
+      the guarantee. Branch protection (server-side) is what actually guarantees
+      nothing reaches `main` except through a PR that passed the required checks.
+      Enable it before relying on these loops.
+- [ ] **Auto-merge posture (`pipeline-pr-automerge.yml`) is a conscious
+      decision.** By default the pipeline requires a **human** to merge every PR,
+      which is the backstop against the PR-review LLM itself being prompt-injected
+      into a false "LGTM" (it reads untrusted PR diffs/bodies). The auto-merge
+      loop, when enabled, deliberately trades that backstop for throughput: it
+      merges build-worker PRs on the automated `LGTM` alone (plus green checks,
+      `MERGEABLE`, exact-identity + freshness + `--match-head-commit` gates — all
+      deterministic, no LLM, so no *added* injection surface of its own). The
+      residual risk it accepts is a review LLM tricked into a wrongful `LGTM`
+      shipping unreviewed code to `main` unattended. Controls: it is **off by
+      default** (`AUTOMERGE_MODE` unset ⇒ inert; set `dry-run` to observe, `live`
+      to act); any PR can be pinned out with `no-auto-merge`; and branch
+      protection's required checks + who-may-merge still bound it. If you require
+      the strict "no code reaches `main` without a human even if a worker is
+      prompt-injected" guarantee, leave `AUTOMERGE_MODE` unset (or require a human
+      approving *review* in branch protection, which the automated verdict is
+      not) — then a human merges everything, as before.
 - [ ] **If enabling `redeploy_bot`**: the exact-match sudoers line in
       docs/DEPLOYMENT.md is added (opt-in — omit it and the tool simply fails
       clean with no new host surface granted).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1813,9 +1813,16 @@ number could reach an unrelated person).
       `MERGEABLE`, exact-identity + freshness + `--match-head-commit` gates — all
       deterministic, no LLM, so no *added* injection surface of its own). The
       residual risk it accepts is a review LLM tricked into a wrongful `LGTM`
-      shipping unreviewed code to `main` unattended. Controls: it is **off by
-      default** (`AUTOMERGE_MODE` unset ⇒ inert; set `dry-run` to observe, `live`
-      to act); any PR can be pinned out with `no-auto-merge`; and branch
+      shipping unreviewed *application* code to `main` unattended. Controls: it is
+      **off by default** (`AUTOMERGE_MODE` unset ⇒ inert; set `dry-run` to
+      observe, `live` to act); it **always routes a PR touching any
+      governance/CI/config path to a human merge** — `.github/**` (workflows/CI,
+      including the auto-merge loop itself), `scripts/**` (the check machinery),
+      `package.json`, typecheck/lint/format config, and the
+      `CLAUDE.md`/`docs/PIPELINE.md`/`docs/SECURITY.md` docs — so the loop can
+      never auto-merge a change to its *own* gates or to what "green" means (which
+      matters because `pull_request` CI runs the workflow version from the PR
+      branch); any PR can be pinned out with `no-auto-merge`; and branch
       protection's required checks + who-may-merge still bound it. If you require
       the strict "no code reaches `main` without a human even if a worker is
       prompt-injected" guarantee, leave `AUTOMERGE_MODE` unset (or require a human

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -23,6 +23,7 @@ label "status:building" "5319E7" "Claimed by the build loop (WIP=1)"
 label "status:built"    "0052CC" "PR open, awaiting review/merge"
 label "needs-human"     "D93F0B" "Escalated: a human must decide"
 label "no-auto-resolve" "FBCA04" "Pin a PR out of the hourly conflict resolver (e.g. while editing it)"
+label "no-auto-merge"   "FBCA04" "Pin a PR out of the serialized auto-merge loop (a human will merge it)"
 label "community-feedback" "0E8A16" "A real member/admin request; input for research proposals"
 
 # Theme areas (VISION.md) — one per proposal, so the memoryless research loop can

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -23,7 +23,7 @@ label "status:building" "5319E7" "Claimed by the build loop (WIP=1)"
 label "status:built"    "0052CC" "PR open, awaiting review/merge"
 label "needs-human"     "D93F0B" "Escalated: a human must decide"
 label "no-auto-resolve" "FBCA04" "Pin a PR out of the hourly conflict resolver (e.g. while editing it)"
-label "no-auto-merge"   "FBCA04" "Pin a PR out of the serialized auto-merge loop (a human will merge it)"
+label "no-auto-merge"   "E99695" "Pin a PR out of the serialized auto-merge loop (a human will merge it)"
 label "community-feedback" "0E8A16" "A real member/admin request; input for research proposals"
 
 # Theme areas (VISION.md) — one per proposal, so the memoryless research loop can


### PR DESCRIPTION
## Summary

Adds `pipeline-pr-automerge.yml`, a **deterministic (no-LLM, no-Max-pool)** loop that merges fully-vetted build-worker PRs one at a time — so a backlog of green + review-approved PRs stops stalling on a human merge.

This came out of reviewing the current queue: all ~10 open PRs are CI-green; the real bottleneck is throughput (they wait on one human merger), and the longer they wait the more they pairwise-conflict on the shared `CHANGELOG.md` / `security-floor.json` append points — which is what keeps escalating the conflict-resolver (e.g. #560) to `needs-human`.

It's a deliberate, tightly-gated reversal of the pipeline's original *"a human merges everything"* rule. Safe to automate because it's **pure shell + `gh`**: it reads PR titles/bodies/comments only as jq **data**, never as instructions, and runs no PR-controlled code — so it has none of the fix/resolve/revise loops' prompt-injection or code-execution surface.

Eligibility — merges the **oldest** PR passing *all* of:
- same-repo, bot-authored, `Closes #` body (the build-worker contract every loop keys on)
- every check green, PR is `MERGEABLE` (no conflict)
- the **latest** automated review verdict is an `LGTM` **newer than the head commit** (a stale approval from before a later push never counts)
- not labelled `needs-human` / `no-auto-merge`

**Exactly one merge per run** → natural serialization: afterwards `main` has advanced, so it dispatches the conflict resolver to rebase whatever now conflicts, and the next PR only re-qualifies once it's green against the new `main`. So a PR is never merged except against the exact `main` its checks last passed on.

## Security / privacy impact

- **No new agent, no Max-pool spend, no code execution on PR-controlled content** — the whole loop is deterministic shell. This is the core reason it's safe to let it merge where the LLM loops are not permitted to.
- **Build-worker PRs only** (same-repo, bot, `Closes #`). Fork PRs, human PRs, and unrelated bot PRs (e.g. Dependabot) are never merged by it.
- Merges only on a **fresh automated `LGTM`** — the same security-review verdict a human currently merges behind, now required to be newer than the head commit so a later push can't ride an old approval.
- **Stop labels** `needs-human` / `no-auto-merge` exclude a PR (same shape as `no-auto-resolve`).
- **Branch protection on `main` remains the enforceable backstop** (required checks + who may merge), exactly as for the push-based loops — this loop supplements it, doesn't replace it. If protection requires a human approving *review*, the merge is refused (the automated verdict is a comment, not a review) and the PR is left for a human with one explanatory note.
- Uses only the `GITHUB_TOKEN` — no claude-code-action, no App-token push. It stays inert until the pipeline token is set (no automated review verdicts exist to gate on before then).

## How verified

- `npx prettier --check` on the workflow + docs — clean; no `actionlint` gate exists in CI.
- Hand-traced the eligibility logic against the live queue: correctly **skips** #560 (both `needs-human` and `CONFLICTING`) and #547 (`needs-human`), and would only act on a same-repo bot PR that is green + mergeable + freshly `LGTM`.
- No source (`src/`) changes, so the TypeScript gate is unaffected.
- Rollout safety valve: repo variable `AUTOMERGE_DRY_RUN=true` logs the PR it *would* merge without merging, so the eligibility logic can be watched against real PRs before going live.

## Rollout notes (in docs/PIPELINE.md)

- Branch protection on `main` must let the Actions identity merge (require the *checks*, not a human approving review).
- Optionally start with `AUTOMERGE_DRY_RUN=true`, watch a few runs, then unset to go live.
- This workflow only takes effect once it's on `main` — merge this PR by hand (it modifies `.github/workflows/`, which the bot loops can't push anyway).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_