### PR TITLE
Fix auto-merge's two gh-rendering bugs: bot-identity and verdict-author checks

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -149,11 +149,17 @@ jobs:
             # match there is reversible (a wrong rebase/nudge); here a bad match
             # merges to `main`, so at these stakes the identity check must admit
             # only the build worker, not any other bot account with same-repo
-            # write access (e.g. Dependabot).
+            # write access (e.g. Dependabot). The gh CLI (GraphQL) renders the
+            # App's login as "app/claude" while REST renders "claude[bot]" —
+            # match both (a human login can contain neither "/" nor "[bot]",
+            # so each form uniquely names the App). The original REST-only
+            # literal matched nothing under gh, silently skipping every bot PR
+            # the first time the loop went live (2026-07-21).
             eligible="$(jq -r '
               (.isDraft | not)
               and (.isCrossRepository | not)
-              and (.author.login == "claude[bot]")
+              and (.author.is_bot == true)
+              and (.author.login == "claude[bot]" or .author.login == "app/claude")
               and ((.body // "") | test("[Cc]loses #[0-9]+"))
               and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-merge") | not))
             ' <<<"$struct")"

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -237,11 +237,17 @@ jobs:
             # body-text-only filter would accept a comment from ANY user who can
             # comment on the PR as a "fresh LGTM" and force an unreviewed merge.
             # The real verdict is posted by pipeline-pr-review.yml via `gh pr
-            # comment` under the GITHUB_TOKEN, i.e. as `github-actions[bot]` — an
-            # identity a normal user CANNOT post as, so requiring it closes the
-            # forgery gap that text matching alone leaves open.
+            # comment` under the GITHUB_TOKEN — an identity a normal user CANNOT
+            # post as ("github-actions" is a GitHub-reserved account), so
+            # requiring it closes the forgery gap that text matching alone
+            # leaves open. gh's GraphQL comment authors render as
+            # "github-actions" (no [bot] suffix, and no is_bot field exists on
+            # comment authors, unlike PR authors) while REST renders
+            # "github-actions[bot]" — match both, same dual-rendering fix as
+            # the build-worker identity gate above; the REST-only literal made
+            # latest_review always empty and the loop inert.
             latest_review="$(gh pr view "$n" --repo "$REPO" --json comments \
-              --jq '[.comments[] | select(.author.login == "github-actions[bot]" and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
+              --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
             if [ -z "$latest_review" ]; then
               echo "PR #$n: no automated review verdict yet — skip."
               echo "::endgroup::"; continue


### PR DESCRIPTION
## Summary

Answers "why are the PRs not auto-merging?": the loop runs with `MODE: live`, but **two** author checks used REST-style login literals that the GraphQL-backed `gh` CLI never produces, so the loop was structurally inert — in dry-run *and* live — since it shipped:

1. **Build-worker identity gate** (`:156`): compared `.author.login == "claude[bot]"`, but `gh` renders App PR authors as **`app/claude`**. Every bot PR was skipped as "not an eligible build-worker PR" (proven by the 23:43 live-run log on #648/#649/#651). Now requires `.author.is_bot == true` **and** login in {`claude[bot]`, `app/claude`} — still exact-App-only (neither form is attainable by a human login; `/` and `[bot]` are invalid in usernames).
2. **LGTM verdict-author gate** (`:244`, caught by this PR's own review): required comment `.author.login == "github-actions[bot]"`, but `gh` renders comment authors as **`github-actions`** (no `[bot]` suffix — and comment authors carry no `is_bot` field, unlike PR authors). `latest_review` therefore always resolved empty, so even with fix 1 every PR would keep skipping at "no automated review verdict yet". Now matches both renderings; `github-actions` is a GitHub-reserved account no human can register, so the anti-forgery reasoning is unchanged.

The sibling loops (autofix/conflict-resolver/revise) gate on `.author.is_bot` and are unaffected.

## Security / privacy impact

Both changes are rendering-robustness only; the trust boundaries are preserved or tightened: the identity gate additionally pins `is_bot`, and both gates still admit only accounts a human cannot post as. No permission, secret, or path-gate changes; the governance-path human-merge routing and all downstream gates (green checks, `MERGEABLE`, verdict-freshness vs head, label pins) are untouched.

## How verified

- Fix 1 diagnosed from live run 29788109711 (`MODE: live`, all three bot PRs rejected at the identity gate). Fix 2 verified by the automated review against this repo's actual comment JSON (`gh pr view 648 --json comments` → `{"login":"github-actions"}`).
- YAML parses clean; prettier clean.
- After merge, the next scheduled tick (≤15 min) re-evaluates the queue: **#648** (oldest, green, LGTM'd) should be the first genuine auto-merge, then #649; #651 stays correctly held by its red checks. If the tick *still* skips, the run log will name the exact gate — but no further rendering-literal checks remain in the file (grepped for `author.login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4