### PR TITLE
Deflake reply-budget assertions by scoping them to a run-unique identity

### DIFF
--- a/tests/repeatMaxTurnsShortcutRouter.test.ts
+++ b/tests/repeatMaxTurnsShortcutRouter.test.ts
@@ -16,7 +16,19 @@ process.env.DISCORD_GUILD_ID ??= '1';
 const hasDb = Boolean(process.env.DATABASE_URL);
 process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
 process.env.WHATSAPP_PROVIDER ??= 'disabled';
-process.env.SUPER_ADMIN_DISCORD_IDS ??= 'super-1,super-2';
+// Run-unique identity used ONLY by the reply-budget assertion below.
+// `countRepliesToUser` aggregates outbound replies for an IDENTITY across the
+// whole `interactions` table over a sliding 24h window — that is what a daily
+// budget means, so the read cannot be conversation-scoped. Counting the shared
+// 'super-1' fixture id therefore absorbs any concurrent insert another test
+// file makes for that same identity, and test files run as parallel processes
+// against ONE Postgres. A per-process id no other file can ever write makes
+// interference structurally impossible rather than merely improbable (issue
+// #675 preferred exactly this scoping over the retry it ultimately shipped).
+// Registered as a super admin so the identity still resolves to the same tier
+// 'super-1' did, keeping the exercised router path unchanged.
+const BUDGET_USER_ID = `budget-super-${process.pid}-${Date.now()}`;
+process.env.SUPER_ADMIN_DISCORD_IDS ??= `super-1,super-2,${BUDGET_USER_ID}`;
 process.env.SUPER_ADMIN_WHATSAPP_NUMBERS ??= 'super-1';
 process.env.REPEAT_MAX_TURNS_SHORTCUT_ENABLED = 'true';
 
@@ -46,13 +58,18 @@ const RUN = `repeatmt-router-${Date.now()}`;
  * interactions table over a sliding 24h window, by design (that's what a
  * daily reply budget means), so it can't be scoped to this test's own
  * conversation_id. The Node test runner executes test FILES in parallel
- * against one shared DB, so another file's concurrent insert for the same
- * 'super-1' discord identity can land between the before/after reads and
- * shift the exact delta (issue #675: "3 !== 2"). Re-running the whole
- * read-seed-read sequence gets a quiet window with overwhelming
- * probability, while a REAL regression fails deterministically on every
- * attempt — so retrying masks nothing (mirrors
- * tests/repository.test.ts's retryOnSharedTableInterference).
+ * against one shared DB, so another file's concurrent insert for the SAME
+ * identity can land between the before/after reads and shift the exact delta
+ * (issue #675: "3 !== 2", which recurred after this retry shipped).
+ *
+ * The primary defence is now `BUDGET_USER_ID`: the budget assertion counts a
+ * per-process identity no other test file can write, so there is no longer a
+ * path by which a concurrent insert reaches the count. This retry is kept as
+ * a backstop for any future interference this file's other reads might hit,
+ * and because a REAL regression still fails deterministically on every
+ * attempt — so retrying masks nothing (mirrors tests/repository.test.ts's
+ * retryOnSharedTableInterference). Every absorbed attempt still emits a
+ * console.warn, so interference is never silent.
  */
 async function retryOnSharedTableInterference(attempts: number, run: () => Promise<void>): Promise<void> {
   for (let attempt = 1; ; attempt++) {
@@ -297,7 +314,8 @@ test(
   'router (repeat-max-turns shortcut): a served repeat-max-turns reply is recorded exactly like a real reply — meta.repeatMaxTurnsShortcut + replyToUserId — and counts toward the daily reply budget',
   { skip: !hasDb },
   async () => {
-    const userId = 'super-1';
+    // Run-unique, NOT the shared 'super-1' — see BUDGET_USER_ID's rationale.
+    const userId = BUDGET_USER_ID;
     let attempt = 0;
 
     await retryOnSharedTableInterference(4, async () => {

--- a/tests/repeatQuestionShortcutRouter.test.ts
+++ b/tests/repeatQuestionShortcutRouter.test.ts
@@ -25,7 +25,19 @@ process.env.WHATSAPP_PROVIDER ??= 'disabled';
 // "different platform" caller without ever touching the (unreachable in
 // these tests) community_users DB lookup non-super-admins would fall through
 // to (which resolves to 'guest' and hits the gated-guest branch instead).
-process.env.SUPER_ADMIN_DISCORD_IDS ??= 'super-1,super-2';
+// Run-unique identity used ONLY by the reply-budget assertion below.
+// `countRepliesToUser` aggregates outbound replies for an IDENTITY across the
+// whole `interactions` table over a sliding 24h window — that is what a daily
+// budget means, so the read cannot be conversation-scoped. Counting the shared
+// 'super-1' fixture id therefore absorbs any concurrent insert another test
+// file makes for that same identity, and test files run as parallel processes
+// against ONE Postgres. A per-process id no other file can ever write makes
+// interference structurally impossible rather than merely improbable (issue
+// #675 preferred exactly this scoping over the retry it ultimately shipped).
+// Registered as a super admin so the identity still resolves to the same tier
+// 'super-1' did, keeping the exercised router path unchanged.
+const BUDGET_USER_ID = `budget-super-${process.pid}-${Date.now()}`;
+process.env.SUPER_ADMIN_DISCORD_IDS ??= `super-1,super-2,${BUDGET_USER_ID}`;
 process.env.SUPER_ADMIN_WHATSAPP_NUMBERS ??= 'super-1';
 process.env.REPEAT_QUESTION_SHORTCUT_ENABLED = 'true';
 
@@ -55,13 +67,18 @@ const RUN = `repeatq-router-${Date.now()}`;
  * interactions table over a sliding 24h window, by design (that's what a
  * daily reply budget means), so it can't be scoped to this test's own
  * conversation_id. The Node test runner executes test FILES in parallel
- * against one shared DB, so another file's concurrent insert for the same
- * 'super-1' discord identity can land between the before/after reads and
- * shift the exact delta (issue #675: "3 !== 2"). Re-running the whole
- * read-seed-read sequence gets a quiet window with overwhelming
- * probability, while a REAL regression fails deterministically on every
- * attempt — so retrying masks nothing (mirrors
- * tests/repository.test.ts's retryOnSharedTableInterference).
+ * against one shared DB, so another file's concurrent insert for the SAME
+ * identity can land between the before/after reads and shift the exact delta
+ * (issue #675: "3 !== 2", which recurred after this retry shipped).
+ *
+ * The primary defence is now `BUDGET_USER_ID`: the budget assertion counts a
+ * per-process identity no other test file can write, so there is no longer a
+ * path by which a concurrent insert reaches the count. This retry is kept as
+ * a backstop for any future interference this file's other reads might hit,
+ * and because a REAL regression still fails deterministically on every
+ * attempt — so retrying masks nothing (mirrors tests/repository.test.ts's
+ * retryOnSharedTableInterference). Every absorbed attempt still emits a
+ * console.warn, so interference is never silent.
  */
 async function retryOnSharedTableInterference(attempts: number, run: () => Promise<void>): Promise<void> {
   for (let attempt = 1; ; attempt++) {
@@ -390,7 +407,8 @@ test(
   'router (repeat-question shortcut): a served repeat-shortcut reply is recorded exactly like a real answer — meta.repeatShortcut + replyToUserId — and counts toward the daily reply budget',
   { skip: !hasDb },
   async () => {
-    const userId = 'super-1';
+    // Run-unique, NOT the shared 'super-1' — see BUDGET_USER_ID's rationale.
+    const userId = BUDGET_USER_ID;
     let attempt = 0;
 
     await retryOnSharedTableInterference(4, async () => {


### PR DESCRIPTION
Closes #684. Follow-up to #675, whose retry-based remedy has been exhausted twice in CI.

## Summary

The reply-budget assertions in both shortcut-router tests count via `countRepliesToUser`, which aggregates outbound replies for an **identity** across the whole `interactions` table over a sliding 24h window. That read cannot be conversation-scoped — a daily budget is per-user by definition — so counting the shared `'super-1'` fixture id absorbed any concurrent insert another test file made for that same identity, and test files run as parallel processes against one Postgres.

#675 addressed this with a bounded retry. It recurred after that shipped, on PR #683's CI:

- `90a91a0` — both files, `4 !== 2`
- `0348ab9` — `repeatMaxTurnsShortcutRouter.test.ts:327`, `3 !== 2` (#675's exact recorded signature)

Both runs exhausted the retry and burned the ci-retry rerun, on a diff that touches none of this.

#675's own acceptance criteria ranked scoping **above** retrying — *"Prefer scoping over retrying … deterministic, no absorb logic needed"* — and this applies that first option. Each budget assertion now counts a per-process `BUDGET_USER_ID` that no other test file can write, registered through the `SUPER_ADMIN_DISCORD_IDS` env each file already sets (the runner isolates env per file), so the identity resolves to the same tier `'super-1'` did and the exercised router path is unchanged.

`retryOnSharedTableInterference` is deliberately kept in both files as a backstop for their other reads, still emitting a `console.warn` per absorbed attempt, and each assertion still pins the exact expected count so a genuine regression fails deterministically. Their doc comments are updated, since they described counting `'super-1'` — no longer true of the budget path.

## Security / privacy impact

None. Test-only: no `src/` changes, so router and shortcut production behaviour is byte-for-byte untouched. No change to auth, tool gating, data-access scope, or stored data.

`tests/security-floor.json` is deliberately **not** modified — neither assertion is `SECURITY:`-prefixed, so no count changes. The only tier-adjacent detail is that the new fixture identity is registered as a super admin, purely so it resolves to the same tier the previous fixture id did; it exists only inside these two test files' env.

## How verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx prettier --check .` — clean
- `npm test` — 2419 tests, 596 skipped. 3 failures remain, all pre-existing on `main` and **unrelated to this diff** (two `docsIngest` and one `agentCoreKnowledgeEntryId` test that reach a live DB without `DATABASE_URL`); they are fixed by PR #683 and are not touched here.
- `npm run build` — clean
- Scope confirmed: `git diff --stat` lists only the two test files.

Verified by inspection that no path remains by which another file's concurrent `interactions` insert can reach either asserted count, since the counted identity is unique per process.

The flake itself is probabilistic, so CI passing once is not proof — but the argument here is structural rather than statistical: the counted identity is no longer shared, so there is nothing left to interfere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN83WBFzsHe9ZX1d5NYsLV)_