### PR TITLE
deps: bump @anthropic-ai/claude-agent-sdk 0.3.201 → 0.3.220

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "community-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.201",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
         "@whiskeysockets/baileys": "6.7.23",
@@ -40,22 +40,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.201.tgz",
-      "integrity": "sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.201",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.201"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.201.tgz",
-      "integrity": "sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +77,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.201.tgz",
-      "integrity": "sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.201.tgz",
-      "integrity": "sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.201.tgz",
-      "integrity": "sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +116,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.201.tgz",
-      "integrity": "sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.201.tgz",
-      "integrity": "sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -142,9 +142,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.201.tgz",
-      "integrity": "sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -155,9 +155,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.201",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.201.tgz",
-      "integrity": "sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.201",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
     "@whiskeysockets/baileys": "6.7.23",


### PR DESCRIPTION
The deliberate version of the bump #688 backed out. This is the package that enforces the repo's tool-gating invariants, so **the behavioural review is the substance here, not the version number.**

## How it was reviewed

The package ships no changelog, so I diffed the shipped type declarations between the two versions. The four levers `agent/core.ts`'s `buildQueryOptions` depends on are **byte-identical** — same names, same types, same doc comments:

| Lever | Used for |
|---|---|
| `tools` | built-in allowlist — `[]`, or `['WebSearch']` for admin+ |
| `allowedTools` | tier-derived auto-approve list |
| `disallowedTools` | `Task`, `WebFetch`, and `WebSearch` below admin |
| `permissionMode` / `PermissionMode` | `'default'` |

`tool()` and `CreateSdkMcpServerOptions` are unchanged as well, so the in-process MCP server in `agent/tools.ts` is unaffected.

## One real behavioural change

The SDK MCP **tool-call timeout moved**:

- 0.3.201 — *"If your SDK MCP calls will run longer than 60s, override `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`"*
- 0.3.220 — *"Tool calls are bounded by the MCP tool-call timeout — the `MCP_TOOL_TIMEOUT` env var (ms), effectively unbounded by default"*

So the implicit ~60s ceiling on a tool call is gone, and this repo sets neither env var.

I judged this acceptable rather than fixing it here: every community tool is a Postgres query, and `storage/db.ts` already bounds those independently via `statement_timeout`, `query_timeout` and `connectionTimeoutMillis` (all `config.db.*`). A hung tool call therefore still terminates at the DB layer rather than relying on the SDK's timeout. Worth revisiting if a non-DB tool is ever added — happy to set `MCP_TOOL_TIMEOUT` explicitly if you'd prefer a belt-and-braces bound now.

## Everything else is additive and inert here

New hook input types, new telemetry fields, a `matchedAskRule` field on the `canUseTool` callback (unused — `core.ts` gates via `allowedTools`, not `canUseTool`), and **three new built-in tools**: `RefreshMcpTools`, `SendFeedback`, `ProposeSkills`.

Those new built-ins are worth a sentence, because a growing built-in surface is exactly the thing that could quietly widen a turn's capability. They're structurally unreachable: `tools` is an explicit **allowlist**, not a denylist, so anything the SDK adds is excluded by default. That's precisely what the existing `SECURITY: members/guests get NO built-in tools; admin+ get exactly WebSearch` test pins — and it passes unchanged against the larger surface, so the allowlist model is verified rather than merely asserted.

## Security / privacy impact

No source changes — `package.json` and `package-lock.json` only. No change to tier derivation, tool gating, data-access scope, outbound filtering, confirm flow, or stored data. `tests/security-floor.json` untouched (881 across 111 files).

The security-relevant surface *is* this dependency, which is why the review above is the deliverable. Net finding: the gating contract is unchanged, one timeout default relaxed with an existing independent backstop.

## How verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx prettier --check .` — clean
- `npm test` — 2425 tests, **0 fail** (1825 pass, 600 skip)
- `npm run test:security` — 881 across 111 files, manifest matches
- `npm run build` — clean

Specifically re-ran the 14 tool-gating assertions in `tests/agentOptions*.test.ts` against the new SDK — tier surfaces, `WebFetch`/`Task` denial for every tier, empty `settingSources`, and the `allowedTools`-vs-`rbac.ts` drift check. All pass.

Scope check: `git diff --stat` shows only `package.json` and `package-lock.json`; the lockfile moves the SDK and its eight per-platform optional deps and nothing else — no repeat of #688's incidental drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN83WBFzsHe9ZX1d5NYsLV)_