### PR TITLE
chore(deps): override adm-zip to ^0.6.0 to resolve GHSA-xcpc-8h2w-3j85 (Dependabot #1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,9 +96,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -111,9 +108,6 @@
       "integrity": "sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -128,9 +122,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -143,9 +134,6 @@
       "integrity": "sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -2480,12 +2468,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": ">=22"
   },
   "overrides": {
+    "adm-zip": "^0.6.0",
     "undici": "^6.27.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #1 — [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85), `adm-zip < 0.6.0` (high): a crafted ZIP triggers a ~4 GB memory allocation (DoS). `adm-zip` is a transitive dependency three levels deep:

```
@huggingface/transformers@4.2.0
└─ onnxruntime-node@1.24.3
   └─ adm-zip@0.5.18   ← vulnerable
```

`npm audit fix --force` would **downgrade** `@huggingface/transformers` 4.2.0 → 3.8.1 (a major-version drop) — a bad trade. Instead this pins the already-published patched `adm-zip@0.6.0` via an npm `overrides` entry (`onnxruntime-node` pins `^0.5.16`, so it won't take 0.6.0 without the override). `@huggingface/transformers` stays at 4.2.0; only the transitive `adm-zip` moves.

## Security / privacy impact

No change to auth, tool gating, outbound filtering, data-access scope, or stored data — this is a dependency-only bump.

On the advisory itself: practical exposure in this codebase is low. `adm-zip` is invoked in exactly one place — `onnxruntime-node`'s **postinstall** script (`install-utils.js`), which unpacks the ONNX native-runtime NuGet package it downloads from a hardcoded, trusted URL at install time. It never runs at runtime and never processes attacker-controlled ZIPs; the bot's own inputs (audio voice notes, text) never reach `adm-zip`. The bump clears the advisory and moves to the patched code path regardless.

## How verified

- `npm audit` → **0 vulnerabilities** (was 3 high, all from this `adm-zip` chain).
- `npm ls adm-zip` → `adm-zip@0.6.0 overridden`, with `@huggingface/transformers@4.2.0` unchanged (no downgrade).
- `npm run typecheck` — clean.
- `npm run build` — clean.
- **Re-ran `onnxruntime-node`'s postinstall** (`node ./script/install`) — it downloaded the NuGet package and extracted the native `.so` runtime files via `adm-zip@0.6.0`, exit 0. This exercises the actual code path that uses `adm-zip`, proving the override doesn't break the install/unpack step.
- `npm test` — only the two pre-existing local-only flakes (`#411` DB-env, `#210` `router.test.ts` process-isolation) surface; this deps-only change touches no source or test files. CI runs the full gate against a real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_