### PR TITLE
Auto-merge: escalate fully-vetted governance-path PRs instead of skipping silently

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -69,6 +69,7 @@ concurrency:
 permissions:
   contents: write # merge the PR (push the merge commit to main)
   pull-requests: write # merge/comment/label
+  issues: write # `gh label create` (ensure human-merge-ready exists) uses the issues API
   actions: write # dispatch the conflict resolver to rebase the rest after a merge
 
 jobs:
@@ -87,6 +88,10 @@ jobs:
       # review) posts ONE marker-guarded note explaining the likely cause,
       # rather than silently doing nothing every tick.
       BLOCKED_MARKER: '<!-- pipeline-automerge-blocked -->'
+      # A governance-path PR that passes every other gate (green, mergeable,
+      # fresh LGTM) is labelled `human-merge-ready` + gets ONE marker-guarded
+      # comment asking a human to merge it, rather than being skipped silently.
+      READY_MARKER: '<!-- pipeline-automerge-human-ready -->'
       # OPT-IN mode gate (repository variable AUTOMERGE_MODE — Settings → Secrets
       # and variables → Actions → Variables). The default (unset) is INERT, so
       # merging this workflow onto `main` never auto-merges anything until an
@@ -181,10 +186,19 @@ jobs:
             # (Deliberately NOT including tests/security-floor.json or CHANGELOG.md
             # — those are per-PR DATA nearly every PR touches; excluding them
             # would merge nothing. This list is the files that change the RULES.)
+            #
+            # A governance hit does NOT stop evaluation, only the merge: the
+            # pipeline's own acceptance criteria make most feature PRs document
+            # themselves in docs/SECURITY.md, so a silent skip here stranded
+            # fully-vetted PRs with no signal to anyone (2026-07-21). Instead,
+            # keep evaluating; if the PR passes EVERY other gate it is labelled
+            # `human-merge-ready` with one marker-guarded comment, so the human
+            # merge it requires actually gets requested.
             files="$(gh pr view "$n" --repo "$REPO" --json files --jq '.files[].path')"
+            governance_hit='false'
             if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/SECURITY\.md$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
-              echo "PR #$n: touches a governance/CI/config path (workflows, check machinery, or governance docs) — requires human merge, skip."
-              echo "::endgroup::"; continue
+              governance_hit='true'
+              echo "PR #$n: touches a governance/CI/config path (workflows, check machinery, or governance docs) — will never auto-merge; still evaluating for the human-merge-ready escalation."
             fi
 
             # Only NOW (structurally eligible) resolve the state GitHub computes
@@ -292,6 +306,38 @@ jobs:
               --jq '[.labels[].name] | any(. == "needs-human" or . == "no-auto-merge")')"
             if [ "$has_stop" = 'true' ]; then
               echo "PR #$n: a stop label (needs-human/no-auto-merge) appeared during evaluation — aborting before merge."
+              echo "::endgroup::"; continue
+            fi
+
+            # --- Governance path: fully vetted, but the merge itself is a
+            # human's. Escalate LOUDLY (label + one marker-guarded comment)
+            # instead of the old silent skip, then keep scanning so a
+            # non-governance PR later in the queue can still merge this run.
+            # The label/comment are idempotent and posted at most once per PR;
+            # they persist across later pushes deliberately — the label means
+            # "auto-merge will never take this one", which stays true.
+            if [ "$governance_hit" = 'true' ]; then
+              if [ "$MODE" != 'live' ]; then
+                echo "PR #$n: DRY RUN (AUTOMERGE_MODE=$MODE) — fully vetted but governance-path; would label human-merge-ready."
+                echo "::endgroup::"; continue
+              fi
+              already_flagged="$(gh pr view "$n" --repo "$REPO" --json comments \
+                | jq -r --arg m "$READY_MARKER" '[.comments[].body] | any(startswith($m))')"
+              if [ "$already_flagged" != 'true' ]; then
+                echo "PR #$n: fully vetted (green + mergeable + fresh LGTM) but governance-path — flagging human-merge-ready."
+                # --force makes create idempotent (updates if it exists); the
+                # label also lives in scripts/setup-labels.sh with the rest.
+                gh label create human-merge-ready --repo "$REPO" \
+                  --color '8250DF' --description 'Fully vetted by auto-merge but touches a governance path; a human must merge' --force \
+                  || echo "::warning::Could not ensure the human-merge-ready label exists."
+                gh pr edit "$n" --repo "$REPO" --add-label human-merge-ready \
+                  || echo "::warning::Could not add the human-merge-ready label to PR #$n."
+                gh pr comment "$n" --repo "$REPO" --body "${READY_MARKER}
+          🤖 Auto-merge evaluated this PR as **fully vetted** — every check green, \`MERGEABLE\`, and a fresh automated \`LGTM\` — but it touches a governance/CI/config path (\`.github/\`, \`scripts/\`, \`package.json\`, check config, or the \`CLAUDE.md\`/\`docs/PIPELINE.md\`/\`docs/SECURITY.md\` governance docs), which always requires a **human merge** (see docs/PIPELINE.md, auto-merge loop). Labelled \`human-merge-ready\` — a maintainer just needs to press merge." \
+                  || echo "::warning::Could not post the human-merge-ready comment on PR #$n."
+              else
+                echo "PR #$n: fully vetted but governance-path — already flagged human-merge-ready, nothing to do."
+              fi
               echo "::endgroup::"; continue
             fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ is a NZ community, and the CI that opens most PRs runs in UTC (a day behind NZ
 for anything after ~noon NZST/NZDT). Get today's date with
 `TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
 
+## 2026-07-22
+
+### Changed
+- **Auto-merge now escalates governance-path PRs instead of skipping them
+  silently**: a build-worker PR that passes every gate (green CI, mergeable,
+  fresh automated LGTM) but touches a governance/CI/config path — which
+  includes `docs/SECURITY.md`, a file most feature PRs must document
+  themselves in — is labelled `human-merge-ready` with one explanatory
+  comment, so the human merge it requires actually gets requested. Previously
+  such PRs sat unmerged with no signal to anyone.
+
 ## 2026-07-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,10 @@ ownership rules:
   typecheck/lint/format config, `CLAUDE.md`, `docs/PIPELINE.md`,
   `docs/SECURITY.md`) — those always require a human merge, so the loop can
   never auto-merge a change to its own guardrails or to what "green" means.
+  A governance-path PR that passes every other gate is not skipped silently:
+  it gets a `human-merge-ready` label plus one marker-guarded comment asking
+  a maintainer to merge (most feature PRs touch `docs/SECURITY.md` to
+  document themselves, so this is the common case, not the exception).
   Never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to
   rebase the rest, and the next PR only re-qualifies once it is green against

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -121,7 +121,14 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   `docs/SECURITY.md` governance docs — so the pipeline can never auto-merge a
   change to its own guardrails or to what "green" means (and since
   `pull_request` CI runs the workflow version from the PR branch, a PR could
-  otherwise weaken a check and still show it "passing"). It merges **exactly one
+  otherwise weaken a check and still show it "passing"). Because the pipeline's
+  own acceptance criteria make most feature PRs document themselves in
+  `docs/SECURITY.md`, a governance hit is common and is NOT a silent skip: a
+  governance-path PR that passes **every other** gate (green, mergeable, fresh
+  LGTM, no stop labels) is labelled `human-merge-ready` and gets one
+  marker-guarded comment asking a maintainer to press merge — the loop still
+  never merges it itself, and it keeps scanning so a non-governance PR later
+  in the queue can still merge that run. It merges **exactly one
   PR per run**: afterwards `main` has advanced, so it dispatches the conflict
   resolver to rebase whatever now conflicts, and the next PR only re-qualifies
   once it is green against the new `main` — so a PR is never merged except

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2132,7 +2132,12 @@ number could reach an unrelated person).
       `CLAUDE.md`/`docs/PIPELINE.md`/`docs/SECURITY.md` docs — so the loop can
       never auto-merge a change to its *own* gates or to what "green" means (which
       matters because `pull_request` CI runs the workflow version from the PR
-      branch); any PR can be pinned out with `no-auto-merge`; and branch
+      branch). A governance-path PR that passes every *other* gate is escalated
+      rather than silently skipped — a `human-merge-ready` label plus one
+      marker-guarded comment — but the merge itself stays a human's; the
+      escalation adds only a label and fixed-text comment (no PR-controlled
+      content interpolated), so it widens no injection surface. Any PR can be
+      pinned out with `no-auto-merge`; and branch
       protection's required checks + who-may-merge still bound it. If you require
       the strict "no code reaches `main` without a human even if a worker is
       prompt-injected" guarantee, leave `AUTOMERGE_MODE` unset (or require a human

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -24,6 +24,7 @@ label "status:built"    "0052CC" "PR open, awaiting review/merge"
 label "needs-human"     "D93F0B" "Escalated: a human must decide"
 label "no-auto-resolve" "FBCA04" "Pin a PR out of the hourly conflict resolver (e.g. while editing it)"
 label "no-auto-merge"   "E99695" "Pin a PR out of the serialized auto-merge loop (a human will merge it)"
+label "human-merge-ready" "8250DF" "Fully vetted by auto-merge but touches a governance path; a human must merge"
 label "community-feedback" "0E8A16" "A real member/admin request; input for research proposals"
 
 # Theme areas (VISION.md) — one per proposal, so the memoryless research loop can


### PR DESCRIPTION
## Summary

The auto-merge governance gate silently skipped any PR touching a governance/CI/config path — but the pipeline's own acceptance criteria make most feature PRs document their security impact in `docs/SECURITY.md`, which is on that list. Result: fully-vetted, green, LGTM'd PRs (#658, #659) sat unmerged all day with no signal to anyone that a human merge was being waited on.

This change keeps the guardrail (no loop ever merges a governance-path PR) but makes it escalate instead of stall:

- The governance check now stops only the **merge**, not the **evaluation**. A governance-path PR that passes every other gate (green checks, `MERGEABLE`, fresh automated LGTM, no stop labels) is labelled `human-merge-ready` and gets one marker-guarded comment (`<!-- pipeline-automerge-human-ready -->`) asking a maintainer to press merge.
- The loop then `continue`s scanning, so a non-governance PR later in the queue can still merge that run.
- Label/comment are idempotent (comment posted at most once per PR, `gh label create --force` for the label itself); dry-run mode logs what it would flag without labelling.
- Added `issues: write` to the workflow's permissions (label creation uses the issues API); added `human-merge-ready` to `scripts/setup-labels.sh`; documented the behaviour in `docs/PIPELINE.md` and `CLAUDE.md`; CHANGELOG entry under 2026-07-22 (NZ).

## Security / privacy impact

No weakening of the merge gate: governance-path PRs still always require a human merge — this only adds a label and a fixed-text comment when one is waiting. The comment body is a static string (no PR-controlled content interpolated). New `issues: write` permission is used solely for idempotent label creation. No change to auth, tool gating, outbound filtering, or data access in the service itself (no `src/` changes).

## How verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run format:check` — clean
- Workflow YAML parsed with PyYAML; the embedded script extracted and passed `bash -n`; verified the multi-line `gh pr comment --body` continuation line renders at column 0 (same pattern as the existing `BLOCKED_MARKER` note)
- `npm test` not run: no TypeScript/source changes (workflow, docs, label script, changelog only); CI runs the full gate regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4)_