### PR TITLE
Build budget 120→180 min; groundskeeper stale threshold 3h→4h in lockstep

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -284,7 +284,7 @@ jobs:
                PUSH INCREMENTALLY: run `git push -u origin HEAD` right after
                your FIRST commit, and `git push origin HEAD` after EVERY
                subsequent commit — the job's GitHub credential can expire
-               mid-build (~1h lifetime vs this job's 120-min budget), and an
+               mid-build (~1h lifetime vs this job's 180-min budget), and an
                unpushed tree dies with the runner (this stranded 6+ finished
                builds on 2026-07-20/22). Branch pushes trigger no CI and no PR
                exists yet, so intermediate pushes are free; do NOT open the PR
@@ -380,9 +380,9 @@ jobs:
           # (issue #27); 80 died at turn 81 on a repo-wide job (issue #41,
           # ESLint+Prettier — formatting sweeps and lint-fix iteration eat
           # turns fast). 300 gives real proposals room to finish; the
-          # `timeout-minutes` above (120) is the wall-clock guard — solo, 300
+          # `timeout-minutes` above (180) is the wall-clock guard — solo, 300
           # turns ≈ 40 min (~7s/turn), but under shared-pool throttling a
-          # legitimate build runs slower, which is why the guard is 120 not 60.
+          # legitimate build runs slower, which is why the guard is 180, not 60.
           claude_args: |
             --max-turns 300
             --model sonnet

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -82,10 +82,17 @@ jobs:
     # the Max pool, so under contention turns are throttled and a legitimate
     # build runs several× slower — 60 min was killing real builds mid-gate (the
     # 2026-07-04 spiral: cancelled at 60 min with `npm test` still running), and
-    # a cancelled run is not retried. 120 gives a contended build room to finish
-    # instead of being killed. Still well under GitHub's 6 h job cap; a genuinely
-    # hung run is still caught by the verify step (and costs at most 2 h).
-    timeout-minutes: 120
+    # a cancelled run is not retried. 120 was then killing real builds too once
+    # the suite grew past ~2300 tests (a full gate pass is ~10 min and a build
+    # runs it 2-3×; issue #633 died at the 120 wall on FOUR consecutive
+    # campaigns, twice with the implementation finished). 180 fits the observed
+    # cost of a real feature build under contention. Two constraints keep this
+    # honest: the groundskeeper's STALE_HOURS must exceed this budget (it is 4h
+    # — keep them in sync when changing either), and a job-level timeout kills
+    # even `if: always()` steps, so the checkpoint/verify/escalate machinery
+    # never runs on a timed-out build — the wall must therefore be a genuine
+    # outlier, not the common case. Still well under GitHub's 6 h job cap.
+    timeout-minutes: 180
     # A real pgvector Postgres so the worker's OWN verification runs the
     # DB-integration tests (which skip without DATABASE_URL) against the same
     # database CI will use on the PR. Without this the worker "passes" locally

--- a/.github/workflows/pipeline-groundskeeper.yml
+++ b/.github/workflows/pipeline-groundskeeper.yml
@@ -26,10 +26,11 @@ name: Pipeline groundskeeper
 # it. A human re-queues by removing `needs-human` and re-adding
 # `status:approved`.
 #
-# STALE_HOURS (3) deliberately exceeds the build job's 120-min
-# `timeout-minutes` plus claim-comment lag: each build attempt re-claims with
-# a fresh comment (bumping the issue's updatedAt), so an issue quiet for 3h
-# cannot have a live build attempt behind it.
+# STALE_HOURS (4) deliberately exceeds the build job's 180-min
+# `timeout-minutes` (keep them in sync when changing either) plus
+# claim-comment lag: each build attempt re-claims with a fresh comment
+# (bumping the issue's updatedAt), so an issue quiet for 4h cannot have a
+# live build attempt behind it.
 
 on:
   schedule:
@@ -51,7 +52,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
-      STALE_HOURS: 3
+      STALE_HOURS: 4
     steps:
       - name: Escalate zombie status:building issues
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,8 @@ ownership rules:
 - The **groundskeeper sweep** (`pipeline-groundskeeper.yml`) is the
   deterministic, no-LLM hourly reconciler for zombie pipeline state: any open
   `status:building` issue with no open same-repo PR closing it and no
-  activity for 3h+ is escalated `needs-human` (both status labels cleared).
-  It exists because a build job that hits its 120-min timeout reports
+  activity for 4h+ is escalated `needs-human` (both status labels cleared).
+  It exists because a build job that hits its 180-min timeout reports
   `cancelled` — invisible to both the failure-keyed retry loop and the
   final-attempt escalation — and a dead fallback-Routine claim leaves no run
   at all; either way the issue previously sat `status:building` forever,
@@ -162,7 +162,7 @@ ownership rules:
   It also **pushes its branch incrementally** (after the first commit and every
   commit thereafter — branch pushes trigger no CI and no PR exists yet, so they
   are free) because the job's GitHub credential can expire mid-build (~1h vs the
-  120-min budget) and an unpushed tree dies with the runner; the PR still opens
+  180-min budget) and an unpushed tree dies with the runner; the PR still opens
   only at the end, so the verify-step/groundskeeper "no PR = dead build"
   contract is unchanged. A deterministic post-agent **checkpoint step** pushes
   any committed-but-unpushed work with the job's GITHUB_TOKEN (agents have

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -403,11 +403,11 @@ sessions:
   status:approved`, implements on a branch, opens a PR "Closes #N", relabels
   `status:built`. Builds run **per-issue** (each issue its own `concurrency`
   group — distinct issues in parallel, no cross-eviction); `--max-turns 300` +
-  a 120-min job timeout bound a run, sized generously so a pool-contended
+  a 180-min job timeout bound a run, sized generously so a pool-contended
   build finishes slowly instead of being killed mid-gate (see the WIP-caps
   bullet above). The worker **pushes its branch incrementally** — right after
   the first commit and after every commit thereafter — because the job's
-  GitHub credential lives ~1h while the job budget is 120 min, and an unpushed
+  GitHub credential lives ~1h while the job budget is 180 min, and an unpushed
   tree dies with the runner (the 2026-07-20/22 strandings: 6+ builds finished
   every gate green, then lost everything to a 401 at the single final push).
   Branch pushes are free (no PR exists yet, `on: push` is main-only), and the
@@ -436,10 +436,10 @@ sessions:
 - `.github/workflows/pipeline-groundskeeper.yml` — deterministic (no model,
   no Max pool) hourly reconciliation sweep, same trust class as auto-merge:
   any open `status:building` issue with **no open same-repo PR** closing it
-  and **no activity for 3h+** is escalated to `needs-human` (both status
+  and **no activity for 4h+** is escalated to `needs-human` (both status
   labels removed) with an explanatory comment. This is the enforcement behind
   the state machine's "building means a build is in flight" invariant: a
-  build job that hits its 120-min timeout reports `cancelled` — which the
+  build job that hits its 180-min timeout reports `cancelled` — which the
   failure-keyed retry loop never re-runs and the final-attempt escalation
   never sees — and a dead fallback-Routine claim leaves no run at all; both
   previously zombied forever (the 2026-07-20 incident: four zombie


### PR DESCRIPTION
## Summary

Issue #633 has now died at the 120-minute wall on **four consecutive build campaigns** — twice with the implementation demonstrably finished (per its escalation summaries). The wall's original sizing math ("solo ≈ 40 min, 120 gives contended builds room") predates this week's suite growth: at ~2,380 tests a full gate pass is ~10 minutes and a build legitimately runs it 2–3×, on top of agent turns throttled by Max-pool contention. 120 minutes has become the common case, not the outlier — and a job-level timeout kills even `if: always()` steps, so the checkpoint/verify/escalation machinery never runs on a timed-out build. Every recovery mechanism this repo added this week is moot for timeout deaths; the only fix is making the wall an actual outlier again.

- `pipeline-build.yml`: `timeout-minutes` 120 → 180, with the comment rewritten to document the observed cost model and the two constraints (groundskeeper sync; timeout kills always() steps).
- `pipeline-groundskeeper.yml`: `STALE_HOURS` 3 → 4 **in the same diff** — at 3h it would sweep a legitimately-running 3-hour build mid-flight. Both comments now name the in-sync constraint explicitly.
- `CLAUDE.md` / `docs/PIPELINE.md`: the 120-min/3h references updated to match.

## Security / privacy impact

None — two numeric workflow knobs and doc sync. No permission, trigger, gate, or code changes. The state-machine contract is unchanged: dead builds still escalate via verify-step/groundskeeper; the thresholds just moved together so neither fires on a healthy build.

## How verified

- Both workflow files parse (PyYAML); `npm run format:check` clean.
- No `src/`/test changes.
- Cross-checked every remaining `120-min`/`3h` reference in the governance docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgbsyHE2BYCjZPCW7sBtD4)_