### PR TITLE
Give the three PR-fixing loops the build worker's checkpoint step

### DIFF
--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -322,7 +322,16 @@ jobs:
             echo "Agent committed nothing — nothing to checkpoint."; exit 0
           fi
           remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          if [ "${head_sha}" = "${remote_sha}" ]; then
+          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
+          # body passed straight through --jq, e.g. the literal "null") — the
+          # same trap pipeline-build.yml had to harden after a real incident.
+          # Treat anything that is not a 40-hex sha as "remote tip unknown":
+          # blanking it skips the divergence pre-check and attempts the ordinary
+          # NON-FORCE push, which the server rejects unless it is a
+          # fast-forward. Without this a bogus value fails the ancestor test and
+          # diverts a perfectly fast-forwardable recovery onto a side ref.
+          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
+          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
             echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
           fi
           target="${BRANCH}"

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -84,6 +84,9 @@ jobs:
       # (a re-run of the same failed CI must not read one real attempt as two).
       ATTEMPT_MARKER: '<!-- pipeline-autofix-attempt -->'
       ESCALATE_MARKER: '<!-- pipeline-autofix-escalation -->'
+      # Its own marker so a recovered-work notice can never inflate the
+      # attempt count or be mistaken for an escalation.
+      CHECKPOINT_MARKER: '<!-- pipeline-autofix-checkpoint -->'
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -282,6 +285,61 @@ jobs:
             --max-turns 200
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch origin:*),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+
+      # DETERMINISTIC CHECKPOINT — the "agent stalled and lost its work" class.
+      # The EXECUTION MODEL block above already tells the agent to run every
+      # command synchronously and NEVER to end its turn waiting for one, but
+      # the sibling loops proved that insufficient: the revise agent ended PR
+      # #606 with "I'll wait for the monitor notification before continuing
+      # with the security test suite, build, and push", and the conflict
+      # resolver ended PR #609 waiting on a Monitor task. Both had already
+      # COMMITTED work, which died with the runner. Autofix runs the same
+      # agent against the same long gate, so it carries the same risk and gets
+      # the same backstop, mirroring the build worker's checkpoint (#633/#682).
+      #
+      # Safe by construction: runs only AFTER the agent has exited (no process
+      # left to influence it or read the token), uses the job's GITHUB_TOKEN
+      # (valid for the whole job, unlike the agent's ~1h App token), and only
+      # ever FAST-FORWARDS the PR branch — if the remote moved under us the
+      # work is parked on a side ref rather than rewriting someone else's push.
+      # Placed BEFORE the verify step so a successful recovery is seen as the
+      # new commit it is.
+      - name: Checkpoint unpushed work (deterministic)
+        if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env, never ${{ }}-interpolated into the script body: a
+          # git ref name may legally contain shell metacharacters. Uses the
+          # same source expression as the checkout above rather than the
+          # job-level HEAD_BRANCH, so this step is self-contained.
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
+        run: |
+          set -euo pipefail
+          n="${{ steps.pr.outputs.number }}"
+          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
+            echo "Agent committed nothing — nothing to checkpoint."; exit 0
+          fi
+          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
+          if [ "${head_sha}" = "${remote_sha}" ]; then
+            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
+          fi
+          target="${BRANCH}"
+          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
+            target="${BRANCH}-ckpt-${{ github.run_id }}"
+            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
+          fi
+          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
+            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
+            exit 0
+          fi
+          echo "Checkpointed ${head_sha} to ${target}."
+          gh pr comment "$n" --body "${CHECKPOINT_MARKER}
+          🤖 Recovered work the autofix agent committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
+
+          ⚠️ This was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -255,6 +255,9 @@ jobs:
       # GITHUB_TOKEN it could exfiltrate (see pipeline-pr-autofix.yml).
       CONFLICT_MARKER: '<!-- pipeline-pr-conflict-attempt -->'
       ESCALATE_MARKER: '<!-- pipeline-pr-conflict-escalation -->'
+      # Its own marker so a recovered-work notice is never mistaken for an
+      # attempt or an escalation.
+      CHECKPOINT_MARKER: '<!-- pipeline-pr-conflict-checkpoint -->'
     steps:
       # Trust boundary + superseded-run guard, BEFORE any checkout. Two jobs
       # in one, both re-derived from the GitHub API rather than the dispatch
@@ -586,6 +589,60 @@ jobs:
             --max-turns 200
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git merge origin/main),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git fetch origin main),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+
+      # DETERMINISTIC CHECKPOINT — the "agent stalled and lost its work" class.
+      # The EXECUTION MODEL block above already tells the agent to run every
+      # command synchronously and NEVER to end its turn waiting for one. It
+      # does not always obey: this loop ended PR #609 with "I'll stop issuing
+      # further commands now and wait for the running Monitor task to notify me
+      # when `npm run test:security` finishes", and the revise loop ended PR
+      # #606 the same way. Both had already COMMITTED work, which died with the
+      # runner — each PR escalated `needs-human` with nothing to show for a
+      # full agent run, and #609's resolution turned out to be a clean merge a
+      # human completed in minutes. The prompt rule is necessary but provably
+      # not sufficient, so this is the deterministic backstop, mirroring the
+      # build worker's own checkpoint for the identical failure (#633/#682).
+      #
+      # Safe by construction: runs only AFTER the agent has exited (no process
+      # left to influence it or read the token), uses the job's GITHUB_TOKEN
+      # (valid for the whole job, unlike the agent's ~1h App token), and only
+      # ever FAST-FORWARDS the PR branch — if the remote moved under us the
+      # work is parked on a side ref rather than rewriting someone else's push.
+      # Placed BEFORE the verify step so a successful recovery is seen as the
+      # new commit it is.
+      - name: Checkpoint unpushed work (deterministic)
+        if: always() && steps.precheck.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env, never ${{ }}-interpolated into the script body —
+          # see the verify step below for why.
+          BRANCH: ${{ steps.precheck.outputs.branch }}
+          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
+            echo "Agent committed nothing — nothing to checkpoint."; exit 0
+          fi
+          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
+          if [ "${head_sha}" = "${remote_sha}" ]; then
+            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
+          fi
+          target="${BRANCH}"
+          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
+            target="${BRANCH}-ckpt-${{ github.run_id }}"
+            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
+          fi
+          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
+            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
+            exit 0
+          fi
+          echo "Checkpointed ${head_sha} to ${target}."
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "${CHECKPOINT_MARKER}
+          🤖 Recovered work the conflict resolver committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
+
+          ⚠️ This resolution was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
 
       - name: Verify the conflict was resolved (else escalate loudly)
         if: always() && steps.precheck.outputs.proceed == 'true'

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -625,7 +625,16 @@ jobs:
             echo "Agent committed nothing — nothing to checkpoint."; exit 0
           fi
           remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          if [ "${head_sha}" = "${remote_sha}" ]; then
+          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
+          # body passed straight through --jq, e.g. the literal "null") — the
+          # same trap pipeline-build.yml had to harden after a real incident.
+          # Treat anything that is not a 40-hex sha as "remote tip unknown":
+          # blanking it skips the divergence pre-check and attempts the ordinary
+          # NON-FORCE push, which the server rejects unless it is a
+          # fast-forward. Without this a bogus value fails the ancestor test and
+          # diverts a perfectly fast-forwardable recovery onto a side ref.
+          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
+          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
             echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
           fi
           target="${BRANCH}"

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -97,6 +97,9 @@ jobs:
       # count.
       ATTEMPT_MARKER: '<!-- pipeline-pr-revise-attempt -->'
       ESCALATE_MARKER: '<!-- pipeline-pr-revise-escalation -->'
+      # Its own marker so a recovered-work notice never counts toward the
+      # 2-try attempt cap either.
+      CHECKPOINT_MARKER: '<!-- pipeline-pr-revise-checkpoint -->'
     steps:
       - name: Inert notice (token not set)
         if: env.HAS_TOKEN != 'true'
@@ -268,6 +271,58 @@ jobs:
             --max-turns 200
             --model sonnet
             --allowedTools "Edit,Write,Read,MultiEdit,Grep,Glob,LS,TodoWrite,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git restore:*),Bash(git rm:*),Bash(git fetch origin:*),Bash(git rev-parse:*),Bash(git push origin HEAD),Bash(gh run view:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(cat:*),Bash(ls:*)"
+
+      # DETERMINISTIC CHECKPOINT — the "agent stalled and lost its work" class.
+      # The EXECUTION MODEL block above already tells the agent to run every
+      # command synchronously and to NEVER end its turn waiting for one. It
+      # does not always obey: on PR #606 this loop's agent ended with "I'll
+      # wait for the monitor notification before continuing with the security
+      # test suite, build, and push", and the conflict resolver ended PR #609
+      # with "I'll stop issuing further commands now and wait for the running
+      # Monitor task". Both had already COMMITTED work, which died with the
+      # runner — each PR was escalated `needs-human` with nothing to show for
+      # a full agent run. The prompt rule is necessary but provably not
+      # sufficient, so this is the deterministic backstop, mirroring the build
+      # worker's own checkpoint for the identical failure (#633/#682).
+      #
+      # Safe by construction: it runs only AFTER the agent has exited (no
+      # process left to influence it or read the token), uses the job's
+      # GITHUB_TOKEN (valid for the whole job, unlike the agent's ~1h App
+      # token), and only ever FAST-FORWARDS the PR branch — if the remote moved
+      # under us the work is parked on a side ref rather than rewriting
+      # someone else's push. Placed BEFORE the verify step on purpose, so a
+      # successful recovery is seen as the new commit it is.
+      - name: Checkpoint unpushed work (deterministic)
+        if: always() && steps.mark.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.precheck.outputs.branch }}
+          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
+            echo "Agent committed nothing — nothing to checkpoint."; exit 0
+          fi
+          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
+          if [ "${head_sha}" = "${remote_sha}" ]; then
+            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
+          fi
+          target="${BRANCH}"
+          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
+            target="${BRANCH}-ckpt-${{ github.run_id }}"
+            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
+          fi
+          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
+            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
+            exit 0
+          fi
+          echo "Checkpointed ${head_sha} to ${target}."
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "${CHECKPOINT_MARKER}
+          🤖 Recovered work the revise agent committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
+
+          ⚠️ This was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
 
       - name: Verify a revision was pushed (else escalate loudly)
         if: always() && steps.mark.outcome == 'success'

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -305,7 +305,16 @@ jobs:
             echo "Agent committed nothing — nothing to checkpoint."; exit 0
           fi
           remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          if [ "${head_sha}" = "${remote_sha}" ]; then
+          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
+          # body passed straight through --jq, e.g. the literal "null") — the
+          # same trap pipeline-build.yml had to harden after a real incident.
+          # Treat anything that is not a 40-hex sha as "remote tip unknown":
+          # blanking it skips the divergence pre-check and attempts the ordinary
+          # NON-FORCE push, which the server rejects unless it is a
+          # fast-forward. Without this a bogus value fails the ancestor test and
+          # diverts a perfectly fast-forwardable recovery onto a side ref.
+          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
+          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
             echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
           fi
           target="${BRANCH}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ for anything after ~noon NZST/NZDT). Get today's date with
 ## 2026-07-25
 
 ### Changed
+- **The three PR-fixing loops now checkpoint committed work too**, closing the
+  same "the agent stalled and its work died with the runner" hole the build
+  worker had. Each loop already told its agent to run every command
+  synchronously and never to end its turn waiting for one — and agents ignored
+  it: the revise worker ended one PR with "I'll wait for the monitor
+  notification before continuing with the security test suite, build, and
+  push", and the conflict resolver ended another waiting on a background task.
+  Both had already committed real work, both lost it, and both PRs were then
+  escalated for a human with nothing to show — one of them a conflict that
+  turned out to be a clean merge finished in minutes. Autofix, the conflict
+  resolver, and the revise loop now each run the build worker's deterministic
+  checkpoint after the agent exits, so committed work is pushed rather than
+  discarded. It only ever fast-forwards the PR branch (a branch that moved
+  underneath gets a separate `-ckpt-` ref instead of being overwritten), and
+  because recovered work never cleared the agent's own checks, the comment it
+  leaves says so plainly: CI decides, and the automated review still has to
+  pass, so recovery can surface work but never slip unverified work into a
+  merge.
 - **The pipeline's build worker now checkpoints committed work
   deterministically**: a post-agent workflow step pushes any
   committed-but-unpushed branch with the job's own token (to a unique

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,23 @@ ownership rules:
   rebuilding (issue #667) — the pointer is resolved by a deterministic
   pre-step (bot comments only, exact template, remote-verified), never by the
   agent reading comment text.
+- **All three PR-fixing loops (autofix, conflict-resolver, revise) carry the
+  same deterministic checkpoint** as the build worker, for the same reason.
+  Each already instructs its agent to run every command synchronously and to
+  NEVER end its turn waiting for one, and that instruction is provably not
+  enough: the revise agent ended PR #606 with *"I'll wait for the monitor
+  notification before continuing with the security test suite, build, and
+  push"*, and the conflict resolver ended PR #609 waiting on a Monitor task —
+  both had already COMMITTED work, which died with the runner, and both PRs
+  escalated `needs-human` with nothing to show (#609's "unresolvable" conflict
+  was then a clean merge a human finished in minutes). The checkpoint runs
+  after the agent exits, pushes committed-but-unpushed work with the job's
+  GITHUB_TOKEN, and only ever FAST-FORWARDS the PR branch — a remote that
+  moved parks the work on a `-ckpt-<run_id>` ref instead of rewriting someone
+  else's push. Because that work never cleared the agent's own gate, the
+  recovery comment says so explicitly: CI on the push is the adjudicator and
+  the automated review still has to pass, so a checkpoint can surface work but
+  can never launder it into a merge.
 - The **auto-merge loop** (`pipeline-pr-automerge.yml`) merges fully-vetted
   build-worker PRs, one at a time, so a backlog of green + approved PRs doesn't
   stall on a human. It is a **deterministic, no-LLM, no-Max-pool** shell loop

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -95,6 +95,24 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   guardrails as autofix (`gh` read-only except `gh pr comment` so a
   principled refusal is explained on the PR). It never opens or merges PRs.
   Do not misflag its pushes as an ownership violation either.
+- **All three of the above (autofix, conflict-resolver, revise) also carry the
+  build worker's deterministic checkpoint step**, for the same reason it was
+  added there: prompt-only compliance is unreliable. Each loop's EXECUTION
+  MODEL block already says to run every command synchronously and NEVER to end
+  the turn waiting for one, and agents still did exactly that — the revise
+  agent ended PR #606 with *"I'll wait for the monitor notification before
+  continuing with the security test suite, build, and push"* and the conflict
+  resolver ended PR #609 waiting on a Monitor task. Both had COMMITTED work
+  that died with the runner; both PRs escalated `needs-human` having produced
+  nothing, and #609's supposedly unresolvable conflict was a clean `main`
+  merge a human completed in minutes. The step runs after the agent exits,
+  pushes committed-but-unpushed work with the job's GITHUB_TOKEN, and only
+  FAST-FORWARDS the PR branch (a moved remote parks the work on a
+  `-ckpt-<run_id>` ref rather than rewriting it). Since that work never passed
+  the agent's own gate, the recovery comment says so outright — CI on the push
+  adjudicates and the automated review must still pass, so a checkpoint can
+  rescue work but never launder unverified work into a merge. Its pushes are
+  likewise not an ownership violation.
 - A fourth exception: the **auto-merge loop** (`pipeline-pr-automerge.yml`)
   merges fully-vetted build-worker PRs — a deliberate, tightly-gated reversal
   of the original "a human merges everything" rule, added because throughput,


### PR DESCRIPTION
## Summary

Closes the *"the agent stalled and its committed work died with the runner"* hole in **autofix**, the **conflict resolver**, and the **revise** loop. The build worker got a deterministic checkpoint for exactly this failure (#633/#682); the three loops that push to existing PR branches never did.

**The prompt rule already exists, and is provably not enough.** Every one of these loops has an `EXECUTION MODEL` block telling the agent to run commands synchronously — the conflict resolver's says verbatim `NEVER end your turn to "wait" for a command.` Agents ignored it anyway:

| PR | Loop | The agent's own final words |
|----|------|------------------------------|
| #606 | revise | *"I'll wait for the monitor notification before continuing with the security test suite, build, and push."* |
| #609 | conflict | *"I'll stop issuing further commands now and wait for the running Monitor task to notify me when `npm run test:security` finishes."* |

Both had already **committed** work. Both lost it. Both PRs escalated `needs-human` having produced nothing — and #609's *"semantically incompatible"* conflict turned out to be a clean `main` merge a human finished in minutes. Adding more prompt text was not going to fix a rule the model already had, so this is the deterministic backstop instead.

## What changed

Each loop now runs the same post-agent checkpoint, placed **immediately before its existing verify step** so a recovery registers as the new commit it is:

- Runs only **after the agent has exited** — no process left to influence it or read the token — with the job's `GITHUB_TOKEN`, which outlives the agent's ~1h App token.
- **No-ops** when the agent committed nothing, or when it already pushed.
- Only ever **fast-forwards** the PR branch. If the remote moved underneath, the work is parked on a `-ckpt-<run_id>` ref rather than rewriting someone else's push.
- Leaves a marker-guarded comment stating plainly that the work **never cleared the agent's own gate**.

Each loop's checkpoint marker is distinct from its attempt/escalation markers, so a recovery notice can never inflate an attempt cap or read as an escalation.

## Security / privacy impact

No new tool, RBAC surface, or data path — CI/workflow plumbing only.

The token posture is unchanged and deliberate: the checkpoint step is the *only* place its `GITHUB_TOKEN` appears, it runs after the agent process is gone, and the checkouts keep `persist-credentials: false`, so there is no new window in which an agent reading untrusted PR/CI content could reach a credential. The push target is constructed from the workflow's own branch expression (passed via `env`, never `${{ }}`-interpolated into the script body, matching the existing convention in these files for refs that may contain shell metacharacters).

**Recovered work cannot be laundered into a merge.** It is unverified by construction, so the comment says so, CI runs on the push and adjudicates, and the auto-merge loop still requires all checks green *plus* a fresh `LGTM` from the review worker. The bounded attempt caps (2 for autofix/revise, 1 for conflict) are untouched.

⚠️ This PR touches `.github/`, `CLAUDE.md`, and `docs/PIPELINE.md` — all governance paths — so by design the auto-merge loop will not touch it and it needs a **human merge**.

## How verified

Workflow/docs only — no source or test changes, so the suite is unaffected.

- All three workflows **parse as valid YAML**, and the checkpoint step is confirmed to sit at the index immediately before each job's `Verify` step.
- The `run` body passes **`bash -n`** with the Actions expressions stubbed out.
- Both early-exit guards dry-run correctly: *agent committed nothing* and *agent already pushed* each no-op.
- `npm run lint`, `npm run format:check`, `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_