### PR TITLE
Deflake usageStats topUsers by asserting scope, not rank; constant-time verify-token compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ for anything after ~noon NZST/NZDT). Get today's date with
   already did: the supplementary signal is dropped and the search results are
   still returned.
 
+### Security
+- **The WhatsApp Cloud webhook verification handshake now compares its
+  `hub.verify_token` in constant time.** The signature path on the same
+  adapter already used `timingSafeEqual`; this closes the remaining `===`
+  comparison of a caller-supplied value against a configured secret. Both
+  sides are hashed before comparison so an attacker-chosen token length can
+  neither throw nor reveal the configured token's length. Low severity — a
+  one-off setup handshake where network jitter dominates the signal — but it
+  removes the last early-exit secret comparison on that path.
+
 ## 2026-07-23
 
 ### Added

--- a/src/platforms/whatsapp/cloudAdapter.ts
+++ b/src/platforms/whatsapp/cloudAdapter.ts
@@ -15,6 +15,7 @@ import {
   extractMessages,
   isAllowedSender,
   parseVerificationRequest,
+  timingSafeEqualString,
   verifySignature,
   type CloudInboundMessage,
 } from './cloudWire.js';
@@ -297,7 +298,15 @@ export class WhatsAppCloudAdapter implements PlatformAdapter {
   private handleVerification(url: URL, res: ServerResponse): void {
     const verification = parseVerificationRequest(url);
     const { verifyToken } = config.whatsapp.cloud;
-    if (verification && verification.mode === 'subscribe' && verification.token === verifyToken) {
+    // Constant-time: the token is a configured secret and `verification.token`
+    // is attacker-controlled, so this must not early-exit on the first
+    // differing byte the way `===` does (the signature path above already
+    // uses timingSafeEqual for the same reason).
+    if (
+      verification &&
+      verification.mode === 'subscribe' &&
+      timingSafeEqualString(verification.token, verifyToken ?? '')
+    ) {
       res.writeHead(200, { 'Content-Type': 'text/plain' }).end(verification.challenge);
       return;
     }

--- a/src/platforms/whatsapp/cloudWire.ts
+++ b/src/platforms/whatsapp/cloudWire.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
 /**
  * Pure helpers for the WhatsApp Business Cloud API webhook wire format
@@ -26,6 +26,27 @@ export function verifySignature(
   const expected = Buffer.from(expectedHex, 'hex');
   if (expected.length !== computed.length) return false;
   return timingSafeEqual(expected, computed);
+}
+
+/**
+ * Constant-time string equality for comparing a caller-supplied value against
+ * a configured secret — the `hub.verify_token` handshake below being the one
+ * such comparison on this adapter that a `===` would otherwise decide with an
+ * early-exit, input-dependent number of byte comparisons.
+ *
+ * Both sides are SHA-256'd first so the compared buffers are always the same
+ * fixed width: `timingSafeEqual` throws outright on a length mismatch, and
+ * length-checking before it would leak the configured token's length. Hashing
+ * is what makes this safe for arbitrary, attacker-chosen input lengths.
+ *
+ * An empty/absent value on either side never matches, so an unconfigured
+ * secret can't be satisfied by an empty request parameter.
+ */
+export function timingSafeEqualString(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const digestA = createHash('sha256').update(a, 'utf8').digest();
+  const digestB = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(digestA, digestB);
 }
 
 export interface WebhookVerification {

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -171,6 +171,58 @@ const RUN = `t${Date.now()}${Math.floor(Math.random() * 1e6)}`;
  * fails deterministically on every attempt — so retrying masks nothing, and
  * the final attempt's assertion error propagates with real values.
  */
+/**
+ * Rank-independent assertion that a platform-scoped `usageStats` call's
+ * `topUsers` really is scoped to that platform.
+ *
+ * This replaces the older "the seeded user appears in topUsers" shape, which
+ * was a DIFFERENT interference mechanism from the absorbed-count deltas
+ * `retryOnSharedTableInterference` exists for, and which retrying could not
+ * fix: `topUsers` is `GROUP BY user_id ORDER BY n DESC LIMIT 5` over inbound
+ * rows in the window, and the seeded user has exactly ONE inbound row, so it
+ * competes for a top-5 slot against every other test file's concurrent
+ * traffic and is routinely evicted regardless of how many times the block is
+ * re-run (the 2026-07-25 CI flake, "discord-scoped topUsers includes the
+ * seeded discord user"). Seeding enough rows to win the slot is not viable
+ * either — `recordInteraction` embeds every message.
+ *
+ * Asserting the scope INVARIANT instead of the seeded row's rank is both
+ * interference-proof and strictly stronger: every id the scoped call returns
+ * must genuinely have an inbound row on that platform inside the window,
+ * which is exactly what a dropped/incorrect platform filter would violate,
+ * whoever happens to top the leaderboard. The non-empty check keeps it from
+ * passing vacuously — the caller seeds an inbound row on this platform in
+ * the same window, so at least one row always qualifies.
+ *
+ * The window predicate mirrors usageStats' own (`direction = 'inbound'`,
+ * `created_at > now() - $interval`, `platform = $platform`).
+ */
+async function assertTopUsersScopedToPlatform(
+  topUsers: Array<{ userId: string }>,
+  platform: 'discord' | 'whatsapp',
+  days: number,
+): Promise<void> {
+  assert.ok(
+    topUsers.length > 0,
+    `${platform}-scoped topUsers must not be empty — the caller seeded an inbound ${platform} row in this window`,
+  );
+  const ids = topUsers.map((u) => u.userId);
+  const { rows } = await pool.query(
+    `SELECT DISTINCT user_id
+       FROM interactions
+      WHERE direction = 'inbound'
+        AND platform = $1
+        AND created_at > now() - $2::interval
+        AND user_id = ANY($3)`,
+    [platform, `${days} days`, ids],
+  );
+  assert.equal(
+    rows.length,
+    ids.length,
+    `every id in ${platform}-scoped topUsers must have an inbound ${platform} row in the window — a leaked id means the platform filter was not applied`,
+  );
+}
+
 async function retryOnSharedTableInterference(attempts: number, run: () => Promise<void>): Promise<void> {
   for (let attempt = 1; ; attempt++) {
     try {
@@ -3340,10 +3392,7 @@ test(
         assert.equal(afterDiscord.inbound - beforeDiscord.inbound, 1);
         assert.equal(afterDiscord.outbound - beforeDiscord.outbound, 1);
         assert.ok(Math.abs(afterDiscord.costUsd - beforeDiscord.costUsd - 1.2) < 1e-9);
-        assert.ok(
-          afterDiscord.topUsers.some((u) => u.userId === discordUser),
-          'discord-scoped topUsers includes the seeded discord user',
-        );
+        await assertTopUsersScopedToPlatform(afterDiscord.topUsers, 'discord', days);
         assert.ok(
           !afterDiscord.topUsers.some((u) => u.userId === whatsappUser),
           'discord-scoped topUsers must never include a whatsapp-only user',
@@ -3361,10 +3410,7 @@ test(
         assert.equal(afterWhatsapp.inbound - beforeWhatsapp.inbound, 1);
         assert.equal(afterWhatsapp.outbound - beforeWhatsapp.outbound, 1);
         assert.ok(Math.abs(afterWhatsapp.costUsd - beforeWhatsapp.costUsd - 0.3) < 1e-9);
-        assert.ok(
-          afterWhatsapp.topUsers.some((u) => u.userId === whatsappUser),
-          'whatsapp-scoped topUsers includes the seeded whatsapp user',
-        );
+        await assertTopUsersScopedToPlatform(afterWhatsapp.topUsers, 'whatsapp', days);
         assert.ok(
           !afterWhatsapp.topUsers.some((u) => u.userId === discordUser),
           'whatsapp-scoped topUsers must never include a discord-only user',

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -108,6 +108,6 @@
   "whatsappBlockRouter.test.ts": 1,
   "whatsappBlockRouterOpen.test.ts": 1,
   "whatsappCloudAdapter.test.ts": 21,
-  "whatsappCloudWire.test.ts": 5,
+  "whatsappCloudWire.test.ts": 8,
   "whatsappWire.test.ts": 1
 }

--- a/tests/whatsappCloudWire.test.ts
+++ b/tests/whatsappCloudWire.test.ts
@@ -5,6 +5,7 @@ import {
   extractMessages,
   isAllowedSender,
   parseVerificationRequest,
+  timingSafeEqualString,
   verifySignature,
 } from '../src/platforms/whatsapp/cloudWire.js';
 
@@ -41,6 +42,34 @@ test('SECURITY: verifySignature rejects missing header, missing secret, and malf
 test('SECURITY: verifySignature rejects a hex signature of the wrong length', () => {
   const body = Buffer.from('{"a":1}');
   assert.equal(verifySignature(body, 'sha256=deadbeef', 'app-secret'), false);
+});
+
+test('timingSafeEqualString: identical strings match', () => {
+  assert.equal(timingSafeEqualString('verify-token', 'verify-token'), true);
+  assert.equal(timingSafeEqualString('a', 'a'), true);
+});
+
+test('SECURITY: timingSafeEqualString rejects a wrong token, including near-misses that share a prefix', () => {
+  // A prefix-sharing near-miss is exactly what a byte-at-a-time `===` would
+  // distinguish by timing; all of these must simply be false.
+  assert.equal(timingSafeEqualString('verify-token', 'verify-toke'), false);
+  assert.equal(timingSafeEqualString('verify-token', 'verify-tokenn'), false);
+  assert.equal(timingSafeEqualString('verify-token', 'Verify-token'), false);
+  assert.equal(timingSafeEqualString('verify-token', 'wrong'), false);
+});
+
+test('SECURITY: timingSafeEqualString handles length mismatches without throwing — hashing keeps the compared buffers fixed-width', () => {
+  // timingSafeEqual() itself throws on differing buffer lengths, so a naive
+  // implementation would turn an attacker-chosen length into a 500 (and an
+  // observable oracle). Both directions, including a very long input.
+  assert.equal(timingSafeEqualString('short', 'a'.repeat(10_000)), false);
+  assert.equal(timingSafeEqualString('a'.repeat(10_000), 'short'), false);
+});
+
+test('SECURITY: timingSafeEqualString never matches when either side is empty — an unset secret cannot be satisfied by an empty parameter', () => {
+  assert.equal(timingSafeEqualString('', ''), false);
+  assert.equal(timingSafeEqualString('', 'verify-token'), false);
+  assert.equal(timingSafeEqualString('verify-token', ''), false);
 });
 
 test('parseVerificationRequest: valid Meta handshake', () => {


### PR DESCRIPTION
The two follow-ups left open after #683 and #685. They're independent — happy to split if you'd rather review them separately.

## Summary

**1. `usageStats` `topUsers` flake (`tests/repository.test.ts`)**

The *"discord-scoped topUsers includes the seeded discord user"* assertion failed on #685's CI run, exhausting that file's `retryOnSharedTableInterference`. This is a **different mechanism** from the absorbed-count deltas #675/#684 addressed, and retrying structurally cannot fix it:

```sql
GROUP BY user_id ORDER BY n DESC LIMIT 5   -- over inbound rows in the window
```

`topUsers` is a top-5 leaderboard and the seeded user has exactly **one** inbound row, so it competes for a slot against every other test file's concurrent traffic and is evicted however many times the block re-runs. Seeding enough rows to win the slot isn't viable either — `recordInteraction` embeds every message.

Both rank-fragile positive assertions (discord and whatsapp) are replaced with `assertTopUsersScopedToPlatform`, which asserts the **scope invariant** instead: every id the platform-scoped call returns must genuinely have an inbound row on that platform inside the window. That is rank-independent and strictly *stronger* than the old check — it's precisely what a dropped or incorrect platform filter would violate, whoever happens to top the leaderboard — and a non-empty check stops it passing vacuously, since the caller seeds a qualifying row in the same window. The negative *"must never include the other platform's user"* assertions are unchanged.

**2. Constant-time `hub.verify_token` comparison (`src/platforms/whatsapp/`)**

`handleVerification` compared a caller-supplied token against the configured secret with `===`, which early-exits on the first differing byte, while `verifySignature` on the same adapter already used `timingSafeEqual`. Adds `timingSafeEqualString` to `cloudWire.ts` — beside `verifySignature`, keeping the crypto in the pure, unit-testable module — and uses it.

Both sides are SHA-256 hashed before comparison so the buffers are fixed-width: `timingSafeEqual` throws outright on a length mismatch, and length-checking beforehand would leak the configured token's length. Hashing is what makes it safe for arbitrary attacker-chosen lengths. An empty value on either side never matches, so an unset secret can't be satisfied by an empty request parameter.

## Security / privacy impact

Fix 2 is the security change, and it is a hardening with no behavioural change: the same tokens match, the same ones are rejected with 403. It closes the last early-exit comparison of a caller-supplied value against a configured secret on that path. Severity is low on its own — a one-off setup handshake where network jitter dominates any timing signal — which is why it was deliberately kept out of #683 rather than expanding that diff.

No change to auth, tier derivation, tool gating, data-access scope, outbound filtering, or stored data. Fix 1 is test-only.

`tests/security-floor.json`: `whatsappCloudWire.test.ts` 5 → 8 for the three new `SECURITY:` tests, regenerated with `npm run test:security:fix` rather than hand-counted.

## How verified

Full gate green locally (no local Postgres, so DB-backed tests skip):

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx prettier --check .` — clean
- `npm test` — 2425 tests, **0 fail** (1825 pass, 600 skip)
- `npm run test:security` — 881 across 111 files, manifest matches
- `npm run build` — clean

The three new `timingSafeEqualString` tests run without a DB and pass locally, including the length-mismatch case that a naive `timingSafeEqual` would throw on. `tests/whatsappCloudAdapter.test.ts` passes unchanged, so the handshake's accept/reject behaviour is unaffected.

Fix 1's assertion is DB-backed and therefore CI-verified only. Note it cannot be *proven* by a green run — the old assertion also passed most of the time. The argument is structural: the new assertion has no dependence on rank, which is the only thing that was failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN83WBFzsHe9ZX1d5NYsLV)_