### PR TITLE
Build worker: deterministic post-agent checkpoint of unpushed work

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -381,6 +381,52 @@ jobs:
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git rm:*),Bash(git checkout -b:*),Bash(git switch -c:*),Bash(git rev-parse:*),Bash(git fetch origin:*),Bash(git merge origin/main),Bash(git push -u origin HEAD),Bash(git push origin HEAD),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(npm:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
 
+      # Deterministic safety net for the incremental-push mandate: agents have
+      # completed multi-hour builds and still never pushed (issue #633's third
+      # attempt: implementation done, gates green, zero pushes — everything
+      # died with the runner). Prompt-only compliance is unreliable, so after
+      # the agent has EXITED, push whatever it committed. This is the #663
+      # adversarial review's own recommended shape: a post-step publish with
+      # the job's GITHUB_TOKEN (valid for the whole job, unlike the ~1h App
+      # token), no adversarial-exfil window (the agent process is gone), and
+      # branch pushes trigger no workflows. If the remote branch exists with
+      # different history (a prior attempt), the checkpoint goes to a unique
+      # -ckpt-<run_id> ref instead of force-pushing over anything.
+      - name: Checkpoint unpushed work (deterministic)
+        if: always() && env.HAS_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+          if [ -z "${branch}" ] || [ "${branch}" = "main" ] || [ "${branch}" = "HEAD" ]; then
+            echo "No work branch in the workspace — nothing to checkpoint."; exit 0
+          fi
+          ahead="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+          if [ "${ahead}" -eq 0 ]; then
+            echo "No commits beyond origin/main — nothing to checkpoint."; exit 0
+          fi
+          head_sha="$(git rev-parse HEAD)"
+          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)"
+          if [ "${remote_sha}" = "${head_sha}" ]; then
+            echo "Branch ${branch} already pushed at ${head_sha}.";
+            echo "CKPT_REF=${branch}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if git push "${push_url}" "HEAD:refs/heads/${branch}" 2>/dev/null; then
+            echo "Checkpointed ${branch} at ${head_sha}."
+            echo "CKPT_REF=${branch}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
+          else
+            alt="${branch}-ckpt-${{ github.run_id }}"
+            if git push "${push_url}" "HEAD:refs/heads/${alt}"; then
+              echo "Remote ${branch} diverged; checkpointed to ${alt} at ${head_sha}."
+              echo "CKPT_REF=${alt}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
+            else
+              echo "::warning::Checkpoint push failed — unpushed work will die with this runner."
+            fi
+          fi
+
       - name: Verify a PR was produced (else escalate + fail loudly)
         if: always() && env.HAS_TOKEN == 'true'
         env:
@@ -445,12 +491,22 @@ jobs:
             # unauthenticated `git ls-remote` would silently fail on a private
             # repo and the escalation would never name the branch.
             surviving=""
-            branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-            if [ -n "${branch}" ] && [ "${branch}" != "main" ] && [ "${branch}" != "HEAD" ]; then
-              remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)"
-              if [ -n "${remote_sha}" ]; then
-                surviving="$(printf 'Pushed work SURVIVES on branch `%s` at commit `%s` — a re-queued build resumes from it via the deterministic resolve-resume pre-step (comment text is never trusted for this).' "${branch}" "${remote_sha}")"
+            # Prefer the checkpoint step's already-verified ref; fall back to a
+            # live lookup. Either way the sha must be exactly 40 hex chars —
+            # `gh api` prints its ERROR BODY to stdout on a 404 (issue #633's
+            # escalation interpolated a JSON error into this template; the
+            # resume pre-step's strict regex rejected it, but the line lied).
+            branch="${CKPT_REF:-}"; remote_sha="${CKPT_SHA:-}"
+            if [ -z "${branch}" ]; then
+              branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+              if [ -n "${branch}" ] && [ "${branch}" != "main" ] && [ "${branch}" != "HEAD" ]; then
+                remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)"
+              else
+                branch=""
               fi
+            fi
+            if [ -n "${branch}" ] && printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then
+              surviving="$(printf 'Pushed work SURVIVES on branch `%s` at commit `%s` — a re-queued build resumes from it via the deterministic resolve-resume pre-step (comment text is never trusted for this).' "${branch}" "${remote_sha}")"
             fi
             # Defence-in-depth for the resolve-resume pre-step's template
             # match: the agent's free-text summary is embedded in this same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ for anything after ~noon NZST/NZDT). Get today's date with
 
 ## 2026-07-25
 
+### Changed
+- **The pipeline's build worker now checkpoints committed work
+  deterministically**: a post-agent workflow step pushes any
+  committed-but-unpushed branch with the job's own token (to a unique
+  `-ckpt` ref if the remote diverged), because agents completed entire
+  multi-hour builds without ever pushing (#633) and everything died with the
+  runner. Escalation forensics also now validate the commit sha shape, so a
+  404 error body can no longer masquerade as a surviving-branch pointer.
+
 ### Added
 - **WhatsApp admins can now block a persistent abuser** (#572): `moderate`
   gains `block_user`/`unblock_user` (WhatsApp only — Discord keeps its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,10 @@ ownership rules:
   are free) because the job's GitHub credential can expire mid-build (~1h vs the
   120-min budget) and an unpushed tree dies with the runner; the PR still opens
   only at the end, so the verify-step/groundskeeper "no PR = dead build"
-  contract is unchanged. Its escalation comment names any surviving pushed
+  contract is unchanged. A deterministic post-agent **checkpoint step** pushes
+  any committed-but-unpushed work with the job's GITHUB_TOKEN (agents have
+  finished whole builds without ever pushing — #633), so nothing committed can
+  die with the runner. Its escalation comment names any surviving pushed
   branch + commit, and a re-queued build resumes from that branch instead of
   rebuilding (issue #667) — the pointer is resolved by a deterministic
   pre-step (bot comments only, exact template, remote-verified), never by the

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -413,7 +413,12 @@ sessions:
   Branch pushes are free (no PR exists yet, `on: push` is main-only), and the
   PR still opens only at the end, so the "no PR = dead build" contract the
   verify step and groundskeeper enforce is unchanged (issue #663's rejection
-  documents why an *early PR* is the wrong fix). Its final-attempt escalation
+  documents why an *early PR* is the wrong fix). Because prompt-only
+  compliance proved unreliable (#633: a full green build, zero pushes), a
+  deterministic **checkpoint step** after the agent exits pushes any
+  committed-but-unpushed work with the job's GITHUB_TOKEN — to the work
+  branch, or a unique `-ckpt-<run_id>` ref if the remote diverged — so
+  committed work can no longer die with the runner. Its final-attempt escalation
   clears **both** `status:building`
   and `status:approved` when adding `needs-human`, so an escalated issue fully
   leaves the automated lanes — leaving `status:approved` behind let the hourly


### PR DESCRIPTION
## Summary

Issue #633's third build attempt proved that prompt-only compliance with the incremental-push mandate (#667/#673) is unreliable: the agent completed the entire `suggest_knowledge` implementation, ran every gate green across 2.5 hours — and never pushed once, so all of it died with the runner for the third time on that issue.

- **New `Checkpoint unpushed work (deterministic)` step** in `pipeline-build.yml`, after the agent step, `if: always()`: if the workspace has a non-main branch with commits beyond `origin/main` that aren't on the remote, it pushes them with the job's `GITHUB_TOKEN` (valid job-long, unlike the ~1h App token the agent uses). If the remote branch exists with diverged history from a prior attempt, it checkpoints to a unique `<branch>-ckpt-<run_id>` ref instead of force-pushing over anything. The pushed ref/sha are exported and preferred by the escalation forensics.
- **Forensics fix**: `gh api` prints its error body to *stdout* on 404, so #633's escalation interpolated a JSON error into the "Pushed work SURVIVES on branch … at commit …" template (the resume pre-step's strict 40-hex regex rejected the forged-looking pointer, so no behavioural harm — but the line lied). Survival is now claimed only with an exact 40-hex sha, sourced from the checkpoint step's verified output or a validated live lookup.
- Docs (`docs/PIPELINE.md`, `CLAUDE.md`) and `CHANGELOG.md` (2026-07-25 NZ) updated.

## Security / privacy impact

This is the deterministic post-step publish the #663 adversarial review itself recommended: it runs only after the agent process has exited, so there is no adversarial-exfil window for the token (same reasoning as `persist-credentials: false` on checkout); branch pushes trigger no workflows (`on: push` is main-only, no PR exists); nothing is merged, reviewed, or executed from a checkpointed branch until the normal PR + review path runs; and the no-force-push property is preserved (divergence goes to a fresh unique ref). No new permissions — the job already holds `contents: write`.

## How verified

- Workflow YAML parses (PyYAML); both modified step scripts pass `bash -n`.
- `npm run format:check` clean; no `src/`/test changes (workflow + docs + changelog only).
- The 40-hex validation regex matches real shas and rejects the exact 404-JSON shape observed in #633's escalation comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4)_