### PR TITLE
Fix preambled review verdicts: trim at the source, keep auto-merge's strict parse

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -247,7 +247,7 @@ jobs:
             # the build-worker identity gate above; the REST-only literal made
             # latest_review always empty and the loop inert.
             latest_review="$(gh pr view "$n" --repo "$REPO" --json comments \
-              --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
+              --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("(^|\\n)PR review \\(automated\\):")))] | last // empty')"
             if [ -z "$latest_review" ]; then
               echo "PR #$n: no automated review verdict yet — skip."
               echo "::endgroup::"; continue
@@ -255,11 +255,18 @@ jobs:
             review_body="$(jq -r '.body' <<<"$latest_review")"
             review_at="$(jq -r '.createdAt' <<<"$latest_review")"
 
-            # Verdict = first 4 lines minus bullet lines, so a phrase inside a
-            # finding can't be misread as the verdict (the exact parse the
-            # review worker uses to route). Require an explicit LGTM and the
-            # absence of the two non-approving verdicts.
-            verdict="$(printf '%s' "$review_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
+            # Verdict = the first 4 lines AFTER the "PR review (automated):"
+            # marker, minus bullet lines, so a phrase inside a finding can't be
+            # misread as the verdict. The review agent sometimes prefixes its
+            # verdict comment with a preamble paragraph ("This all checks out
+            # ..."), which both broke the old start-anchored comment match and
+            # would put the wrong lines under this parse — reading from the
+            # marker onward handles marker-first and preambled comments
+            # identically (PR #649, 2026-07-21: a genuine LGTM skipped as "no
+            # verdict" purely because of a preamble). Require an explicit LGTM
+            # and the absence of the two non-approving verdicts.
+            verdict_body="${review_body#*PR review (automated):}"
+            verdict="$(printf '%s' "$verdict_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
             if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
                || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
               echo "PR #$n: latest review verdict is not an LGTM approval — skip."

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -247,7 +247,7 @@ jobs:
             # the build-worker identity gate above; the REST-only literal made
             # latest_review always empty and the loop inert.
             latest_review="$(gh pr view "$n" --repo "$REPO" --json comments \
-              --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("(^|\\n)PR review \\(automated\\):")))] | last // empty')"
+              --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
             if [ -z "$latest_review" ]; then
               echo "PR #$n: no automated review verdict yet — skip."
               echo "::endgroup::"; continue
@@ -255,18 +255,16 @@ jobs:
             review_body="$(jq -r '.body' <<<"$latest_review")"
             review_at="$(jq -r '.createdAt' <<<"$latest_review")"
 
-            # Verdict = the first 4 lines AFTER the "PR review (automated):"
-            # marker, minus bullet lines, so a phrase inside a finding can't be
-            # misread as the verdict. The review agent sometimes prefixes its
-            # verdict comment with a preamble paragraph ("This all checks out
-            # ..."), which both broke the old start-anchored comment match and
-            # would put the wrong lines under this parse — reading from the
-            # marker onward handles marker-first and preambled comments
-            # identically (PR #649, 2026-07-21: a genuine LGTM skipped as "no
-            # verdict" purely because of a preamble). Require an explicit LGTM
-            # and the absence of the two non-approving verdicts.
-            verdict_body="${review_body#*PR review (automated):}"
-            verdict="$(printf '%s' "$verdict_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
+            # Verdict = first 4 lines minus bullet lines, so a phrase inside a
+            # finding can't be misread as the verdict. The comment is GUARANTEED
+            # marker-first: the review workflow deterministically trims any
+            # agent preamble at post time (see pipeline-pr-review.yml), so the
+            # strict ^-anchored match above and this top-of-comment parse are
+            # unambiguous even when review commentary QUOTES the marker string
+            # further down (PR #656 review found substring-based extraction
+            # here was decoy-prone in both directions; anchoring the SHAPE at
+            # the source removes the ambiguity class entirely).
+            verdict="$(printf '%s' "$review_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
             if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
                || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
               echo "PR #$n: latest review verdict is not an LGTM approval — skip."

--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -148,6 +148,23 @@ jobs:
             exit 1
           fi
 
+          # Normalise the verdict to start AT the "PR review (automated):"
+          # marker: the agent sometimes prefixes a preamble paragraph ("This
+          # all checks out — ..."), and every downstream consumer (auto-merge's
+          # verdict gate, revise's precheck) parses relative to that marker —
+          # a preamble forces them to search for it mid-comment, which is
+          # ambiguous the moment commentary QUOTES the marker (as reviews of
+          # this very machinery do). Trimming here, deterministically, at the
+          # single place the comment is composed, means consumers can rely on
+          # a marker-first body. Only the FIRST line-anchored occurrence is
+          # the trim point; if the marker is absent entirely, post as-is (the
+          # no-output guard above already handled the empty case, and a
+          # marker-less review reads as "no verdict" downstream — fail-safe).
+          marker_line="$(printf '%s\n' "$review" | grep -nE '^PR review \(automated\):' | head -1 | cut -d: -f1 || true)"
+          if [ -n "$marker_line" ] && [ "$marker_line" -gt 1 ]; then
+            review="$(printf '%s\n' "$review" | tail -n +"$marker_line")"
+          fi
+
           # GitHub comment bodies cap ~65535 chars; keep well under.
           printf '%s' "$review" | head -c 60000 > review.txt
           gh pr comment "$PR" --body-file review.txt


### PR DESCRIPTION
## Summary

Answers "did #649 auto-merge on the next tick?" — no: its genuine 23:00 LGTM was skipped as *"no automated review verdict yet"* (02:08 run log) because the review agent prefixed a preamble paragraph before the `PR review (automated):` marker, and auto-merge's matcher anchors the marker to the comment start. #648 merged only because its verdict happened to start clean.

This PR's first attempt (marker-relative extraction inside auto-merge) was itself caught by review as decoy-prone: first-occurrence extraction breaks when a *preamble* quotes the literal marker; the suggested last-occurrence fix breaks the mirrored case — commentary quoting the marker in bullets *after* the real one, which the very review comment raising the issue does. Decoy-order arbitration inside the consumer can't be made unambiguous in a repo whose reviews routinely discuss this machinery.

**Final approach — anchor the shape at the source:**
1. **`pipeline-pr-review.yml`**: the deterministic post step (which composes the comment from `review.txt`) now trims everything before the first line-anchored `PR review (automated):` before posting. Posted verdicts are *guaranteed marker-first*. A marker-less review posts as-is and correctly reads as "no verdict" downstream (fail-safe); the existing empty-output guard is unchanged.
2. **`pipeline-pr-automerge.yml`**: reverts to the strict `^`-anchored comment match and top-of-comment 4-line parse — now unambiguous regardless of what the body quotes further down, with no substring extraction at all.

Trim logic exercised in bash against the three real shapes: #649's preambled LGTM (trims, classifies LGTM), #648's marker-first (line 1, untouched), and marker-less text (untouched → no-verdict).

## Security / privacy impact

Trust boundaries unchanged or tightened: the `github-actions` author identity gate is untouched (it, not the marker, is the forgery barrier); auto-merge returns to its *strictest* matcher; the trim is deterministic shell in the workflow's own post step, operating on agent output it already posts verbatim, introducing no new inputs or permissions. Revise's precheck (which selects on the same marker) also benefits from guaranteed marker-first comments.

## Post-merge note

The source-side trim fixes all *future* verdicts. #649's existing preambled comment remains unrecognized under the strict matcher, and the review workflow has no `workflow_dispatch` — so #649 needs one manual nudge: either merge it by hand (it's green with a verified LGTM), or push any trivial commit to its branch to trigger a fresh (now auto-trimmed) review. Recommend just merging it manually as the last hand-merge of the migration.

## How verified

- Diagnosed from live run 29795027000; the decoy analysis validated against the actual #656 review comment (quotes the marker in bullets after the real one).
- Trim logic run in bash against all three real comment shapes (output in the commit message).
- Both workflows parse as valid YAML; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4