### PR TITLE
Skip docs-ingest URLs that have 404'd for N consecutive runs (#611)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -314,6 +314,16 @@ DOCS_INGEST_CONCURRENCY=5
 # Set empty to ingest the whole corpus. Tune to taste (e.g. drop api/go but keep
 # api/python by removing it from this list).
 DOCS_INGEST_EXCLUDE_PATHS=api/go,api/csharp,api/java,api/python,api/typescript,api/ruby,api/php,api/cli,api/compliance
+# Dead-URL skipping: the upstream index habitually lists pages that don't exist
+# (one observed run: 157/586 404ing, all under api/terraform/beta/*). After this
+# many CONSECUTIVE runs of failing to fetch, a page URL is reported ONCE and
+# then skipped instead of being re-fetched every run. Set 0 to disable skipping
+# (fetch every listed page every run, as before).
+DOCS_INGEST_DEAD_URL_RUNS=3
+# How long a skipped URL stays skipped before one re-probe. This makes the skip
+# self-healing: if upstream restores the page the re-probe succeeds and it
+# rejoins the normal fetch set automatically.
+DOCS_INGEST_DEAD_URL_RECHECK_DAYS=30
 # Knowledge link-rot check: a ~weekly job HEAD-checks every knowledge entry's
 # sourceUrl and flags dead citations for admin review (list_knowledge
 # sourceUnreachable filter). Off by default. sourceUrl is admin-authored only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ for anything after ~noon NZST/NZDT). Get today's date with
   is unset.
 
 ### Fixed
+- **Docs ingest stops re-fetching pages the upstream index lists but doesn't
+  have** (#611): Anthropic's `llms.txt` habitually lists a tranche of dead
+  pages — one observed run had 157 of 586 returning 404, all under
+  `api/terraform/beta/*` — and every weekly run re-requested all of them. A
+  page that fails to fetch on `DOCS_INGEST_DEAD_URL_RUNS` consecutive runs
+  (default 3, so ~3 weeks at the weekly cadence) is now reported **once** and
+  then skipped, instead of costing a request and a log line every week. The
+  skip is self-healing rather than permanent: each skipped page is re-probed
+  once every `DOCS_INGEST_DEAD_URL_RECHECK_DAYS` (default 30), so if Anthropic
+  restores the page it silently rejoins the normal fetch set with no operator
+  action. Set `DOCS_INGEST_DEAD_URL_RUNS=0` to keep fetching everything every
+  run. This completes the second half of #611 — the first half (batching the
+  404 log spam into one summary line) shipped in #613. No knowledge can be lost
+  by a skip: pruning still keys off the index, never off fetch success.
 - **`knowledge_search` no longer throws away a good answer when a secondary
   lookup fails.** The advisory conflict-badge check and the below-floor
   lexical fallback were the only two unguarded database calls in the handler,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -477,6 +477,15 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
   off the **index**, not fetch success — a `'docs'` chunk is removed only when
   its page is no longer listed in the index at all, so a page that transiently
   404s/times out (the index habitually lists some dead URLs) is never deleted.
+  That same dead-URL habit is also bounded on the *fetch* side (issue #611): a
+  URL that fails `DOCS_INGEST_DEAD_URL_RUNS` consecutive runs (default 3, ~3
+  weeks at the weekly cadence; `0` disables) is reported once and then skipped
+  rather than re-fetched every run, with one re-probe every
+  `DOCS_INGEST_DEAD_URL_RECHECK_DAYS` so an upstream fix self-heals with no
+  operator action. This changes only which *already-listed, first-party* URLs
+  are requested — it can neither widen the fetch set nor delete knowledge
+  (pruning still keys off the index, per above), and the streak table holds
+  URLs only, no user identifier.
   Bounds:
   fixed source URL (override-only), `DOCS_INGEST_MAX_PAGES`/
   `DOCS_INGEST_MAX_CHUNKS` caps, polite fetch concurrency, and a redeploy-safe

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -187,9 +187,13 @@ export async function defaultDocsIngestRun(fetchText?: (url: string) => Promise<
   // EVERY page fetch attempted this run failed (e.g. the docs host blocks
   // the bot's user-agent, or a network partition to that host) — the index
   // fetch succeeding told us nothing about whether the pages themselves are
-  // reachable.
-  if (result.pages > 0 && result.fetched === 0) {
-    throw new Error(`Docs ingest: all ${result.pages} page fetches failed`);
+  // reachable. Measured against pages ATTEMPTED, not pages listed: a page
+  // skipped as persistently dead (issue #611) is never fetched, so counting it
+  // here would raise a false "all fetches failed" alarm on a run whose every
+  // remaining page is dead-skipped — or mask a real one.
+  const attempted = result.pages - result.deadSkipped;
+  if (attempted > 0 && result.fetched === 0) {
+    throw new Error(`Docs ingest: all ${attempted} attempted page fetches failed`);
   }
   // Total failure, stage 3: pages fetched fine, but EVERY resulting chunk
   // upsert threw (e.g. the DB rejects every write) — zero created/updated/

--- a/src/config.ts
+++ b/src/config.ts
@@ -539,6 +539,20 @@ const EnvSchema = z.object({
   DOCS_INGEST_EXCLUDE_PATHS: z
     .string()
     .default('api/go,api/csharp,api/java,api/python,api/typescript,api/ruby,api/php,api/cli,api/compliance'),
+  // Dead-URL skipping (issue #611, the growth path #613 deferred): after this
+  // many CONSECUTIVE runs in which a page URL fails to fetch, it is reported
+  // once and then skipped instead of being re-fetched every run — the upstream
+  // index habitually lists a tranche of pages that don't exist. 0 disables the
+  // skipping entirely (every listed page is fetched every run, as before).
+  // Default 3 is deliberately conservative: the job runs ~weekly, so a URL must
+  // fail for ~3 weeks before it is skipped at all.
+  DOCS_INGEST_DEAD_URL_RUNS: z.coerce.number().int().min(0).max(100).default(3),
+  // How long a skipped (dead) URL stays skipped before ONE re-probe. This is
+  // what makes the skip self-healing: if upstream restores the page, the next
+  // re-probe succeeds, its failure row is deleted, and it returns to the normal
+  // fetch set with no operator action. Never 0 — a 0-day cooldown would re-probe
+  // every run and defeat the point.
+  DOCS_INGEST_DEAD_URL_RECHECK_DAYS: z.coerce.number().int().positive().max(365).default(30),
   // Knowledge link-rot check (issue #448): a weekly background job HEAD-checks
   // every knowledge entry's sourceUrl and flags dead citations for admin
   // review (list_knowledge sourceUnreachable filter). OFF by default, matching
@@ -1004,6 +1018,8 @@ export const config = {
     maxChunks: env.DOCS_INGEST_MAX_CHUNKS,
     concurrency: env.DOCS_INGEST_CONCURRENCY,
     excludePaths: csv(env.DOCS_INGEST_EXCLUDE_PATHS),
+    deadUrlRuns: env.DOCS_INGEST_DEAD_URL_RUNS,
+    deadUrlRecheckDays: env.DOCS_INGEST_DEAD_URL_RECHECK_DAYS,
   },
   knowledgeLinkCheck: {
     enabled: env.KNOWLEDGE_LINK_CHECK_ENABLED ?? false,

--- a/src/context/docsIngest.ts
+++ b/src/context/docsIngest.ts
@@ -381,11 +381,18 @@ export async function runDocsIngest(
   // stops costing a request every run (issue #611). Reading the streak state
   // must never break a run: on a read failure, fall back to fetching everything
   // (today's behaviour) rather than skipping blindly.
+  // `DOCS_INGEST_DEAD_URL_RUNS=0` is a COMPLETE off-switch, not just "never
+  // skip": no streak read, no streak write, no reporting — so a deployment that
+  // opts out behaves byte-identically to before this feature, with no extra
+  // queries at all.
+  const deadUrlsEnabled = config.docsIngest.deadUrlRuns > 0;
   let failureState = new Map<string, DocsIngestUrlFailure>();
-  try {
-    failureState = new Map((await listFailures()).map((f) => [f.url, f]));
-  } catch (err) {
-    logger.warn({ err }, 'Docs ingest: dead-URL state read failed; fetching every listed page this run');
+  if (deadUrlsEnabled) {
+    try {
+      failureState = new Map((await listFailures()).map((f) => [f.url, f]));
+    } catch (err) {
+      logger.warn({ err }, 'Docs ingest: dead-URL state read failed; fetching every listed page this run');
+    }
   }
   const { toFetch, skipped: deadSkippedUrls } = partitionDeadUrls(
     urls,
@@ -437,10 +444,10 @@ export async function runDocsIngest(
   // dead threshold — once. Best-effort throughout: this is bookkeeping for a
   // logging/efficiency optimisation, so a write failure must never fail a run
   // whose actual ingest work succeeded.
-  try {
-    await clearFailures(recoveredUrls);
-    await recordFailures(failedFetchUrls);
-    if (config.docsIngest.deadUrlRuns > 0) {
+  if (deadUrlsEnabled) {
+    try {
+      await clearFailures(recoveredUrls);
+      await recordFailures(failedFetchUrls);
       // A URL is newly dead when this run's failure takes its streak to the
       // threshold and it has never been reported. `+ 1` because `failureState`
       // is the pre-run snapshot and `recordFailures` has just bumped it.
@@ -471,9 +478,9 @@ export async function runDocsIngest(
         );
         await markReported(newlyDead);
       }
+    } catch (err) {
+      logger.warn({ err }, 'Docs ingest: dead-URL bookkeeping failed; run results are unaffected');
     }
-  } catch (err) {
-    logger.warn({ err }, 'Docs ingest: dead-URL bookkeeping failed; run results are unaffected');
   }
 
   if (failedFetchUrls.length > 0) {

--- a/src/context/docsIngest.ts
+++ b/src/context/docsIngest.ts
@@ -444,11 +444,18 @@ export async function runDocsIngest(
       // A URL is newly dead when this run's failure takes its streak to the
       // threshold and it has never been reported. `+ 1` because `failureState`
       // is the pre-run snapshot and `recordFailures` has just bumped it.
-      const newlyDead = failedFetchUrls.filter((url) => {
+      const crossedThisRun = failedFetchUrls.filter((url) => {
         const prior = failureState.get(url);
         const streak = (prior?.consecutiveFailures ?? 0) + 1;
         return streak >= config.docsIngest.deadUrlRuns && prior?.reportedAt == null;
       });
+      // A URL can also become dead WITHOUT failing this run: lowering
+      // DOCS_INGEST_DEAD_URL_RUNS pushes an existing sub-threshold streak over
+      // the line, and it is then skipped before it is ever re-attempted — so it
+      // would go quiet having never been reported. Report those too, so
+      // "reported once, then skipped" holds however the URL crossed.
+      const skippedUnreported = deadSkippedUrls.filter((url) => failureState.get(url)?.reportedAt == null);
+      const newlyDead = [...new Set([...crossedThisRun, ...skippedUnreported])];
       if (newlyDead.length > 0) {
         logger.warn(
           {

--- a/src/context/docsIngest.ts
+++ b/src/context/docsIngest.ts
@@ -446,7 +446,17 @@ export async function runDocsIngest(
   // whose actual ingest work succeeded.
   if (deadUrlsEnabled) {
     try {
-      await clearFailures(recoveredUrls);
+      // A streak row is also stale once its URL has left the index entirely —
+      // dropped upstream, or newly excluded via DOCS_INGEST_EXCLUDE_PATHS. Such
+      // a URL is never fetched again, so a success would never clear it and the
+      // row would linger forever. Reap those here, keyed off the FULL index
+      // (`allUrls`, not the maxPages slice) exactly like the chunk prune below,
+      // so a page merely past the fetch cap is never mistaken for one that
+      // vanished. This is what actually bounds the table by the CURRENT dead
+      // tranche rather than by history (PR #691 review).
+      const indexed = new Set(allUrls);
+      const orphaned = [...failureState.keys()].filter((url) => !indexed.has(url));
+      await clearFailures([...recoveredUrls, ...orphaned]);
       await recordFailures(failedFetchUrls);
       // A URL is newly dead when this run's failure takes its streak to the
       // threshold and it has never been reported. `+ 1` because `failureState`

--- a/src/context/docsIngest.ts
+++ b/src/context/docsIngest.ts
@@ -1,10 +1,15 @@
 import { config } from '../config.js';
 import { logger } from '../logger.js';
 import {
+  clearDocsIngestUrlFailures,
   deleteProvenancedKnowledgeByTitles,
   latestKnowledgeUpdateAtByProvenance,
+  listDocsIngestUrlFailures,
   listGlobalKnowledgeTitlesByProvenance,
+  markDocsIngestUrlsReported,
+  recordDocsIngestUrlFailures,
   syncGlobalKnowledgeByProvenance,
+  type DocsIngestUrlFailure,
 } from '../storage/repository.js';
 
 /**
@@ -205,6 +210,41 @@ function rollupByPathPrefix(urls: readonly string[]): Array<{ prefix: string; co
     .sort((a, b) => b.count - a.count || a.prefix.localeCompare(b.prefix));
 }
 
+/**
+ * Decide which listed URLs to actually fetch this run, given each URL's current
+ * failing streak (issue #611). A URL is SKIPPED only when it has failed
+ * `deadRuns` or more consecutive runs AND its last failure is inside the
+ * re-probe cooldown. Pure (state + clock in, decision out) so the policy is
+ * unit-testable without a DB or network.
+ *
+ * `deadRuns <= 0` disables skipping entirely — every listed URL is fetched, as
+ * before this feature.
+ *
+ * The cooldown is what keeps a skip self-healing: once `recheckMs` has elapsed
+ * a dead URL is re-probed exactly once. If upstream restored it the fetch
+ * succeeds, its failure row is deleted, and it rejoins the normal set with no
+ * operator action; if it still 404s, its streak bumps and it goes quiet again.
+ */
+export function partitionDeadUrls(
+  urls: readonly string[],
+  failures: ReadonlyMap<string, { consecutiveFailures: number; lastFailedAt: Date }>,
+  deadRuns: number,
+  recheckMs: number,
+  now: number,
+): { toFetch: string[]; skipped: string[] } {
+  if (deadRuns <= 0) return { toFetch: [...urls], skipped: [] };
+  const toFetch: string[] = [];
+  const skipped: string[] = [];
+  for (const url of urls) {
+    const state = failures.get(url);
+    const isDead = state !== undefined && state.consecutiveFailures >= deadRuns;
+    const dueForRecheck = state !== undefined && now - state.lastFailedAt.getTime() >= recheckMs;
+    if (isDead && !dueForRecheck) skipped.push(url);
+    else toFetch.push(url);
+  }
+  return { toFetch, skipped };
+}
+
 /** Run `worker` over `items` with at most `concurrency` in flight. */
 async function runPool<T>(
   items: readonly T[],
@@ -232,6 +272,15 @@ export interface DocsIngestResult {
   removed: number;
   skipped: number;
   /**
+   * Pages in the index slice NOT fetched this run because they are currently
+   * skipped as persistently dead (issue #611). Counted separately from
+   * `skipped` (which means "chunk not written") and from `failed` (a fetch that
+   * was attempted and threw) — a dead-skipped page costs no request at all.
+   * `pages - deadSkipped` is therefore the number of fetches actually
+   * attempted, which is what the caller's all-fetches-failed check must use.
+   */
+  deadSkipped: number;
+  /**
    * True only when the llms.txt index itself failed to fetch — a total-run
    * failure, distinct from a zero-URL parse (a legitimate no-op when the
    * index is reachable but happens to list nothing). This is only the FIRST
@@ -245,6 +294,18 @@ export interface DocsIngestResult {
 }
 
 /**
+ * Dead-URL store + clock, injectable so the skip/report policy can be tested
+ * without a DB (issue #611). Production uses the repository defaults.
+ */
+export interface DocsIngestDeps {
+  listFailures?: () => Promise<DocsIngestUrlFailure[]>;
+  recordFailures?: (urls: readonly string[]) => Promise<void>;
+  clearFailures?: (urls: readonly string[]) => Promise<void>;
+  markReported?: (urls: readonly string[]) => Promise<void>;
+  now?: () => number;
+}
+
+/**
  * One ingest run. Fetches the index, then every page (concurrency-limited),
  * chunks + diff-upserts each into `knowledge` under the 'docs' provenance, and
  * prunes chunks whose sections disappeared upstream. `fetchText` is injectable
@@ -253,7 +314,15 @@ export interface DocsIngestResult {
  */
 export async function runDocsIngest(
   fetchText: (url: string) => Promise<string> = defaultFetchText,
+  deps: DocsIngestDeps = {},
 ): Promise<DocsIngestResult> {
+  const {
+    listFailures = listDocsIngestUrlFailures,
+    recordFailures = recordDocsIngestUrlFailures,
+    clearFailures = clearDocsIngestUrlFailures,
+    markReported = markDocsIngestUrlsReported,
+    now = () => Date.now(),
+  } = deps;
   const result: DocsIngestResult = {
     pages: 0,
     fetched: 0,
@@ -264,6 +333,7 @@ export async function runDocsIngest(
     unchanged: 0,
     removed: 0,
     skipped: 0,
+    deadSkipped: 0,
     indexFetchFailed: false,
   };
 
@@ -301,11 +371,37 @@ export async function runDocsIngest(
   // failure class in near-identical lines). Full per-page detail is still
   // emitted at debug level, unchanged in shape.
   const failedFetchUrls: string[] = [];
+  // Successfully-fetched URLs that currently carry a failing streak — clearing
+  // only these (rather than all successes) keeps the post-run write proportional
+  // to the dead tranche instead of to the whole index (issue #611).
+  const recoveredUrls: string[] = [];
+
+  // Skip URLs that have failed for `deadUrlRuns` consecutive runs and are still
+  // inside their re-probe cooldown, so a permanently-dead upstream tranche
+  // stops costing a request every run (issue #611). Reading the streak state
+  // must never break a run: on a read failure, fall back to fetching everything
+  // (today's behaviour) rather than skipping blindly.
+  let failureState = new Map<string, DocsIngestUrlFailure>();
+  try {
+    failureState = new Map((await listFailures()).map((f) => [f.url, f]));
+  } catch (err) {
+    logger.warn({ err }, 'Docs ingest: dead-URL state read failed; fetching every listed page this run');
+  }
+  const { toFetch, skipped: deadSkippedUrls } = partitionDeadUrls(
+    urls,
+    failureState,
+    config.docsIngest.deadUrlRuns,
+    config.docsIngest.deadUrlRecheckDays * 86_400_000,
+    now(),
+  );
+  result.deadSkipped = deadSkippedUrls.length;
+
   const worker = async (url: string): Promise<void> => {
     let md: string;
     try {
       md = await fetchText(url);
       result.fetched += 1;
+      if (failureState.has(url)) recoveredUrls.push(url);
     } catch (err) {
       logger.debug({ err, url }, 'Docs ingest: page fetch failed');
       failedFetchUrls.push(url);
@@ -335,7 +431,43 @@ export async function runDocsIngest(
     }
   };
 
-  await runPool(urls, config.docsIngest.concurrency, worker);
+  await runPool(toFetch, config.docsIngest.concurrency, worker);
+
+  // Persist this run's outcomes, then report any URL that has JUST crossed the
+  // dead threshold — once. Best-effort throughout: this is bookkeeping for a
+  // logging/efficiency optimisation, so a write failure must never fail a run
+  // whose actual ingest work succeeded.
+  try {
+    await clearFailures(recoveredUrls);
+    await recordFailures(failedFetchUrls);
+    if (config.docsIngest.deadUrlRuns > 0) {
+      // A URL is newly dead when this run's failure takes its streak to the
+      // threshold and it has never been reported. `+ 1` because `failureState`
+      // is the pre-run snapshot and `recordFailures` has just bumped it.
+      const newlyDead = failedFetchUrls.filter((url) => {
+        const prior = failureState.get(url);
+        const streak = (prior?.consecutiveFailures ?? 0) + 1;
+        return streak >= config.docsIngest.deadUrlRuns && prior?.reportedAt == null;
+      });
+      if (newlyDead.length > 0) {
+        logger.warn(
+          {
+            count: newlyDead.length,
+            consecutiveRuns: config.docsIngest.deadUrlRuns,
+            recheckDays: config.docsIngest.deadUrlRecheckDays,
+            sample: newlyDead.slice(0, 5),
+            rollup: rollupByPathPrefix(newlyDead)
+              .map(({ prefix, count }) => `${count}× ${prefix}`)
+              .join(', '),
+          },
+          'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+        );
+        await markReported(newlyDead);
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Docs ingest: dead-URL bookkeeping failed; run results are unaffected');
+  }
 
   if (failedFetchUrls.length > 0) {
     const rollup = rollupByPathPrefix(failedFetchUrls)
@@ -344,7 +476,10 @@ export async function runDocsIngest(
     logger.warn(
       {
         failed: failedFetchUrls.length,
-        attempted: urls.length,
+        // Fetches actually ATTEMPTED — excludes dead-skipped pages, which cost
+        // no request (issue #611), so "failed of attempted" stays honest.
+        attempted: toFetch.length,
+        deadSkipped: result.deadSkipped,
         sample: failedFetchUrls.slice(0, 5),
         rollup,
       },

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -1722,6 +1722,81 @@ export async function deleteProvenancedKnowledgeByTitles(
   return rowCount ?? 0;
 }
 
+// --- Docs-ingest dead-URL tracking (issue #611) ------------------------------
+
+export interface DocsIngestUrlFailure {
+  url: string;
+  consecutiveFailures: number;
+  lastFailedAt: Date;
+  /** Non-null once the URL crossed the dead threshold and was reported. */
+  reportedAt: Date | null;
+}
+
+/**
+ * Every URL currently in a failing streak. A row exists only while a URL is
+ * failing (a successful fetch deletes it — see `clearDocsIngestUrlFailures`),
+ * so this is bounded by the size of the upstream index's dead tranche, not by
+ * history. Returned raw: the caller (`runDocsIngest`) applies the
+ * threshold/recheck policy, keeping this function free of config coupling and
+ * the policy directly unit-testable.
+ */
+export async function listDocsIngestUrlFailures(): Promise<DocsIngestUrlFailure[]> {
+  const { rows } = await pool.query(
+    `SELECT url, consecutive_failures, last_failed_at, reported_at FROM docs_ingest_url_failures`,
+  );
+  return rows.map((r) => ({
+    url: r.url as string,
+    consecutiveFailures: Number(r.consecutive_failures),
+    lastFailedAt: r.last_failed_at as Date,
+    reportedAt: (r.reported_at as Date | null) ?? null,
+  }));
+}
+
+/**
+ * Record one more consecutive failure for each URL, creating the row on first
+ * failure. `first_failed_at` is preserved across bumps (it dates the streak);
+ * `last_failed_at` moves to now, which is what the re-probe cooldown measures
+ * from. No-op on an empty list.
+ */
+export async function recordDocsIngestUrlFailures(urls: readonly string[]): Promise<void> {
+  // De-duplicated because ON CONFLICT DO UPDATE errors outright ("cannot affect
+  // row a second time") if the same key appears twice in one statement.
+  const unique = [...new Set(urls)];
+  if (unique.length === 0) return;
+  await pool.query(
+    `INSERT INTO docs_ingest_url_failures (url)
+     SELECT unnest($1::text[])
+     ON CONFLICT (url) DO UPDATE
+       SET consecutive_failures = docs_ingest_url_failures.consecutive_failures + 1,
+           last_failed_at = now()`,
+    [unique],
+  );
+}
+
+/**
+ * Clear the failing streak for URLs that fetched successfully — this is what
+ * makes the streak CONSECUTIVE (one success resets it) and what lets an
+ * upstream fix self-heal a skipped URL on its next re-probe. No-op on an empty
+ * list.
+ */
+export async function clearDocsIngestUrlFailures(urls: readonly string[]): Promise<void> {
+  if (urls.length === 0) return;
+  await pool.query(`DELETE FROM docs_ingest_url_failures WHERE url = ANY($1)`, [[...urls]]);
+}
+
+/**
+ * Stamp `reported_at` on URLs whose dead-threshold crossing has just been
+ * logged, so the operator is told once rather than on every subsequent run.
+ * No-op on an empty list.
+ */
+export async function markDocsIngestUrlsReported(urls: readonly string[]): Promise<void> {
+  if (urls.length === 0) return;
+  await pool.query(
+    `UPDATE docs_ingest_url_failures SET reported_at = now() WHERE url = ANY($1) AND reported_at IS NULL`,
+    [[...urls]],
+  );
+}
+
 // --- Membership (three-tier RBAC) -------------------------------------------
 
 export type StoredRole = 'admin' | 'member';

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -905,3 +905,27 @@ CREATE TABLE IF NOT EXISTS member_digest_sends (
   sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   CONSTRAINT member_digest_sends_singleton CHECK (id = 1)
 );
+
+-- ---------------------------------------------------------------------------
+-- Per-URL consecutive fetch-failure tracking for the docs-ingest job
+-- (issue #611, the growth path #613 deferred). Anthropic's llms.txt index
+-- habitually lists a tranche of pages that don't exist (one observed run:
+-- 157/586 404ing, all under api/terraform/beta/*), and every weekly run
+-- re-fetched all of them. A URL that fails DOCS_INGEST_DEAD_URL_RUNS runs in
+-- a row is reported ONCE and then skipped, with a periodic re-probe
+-- (DOCS_INGEST_DEAD_URL_RECHECK_DAYS) so an upstream fix self-heals.
+--
+-- A row exists only while a URL is CURRENTLY failing: a successful fetch
+-- deletes it, so this table stays small and never needs its own retention
+-- purge. Holds first-party docs URLs only — no user identifier, so
+-- forget_me/purge_user_data have nothing to touch here.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS docs_ingest_url_failures (
+  url                  TEXT        PRIMARY KEY,
+  consecutive_failures INTEGER     NOT NULL DEFAULT 1,
+  first_failed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_failed_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Set when the URL crossed the dead threshold and was reported, so the
+  -- operator is told once rather than every run.
+  reported_at          TIMESTAMPTZ
+);

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -916,8 +916,10 @@ CREATE TABLE IF NOT EXISTS member_digest_sends (
 -- (DOCS_INGEST_DEAD_URL_RECHECK_DAYS) so an upstream fix self-heals.
 --
 -- A row exists only while a URL is CURRENTLY failing: a successful fetch
--- deletes it, so this table stays small and never needs its own retention
--- purge. Holds first-party docs URLs only — no user identifier, so
+-- deletes it, and a row whose URL has left the index entirely (dropped
+-- upstream, or newly excluded) is reaped on the next run — so this table stays
+-- bounded by the current dead tranche and never needs its own retention purge.
+-- Holds first-party docs URLs only — no user identifier, so
 -- forget_me/purge_user_data have nothing to touch here.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS docs_ingest_url_failures (

--- a/tests/backgroundJobs.test.ts
+++ b/tests/backgroundJobs.test.ts
@@ -996,6 +996,34 @@ test(
 );
 
 test(
+  'defaultDocsIngestRun does NOT throw when every listed page was dead-SKIPPED rather than attempted — a skipped page costs no fetch, so it must not read as "all fetches failed" (issue #611)',
+  { skip },
+  async (t) => {
+    // The stage-2 total-failure check compares fetched against pages ATTEMPTED.
+    // Before #611 it compared against pages LISTED, so a run whose every page is
+    // skipped as persistently dead (fetched === 0) would raise a false
+    // job-failure alarm — and DM super admins — despite nothing being wrong.
+    const pageUrl = `${config.docsIngest.indexUrl.replace(/\/[^/]*$/, '')}/docs/en/api/terraform/beta/dead-611.md`;
+    await pool.query(
+      `INSERT INTO docs_ingest_url_failures (url, consecutive_failures, reported_at)
+       VALUES ($1, 99, now())
+       ON CONFLICT (url) DO UPDATE SET consecutive_failures = 99, last_failed_at = now()`,
+      [pageUrl],
+    );
+    try {
+      const fetchText = async (url: string): Promise<string> => {
+        if (url === config.docsIngest.indexUrl) return `- [dead](${pageUrl})`;
+        throw new Error('unreachable: a dead-skipped page must never be fetched');
+      };
+      t.mock.timers.enable({ apis: ['Date'], now: FAR_FUTURE_MS() });
+      await assert.doesNotReject(() => defaultDocsIngestRun(fetchText));
+    } finally {
+      await pool.query(`DELETE FROM docs_ingest_url_failures WHERE url = $1`, [pageUrl]);
+    }
+  },
+);
+
+test(
   'defaultKnowledgeLinkCheckRun does NOT throw on a legitimate zero-attempted-failure run (real freshness guard + real sweep, injected fetch/lookup that never fails)',
   { skip },
   async (t) => {

--- a/tests/backgroundJobs.test.ts
+++ b/tests/backgroundJobs.test.ts
@@ -72,6 +72,12 @@ const { getJobHealthSnapshot, resetJobHealthRegistryForTests } =
 const { getPendingAlertsForTests, getPendingAlertEntriesForTests, resetPendingAlertsForTests } =
   await import('../src/pendingAlertQueue.js');
 
+// Pin the docs-ingest dead-URL feature OFF by default here (issue #611): the
+// pre-existing docs-ingest tests in this file drive real page-fetch failures
+// through the REAL repository store, and must keep behaving exactly as they did
+// before the feature. The one dead-skip test below opts itself back in.
+(config.docsIngest as { deadUrlRuns: number }).deadUrlRuns = 0;
+
 after(async () => {
   await closeDb();
 });
@@ -1004,20 +1010,34 @@ test(
     // skipped as persistently dead (fetched === 0) would raise a false
     // job-failure alarm — and DM super admins — despite nothing being wrong.
     const pageUrl = `${config.docsIngest.indexUrl.replace(/\/[^/]*$/, '')}/docs/en/api/terraform/beta/dead-611.md`;
+    // Anchor the failure row to the SAME instant the clock is mocked to. This
+    // suite runs the real freshness guard against a mocked far-future Date, and
+    // the dead-URL cooldown is measured from `last_failed_at` — so a row written
+    // at real now() would read as 5 years stale, fall due for its re-probe, and
+    // be fetched rather than skipped (which is correct behaviour, just not the
+    // scenario under test).
+    const farFuture = FAR_FUTURE_MS();
     await pool.query(
-      `INSERT INTO docs_ingest_url_failures (url, consecutive_failures, reported_at)
-       VALUES ($1, 99, now())
-       ON CONFLICT (url) DO UPDATE SET consecutive_failures = 99, last_failed_at = now()`,
-      [pageUrl],
+      `INSERT INTO docs_ingest_url_failures (url, consecutive_failures, first_failed_at, last_failed_at, reported_at)
+       VALUES ($1, 99, $2, $2, $2)
+       ON CONFLICT (url) DO UPDATE
+         SET consecutive_failures = 99, last_failed_at = $2, reported_at = $2`,
+      [pageUrl, new Date(farFuture)],
     );
+    // This file pins the feature off by default (see the top of the file) — opt
+    // back in for this test, which is specifically about the skip behaviour.
+    const docsCfg = config.docsIngest as { deadUrlRuns: number };
+    const wasDeadUrlRuns = docsCfg.deadUrlRuns;
+    docsCfg.deadUrlRuns = 3;
     try {
       const fetchText = async (url: string): Promise<string> => {
         if (url === config.docsIngest.indexUrl) return `- [dead](${pageUrl})`;
         throw new Error('unreachable: a dead-skipped page must never be fetched');
       };
-      t.mock.timers.enable({ apis: ['Date'], now: FAR_FUTURE_MS() });
+      t.mock.timers.enable({ apis: ['Date'], now: farFuture });
       await assert.doesNotReject(() => defaultDocsIngestRun(fetchText));
     } finally {
+      docsCfg.deadUrlRuns = wasDeadUrlRuns;
       await pool.query(`DELETE FROM docs_ingest_url_failures WHERE url = $1`, [pageUrl]);
     }
   },

--- a/tests/docsIngest.test.ts
+++ b/tests/docsIngest.test.ts
@@ -758,3 +758,59 @@ test(
     });
   },
 );
+
+test('runDocsIngest: lowering the threshold onto an existing streak still reports the URL once before it goes quiet (PR #691 review)', async (t) => {
+  // The URL has 2 prior failures and was never reported. An operator lowers
+  // DOCS_INGEST_DEAD_URL_RUNS to 2, so it is dead on the NEXT run — and is
+  // therefore skipped before it is ever re-attempted, never entering
+  // failedFetchUrls. It must still get its one-time report rather than
+  // silently disappearing from the fetch set.
+  await withDeadUrlConfig(2, 30, async () => {
+    const { logger } = await import('../src/logger.js');
+    const warn = t.mock.method(logger, 'warn');
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 2)]);
+    const attempted: string[] = [];
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      attempted.push(url);
+      throw new Error(`404 ${url}`);
+    };
+
+    const res = await runDocsIngest(fetchText, deps);
+
+    assert.deepEqual(attempted, [], 'already over the lowered threshold, so it is skipped, not fetched');
+    assert.equal(res.deadSkipped, 1);
+    const deadWarns = warn.mock.calls.filter(
+      (c) =>
+        c.arguments[1] === 'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+    );
+    assert.equal(deadWarns.length, 1, 'the one-time report still fires for a config-induced crossing');
+    assert.deepEqual((deadWarns[0].arguments[0] as { sample: string[] }).sample, [DEAD_URL]);
+    assert.deepEqual(calls.reported, [[DEAD_URL]], 'and it is stamped, so it never reports again');
+  });
+});
+
+test('runDocsIngest: an already-reported URL that stays skipped is never re-reported (the report is once, not per run)', async (t) => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const { logger } = await import('../src/logger.js');
+    const warn = t.mock.method(logger, 'warn');
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 5, 0, new Date())]);
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      throw new Error('unreachable: this URL is dead and in cooldown');
+    };
+
+    const res = await runDocsIngest(fetchText, deps);
+
+    assert.equal(res.deadSkipped, 1, 'still skipped');
+    assert.equal(
+      warn.mock.calls.filter(
+        (c) =>
+          c.arguments[1] === 'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+      ).length,
+      0,
+      'already reported, so the run stays silent about it',
+    );
+    assert.deepEqual(calls.reported, []);
+  });
+});

--- a/tests/docsIngest.test.ts
+++ b/tests/docsIngest.test.ts
@@ -827,3 +827,27 @@ test('runDocsIngest: an already-reported URL that stays skipped is never re-repo
     assert.deepEqual(calls.reported, []);
   });
 });
+
+test('runDocsIngest: a streak row whose URL has left the index is reaped, so the table stays bounded by the current dead tranche (PR #691 review)', async () => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const goneFromIndex = 'https://platform.claude.com/docs/en/api/terraform/beta/removed-upstream.md';
+    // Two open streaks: one URL still listed, one that has vanished from the
+    // index. The vanished one will never be fetched again, so nothing would
+    // ever clear it — it must be reaped here instead of lingering forever.
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 1), failure(goneFromIndex, 1)]);
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      throw new Error(`404 ${url}`);
+    };
+
+    await runDocsIngest(fetchText, deps);
+
+    assert.equal(calls.cleared.length, 1, 'one clear call');
+    assert.deepEqual(
+      calls.cleared[0],
+      [goneFromIndex],
+      'only the de-listed URL is reaped — the still-listed one keeps its streak',
+    );
+    assert.deepEqual(calls.recorded, [[DEAD_URL]], 'the still-listed URL still bumps its streak');
+  });
+});

--- a/tests/docsIngest.test.ts
+++ b/tests/docsIngest.test.ts
@@ -29,6 +29,14 @@ const {
   DOCS_PROVENANCE,
 } = await import('../src/context/docsIngest.js');
 
+// Pin the dead-URL feature OFF for this file by default (issue #611). Every
+// test written before it existed calls runDocsIngest WITHOUT stub deps, so with
+// the feature on they would read/write the real docs_ingest_url_failures table
+// against the shared CI database — and a URL failed by enough of them could
+// start being SKIPPED, silently changing those tests' expected counts. The
+// dead-URL tests at the bottom opt themselves back in via withDeadUrlConfig.
+(config.docsIngest as { deadUrlRuns: number }).deadUrlRuns = 0;
+
 after(async () => {
   if (hasDb) {
     await pool.query(`DELETE FROM knowledge WHERE created_by_role = $1`, [DOCS_PROVENANCE]);
@@ -712,7 +720,12 @@ test('runDocsIngest: with deadUrlRuns=0 a long-dead URL is still fetched and nev
       0,
       'no dead-URL reporting when the feature is disabled',
     );
+    // 0 is a COMPLETE off-switch, not just "never skip": no streak read and no
+    // streak write either, so opting out is byte-identical to pre-feature
+    // behaviour with no extra queries.
     assert.deepEqual(calls.reported, []);
+    assert.deepEqual(calls.recorded, [], 'no streak write when the feature is off');
+    assert.deepEqual(calls.cleared, [], 'no streak clear when the feature is off');
   });
 });
 

--- a/tests/docsIngest.test.ts
+++ b/tests/docsIngest.test.ts
@@ -25,6 +25,7 @@ const {
   chunkMarkdown,
   shouldRunDocsIngest,
   runDocsIngest,
+  partitionDeadUrls,
   DOCS_PROVENANCE,
 } = await import('../src/context/docsIngest.js');
 
@@ -521,5 +522,239 @@ test(
     assert.ok(res.skipped >= 1, 'the collided chunk is reported skipped');
 
     await pool.query(`DELETE FROM knowledge WHERE title = $1 AND scope = 'global'`, [humanTitle]);
+  },
+);
+
+// --- Dead-URL skipping (issue #611) -----------------------------------------
+// The upstream index habitually lists a tranche of pages that don't exist (one
+// observed run: 157/586 404ing under api/terraform/beta/*). #613 batched the
+// LOGGING of those failures; this closes #611's remaining ask — stop re-fetching
+// them every run, report once, and self-heal via a periodic re-probe.
+
+const DEAD_URL = 'https://platform.claude.com/docs/en/api/terraform/beta/dead.md';
+const LIVE_URL = 'https://platform.claude.com/docs/en/api/messages.md';
+
+/** A failure-state entry as listDocsIngestUrlFailures would return it. */
+function failure(url: string, consecutiveFailures: number, agedDays = 0, reportedAt: Date | null = null) {
+  return {
+    url,
+    consecutiveFailures,
+    lastFailedAt: new Date(Date.now() - agedDays * 86_400_000),
+    reportedAt,
+  };
+}
+
+/** Captures every dead-URL store call so a test can assert on the bookkeeping. */
+function stubDeadUrlStore(failures: ReturnType<typeof failure>[] = []) {
+  const calls = {
+    recorded: [] as string[][],
+    cleared: [] as string[][],
+    reported: [] as string[][],
+  };
+  return {
+    calls,
+    deps: {
+      listFailures: async () => failures,
+      recordFailures: async (urls: readonly string[]) => {
+        calls.recorded.push([...urls]);
+      },
+      clearFailures: async (urls: readonly string[]) => {
+        calls.cleared.push([...urls]);
+      },
+      markReported: async (urls: readonly string[]) => {
+        calls.reported.push([...urls]);
+      },
+    },
+  };
+}
+
+/** Runs `fn` with the dead-URL config knobs overridden, restoring them after. */
+async function withDeadUrlConfig(runs: number, recheckDays: number, fn: () => Promise<void>): Promise<void> {
+  const cfg = config.docsIngest as { deadUrlRuns: number; deadUrlRecheckDays: number };
+  const wasRuns = cfg.deadUrlRuns;
+  const wasDays = cfg.deadUrlRecheckDays;
+  cfg.deadUrlRuns = runs;
+  cfg.deadUrlRecheckDays = recheckDays;
+  try {
+    await fn();
+  } finally {
+    cfg.deadUrlRuns = wasRuns;
+    cfg.deadUrlRecheckDays = wasDays;
+  }
+}
+
+test('partitionDeadUrls: skips only URLs at/over the threshold that are still inside the re-probe cooldown', () => {
+  const now = Date.now();
+  const recheckMs = 30 * 86_400_000;
+  const state = new Map([
+    ['a', { consecutiveFailures: 1, lastFailedAt: new Date(now) }], // under threshold
+    ['b', { consecutiveFailures: 3, lastFailedAt: new Date(now) }], // dead, in cooldown
+    ['c', { consecutiveFailures: 9, lastFailedAt: new Date(now - 31 * 86_400_000) }], // dead, due for re-probe
+  ]);
+  const { toFetch, skipped } = partitionDeadUrls(['a', 'b', 'c', 'd'], state, 3, recheckMs, now);
+  assert.deepEqual(skipped, ['b'], 'only the in-cooldown dead URL is skipped');
+  assert.deepEqual(
+    toFetch,
+    ['a', 'c', 'd'],
+    'under-threshold, due-for-re-probe, and never-failed URLs are all fetched',
+  );
+});
+
+test('partitionDeadUrls: deadRuns=0 disables skipping entirely — every listed URL is fetched', () => {
+  const now = Date.now();
+  const state = new Map([['b', { consecutiveFailures: 99, lastFailedAt: new Date(now) }]]);
+  const { toFetch, skipped } = partitionDeadUrls(['a', 'b'], state, 0, 30 * 86_400_000, now);
+  assert.deepEqual(skipped, []);
+  assert.deepEqual(toFetch, ['a', 'b'], 'a long-dead URL is still fetched when the feature is off');
+});
+
+test('partitionDeadUrls: a URL exactly AT the threshold is skipped (>=, not >)', () => {
+  const now = Date.now();
+  const state = new Map([['b', { consecutiveFailures: 3, lastFailedAt: new Date(now) }]]);
+  const { skipped } = partitionDeadUrls(['b'], state, 3, 30 * 86_400_000, now);
+  assert.deepEqual(skipped, ['b']);
+});
+
+test('runDocsIngest: a persistently-dead URL is not fetched at all and is counted in deadSkipped', async () => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 3)]);
+    const attempted: string[] = [];
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})\n- [b](${LIVE_URL})`;
+      attempted.push(url);
+      throw new Error(`404 ${url}`); // LIVE_URL also fails, keeping this test DB-free
+    };
+
+    const res = await runDocsIngest(fetchText, deps);
+
+    assert.ok(!attempted.includes(DEAD_URL), 'the dead URL costs no request at all');
+    assert.deepEqual(attempted, [LIVE_URL], 'only the non-dead URL is attempted');
+    assert.equal(res.deadSkipped, 1, 'the skip is counted');
+    assert.equal(res.pages, 2, 'pages still reflects the full index slice');
+    assert.equal(res.failed, 1, 'only the attempted-and-failed page counts as failed');
+    assert.deepEqual(calls.recorded, [[LIVE_URL]], 'only the attempted failure bumps a streak');
+  });
+});
+
+test('runDocsIngest: a URL crossing the dead threshold is reported ONCE and stamped reported', async (t) => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const { logger } = await import('../src/logger.js');
+    const warn = t.mock.method(logger, 'warn');
+    // Two prior consecutive failures — this run's failure is the 3rd, crossing.
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 2)]);
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      throw new Error(`404 ${url}`);
+    };
+
+    await runDocsIngest(fetchText, deps);
+
+    const deadWarns = warn.mock.calls.filter(
+      (c) =>
+        c.arguments[1] === 'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+    );
+    assert.equal(deadWarns.length, 1, 'exactly one newly-dead report');
+    const payload = deadWarns[0].arguments[0] as { count: number; sample: string[]; rollup: string };
+    assert.equal(payload.count, 1);
+    assert.deepEqual(payload.sample, [DEAD_URL]);
+    assert.match(payload.rollup, /1× api\/terraform\/beta/);
+    assert.deepEqual(calls.reported, [[DEAD_URL]], 'the crossing is stamped so it is never re-reported');
+  });
+});
+
+test('runDocsIngest: an ALREADY-reported dead URL that gets re-probed and fails again is not re-reported', async (t) => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const { logger } = await import('../src/logger.js');
+    const warn = t.mock.method(logger, 'warn');
+    // Well past the threshold, already reported, and due for its re-probe.
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 9, 31, new Date())]);
+    const attempted: string[] = [];
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      attempted.push(url);
+      throw new Error(`404 ${url}`);
+    };
+
+    const res = await runDocsIngest(fetchText, deps);
+
+    assert.deepEqual(attempted, [DEAD_URL], 'the cooldown elapsed, so it IS re-probed exactly once');
+    assert.equal(res.deadSkipped, 0, 'a re-probed URL is not counted as skipped this run');
+    const deadWarns = warn.mock.calls.filter(
+      (c) =>
+        c.arguments[1] === 'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+    );
+    assert.equal(deadWarns.length, 0, 'no second report — the operator was already told once');
+    assert.deepEqual(calls.reported, [], 'nothing re-stamped');
+  });
+});
+
+test('runDocsIngest: with deadUrlRuns=0 a long-dead URL is still fetched and never reported', async (t) => {
+  await withDeadUrlConfig(0, 30, async () => {
+    const { logger } = await import('../src/logger.js');
+    const warn = t.mock.method(logger, 'warn');
+    const { calls, deps } = stubDeadUrlStore([failure(DEAD_URL, 99)]);
+    const attempted: string[] = [];
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      attempted.push(url);
+      throw new Error(`404 ${url}`);
+    };
+
+    const res = await runDocsIngest(fetchText, deps);
+
+    assert.deepEqual(attempted, [DEAD_URL], 'skipping is off, so the URL is fetched as before');
+    assert.equal(res.deadSkipped, 0);
+    assert.equal(
+      warn.mock.calls.filter(
+        (c) =>
+          c.arguments[1] === 'Docs ingest: URLs persistently failing; skipping them until the next re-probe',
+      ).length,
+      0,
+      'no dead-URL reporting when the feature is disabled',
+    );
+    assert.deepEqual(calls.reported, []);
+  });
+});
+
+test('runDocsIngest: a dead-URL store read failure degrades to fetching everything, never to skipping blindly', async () => {
+  await withDeadUrlConfig(3, 30, async () => {
+    const attempted: string[] = [];
+    const fetchText = async (url: string): Promise<string> => {
+      if (url === config.docsIngest.indexUrl) return `- [a](${DEAD_URL})`;
+      attempted.push(url);
+      throw new Error(`404 ${url}`);
+    };
+
+    const res = await runDocsIngest(fetchText, {
+      listFailures: async () => {
+        throw new Error('db down');
+      },
+      recordFailures: async () => {},
+      clearFailures: async () => {},
+      markReported: async () => {},
+    });
+
+    assert.deepEqual(attempted, [DEAD_URL], 'an unreadable streak store must not cause a silent skip');
+    assert.equal(res.deadSkipped, 0);
+  });
+});
+
+test(
+  'runDocsIngest: a dead URL that fetches successfully again has its failing streak cleared (self-heals)',
+  { skip },
+  async () => {
+    await withDeadUrlConfig(3, 30, async () => {
+      const { calls, deps } = stubDeadUrlStore([failure(LIVE_URL, 9, 31)]);
+      const fetchText = async (url: string): Promise<string> => {
+        if (url === config.docsIngest.indexUrl) return `- [a](${LIVE_URL})`;
+        return '# Messages\n\nThe Messages API sends a conversation to the model.';
+      };
+
+      const res = await runDocsIngest(fetchText, deps);
+
+      assert.equal(res.fetched, 1, 'the re-probe succeeded');
+      assert.deepEqual(calls.cleared, [[LIVE_URL]], 'the streak is deleted, so it rejoins the normal set');
+      assert.deepEqual(calls.recorded, [[]], 'nothing failed, so nothing is recorded');
+    });
   },
 );

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -65,6 +65,10 @@ const {
   KNOWLEDGE_GAP_QUERY_MAX_CHARS,
   recentModerationEntries,
   adminActivitySummary,
+  listDocsIngestUrlFailures,
+  recordDocsIngestUrlFailures,
+  clearDocsIngestUrlFailures,
+  markDocsIngestUrlsReported,
   autoEnrollMemberWithAudit,
   AUTO_ENROLL_ACTOR,
   usageStats,
@@ -10495,5 +10499,79 @@ test(
     assert.deepEqual(await recentConversationTail('discord', conv, 0), [], 'limit 0 disables the backfill');
 
     await pool.query(`DELETE FROM interactions WHERE conversation_id = ANY($1)`, [[conv, otherConv]]);
+  },
+);
+
+// --- Docs-ingest dead-URL tracking (issue #611) ------------------------------
+
+test(
+  'repository: docs-ingest URL failures accumulate a CONSECUTIVE streak, a success clears it, and reporting is stamped once',
+  { skip },
+  async () => {
+    const a = `https://example.invalid/${RUN}/a.md`;
+    const b = `https://example.invalid/${RUN}/b.md`;
+    const mine = async () => (await listDocsIngestUrlFailures()).filter((f) => f.url.includes(RUN));
+    try {
+      // First failure creates the row at 1.
+      await recordDocsIngestUrlFailures([a, b]);
+      let rows = await mine();
+      assert.equal(rows.length, 2, 'a row per failing URL');
+      assert.ok(
+        rows.every((r) => r.consecutiveFailures === 1 && r.reportedAt === null),
+        'first failure starts the streak at 1, unreported',
+      );
+
+      // Second and third failures bump the same rows rather than duplicating.
+      await recordDocsIngestUrlFailures([a, b]);
+      await recordDocsIngestUrlFailures([a]);
+      rows = await mine();
+      assert.equal(rows.length, 2, 'still one row per URL — the upsert bumps, never duplicates');
+      assert.equal(rows.find((r) => r.url === a)?.consecutiveFailures, 3);
+      assert.equal(rows.find((r) => r.url === b)?.consecutiveFailures, 2);
+
+      // Reporting stamps only the named URL, and only once.
+      await markDocsIngestUrlsReported([a]);
+      const firstStamp = (await mine()).find((r) => r.url === a)?.reportedAt;
+      assert.ok(firstStamp instanceof Date, 'the reported URL is stamped');
+      assert.equal((await mine()).find((r) => r.url === b)?.reportedAt, null, 'the other URL is untouched');
+      await markDocsIngestUrlsReported([a]);
+      assert.deepEqual(
+        (await mine()).find((r) => r.url === a)?.reportedAt,
+        firstStamp,
+        're-marking is a no-op — the original report time is preserved (WHERE reported_at IS NULL)',
+      );
+
+      // A success deletes the row entirely — that is what makes the streak
+      // CONSECUTIVE and lets a restored upstream page self-heal.
+      await clearDocsIngestUrlFailures([a]);
+      rows = await mine();
+      assert.deepEqual(
+        rows.map((r) => r.url),
+        [b],
+        'the recovered URL is gone; the still-failing one remains',
+      );
+
+      // A fresh failure after recovery starts from 1 again, not from 3.
+      await recordDocsIngestUrlFailures([a]);
+      assert.equal(
+        (await mine()).find((r) => r.url === a)?.consecutiveFailures,
+        1,
+        'the streak restarts after a success — it is consecutive, not cumulative',
+      );
+    } finally {
+      await pool.query(`DELETE FROM docs_ingest_url_failures WHERE url LIKE $1`, [`%${RUN}%`]);
+    }
+  },
+);
+
+test(
+  'repository: the docs-ingest failure helpers are all no-ops on an empty list (no stray query, no row churn)',
+  { skip },
+  async () => {
+    await assert.doesNotReject(async () => {
+      await recordDocsIngestUrlFailures([]);
+      await clearDocsIngestUrlFailures([]);
+      await markDocsIngestUrlsReported([]);
+    });
   },
 );


### PR DESCRIPTION
Closes #611

## Summary

Closes the second, deferred half of #611. The first half — batching the per-page 404 warnings into one run-end summary — shipped as #613, which explicitly left this piece as a growth path because it needs persisted state:

> "the 'consistently-404 for K runs' rolling tracker from #611, to stop re-attempting URLs the index has listed as dead for many consecutive runs — a separate, larger proposal given it needs new persisted state."

Anthropic's `llms.txt` habitually lists pages that don't exist (the run in #611: **157 of 586 returning 404**, all under `api/terraform/beta/*`). #613 made that quiet in the log; the weekly job still re-requested every dead page, every run.

A URL that fails to fetch on `DOCS_INGEST_DEAD_URL_RUNS` consecutive runs (default **3** — ~3 weeks at the weekly cadence) is now reported **once** and then skipped. The skip is **self-healing, not permanent**: each skipped URL is re-probed once every `DOCS_INGEST_DEAD_URL_RECHECK_DAYS` (default 30), and a successful fetch deletes its streak row so it rejoins the normal fetch set with no operator action. `DOCS_INGEST_DEAD_URL_RUNS=0` is a complete off-switch — no streak read, no streak write, no reporting.

### Changes

- **`schema.sql`** — new `docs_ingest_url_failures` table. A row exists only while a URL is *currently* failing (a success deletes it), so it stays bounded by the size of the dead tranche rather than by history, and needs no retention purge. Holds URLs only — no user identifier, so `forget_me`/`purge_user_data` have nothing to touch.
- **`repository.ts`** — `list`/`record`/`clear`/`markReported` helpers, returning raw streak state so the *policy* lives in `docsIngest.ts` (no config coupling in the repo layer). The record upsert de-duplicates its input, because `ON CONFLICT DO UPDATE` errors outright if a key repeats in one statement.
- **`docsIngest.ts`** — pure `partitionDeadUrls()` (state + clock in, decision out) so the skip rule is unit-testable with no DB or network; the store and clock are injectable. New `deadSkipped` result field.
- **`backgroundJobs.ts`** — the stage-2 *"all page fetches failed"* alarm now measures against pages **attempted** (`pages - deadSkipped`), not pages *listed*. Without this, a run whose every remaining page is dead-skipped has `fetched === 0` and would DM super admins a **false total-failure alarm**.

## Security / privacy impact

No new tool, RBAC surface, user data, or external input — this only changes *which already-listed, first-party URLs get requested* on a background job that reads one fixed official index. It cannot widen the fetch set, and it **cannot lose knowledge**: pruning still keys off the index, never off fetch success (the existing fail-safe #611's own report relies on). The new table stores URLs and counters only.

No `SECURITY:`-prefixed test is added and `tests/security-floor.json` is unchanged (888) — same reasoning #613 recorded for the sibling change: there is no tool or data-access surface here for one to pin.

Fail-safe throughout: an unreadable streak store falls back to **fetching everything** (never to skipping blindly), and a bookkeeping write failure is logged without failing a run whose ingest work succeeded.

## How verified

⚠️ **Local caveat:** this sandbox has no Postgres (and no pgvector or Docker daemon to start one), so **all 613 DB-gated tests skip locally** — including the dead-skip regression test. CI is the real check for those; the first CI run duly caught a defect in that test (see below).

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — clean.
- `npm run test:security` — **888/888**, manifest unchanged.
- `npm test` — **2449 tests, 0 failures**, *of which 613 DB-gated skipped locally*.

New coverage:
- **Pure policy** (`partitionDeadUrls`, runs everywhere): threshold boundary (`>=`, not `>`), in-cooldown skip vs. due-for-re-probe, `deadRuns=0` disables.
- **Run level** (DB-free — stubbed store + all-fetches-fail): a dead URL costs no request and is counted in `deadSkipped`; a threshold crossing is reported exactly once and stamped; an already-reported URL that re-probes and fails again is **not** re-reported; a config-lowered crossing still reports once before going quiet; a store read failure degrades to fetching everything; `=0` performs no store calls at all.
- **DB-backed repository**: streaks are *consecutive* (a success resets to 1, not cumulative), the upsert bumps rather than duplicating, re-marking preserves the original report time, empty-list calls are no-ops.
- **DB-backed regression guard**: `defaultDocsIngestRun` does **not** throw when every listed page was dead-skipped.

## Review fixes

- **Config-lowered crossing went unreported** (`4069ae9`): the newly-dead report was computed only from URLs that failed *this run*, but lowering `DOCS_INGEST_DEAD_URL_RUNS` onto an existing streak makes a URL dead *before* it is ever re-attempted — so it dropped out of the fetch set silently. Now reported on the crossing however it happened.
- **Dead-skip regression test failed on real Postgres** (`4e6eba8`): it wrote its row at real `now()` then mocked `Date` to `FAR_FUTURE_MS` (+5 years, this suite's convention for the *outer* freshness guard), so the row read as ancient, fell due for re-probe, and was fetched instead of skipped. Product behaviour was correct — a 5-year-old failure *should* be re-probed — so the fix anchors the row to the same mocked instant. Reviewing that also surfaced a second hazard: pre-existing docs-ingest tests call `runDocsIngest` without stub deps and would read/write the real streak table against the shared CI database, so `=0` became a complete off-switch and both affected files pin it off at module scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)