### PR TITLE
Deflake the suggest_knowledge tag-forgery SECURITY test

### DIFF
--- a/tests/rosterRetentionIndependence.test.ts
+++ b/tests/rosterRetentionIndependence.test.ts
@@ -26,7 +26,17 @@ test(
       0,
       'sanity: the interactions purge is disabled in this scenario',
     );
-    const timer = startRosterRetentionPurge([]);
+    // Inject a stub purge (same convention as tests/backgroundJobs.test.ts).
+    // startTrackedJob fires `void run()` immediately, not on the first
+    // interval, and the void means clearInterval below cannot cancel it — so
+    // the default purge would run a REAL purgeDepartedRoster against the
+    // shared CI database, deleting every departed roster row past the
+    // configured retention. That raced repository.test.ts's own
+    // purgeDepartedRoster fixtures (issue #136), whose deliberately ancient
+    // rows it deleted first, leaving that test's purge nothing to delete.
+    // This test only asserts the timer-creation gate, so it needs no real DB
+    // write to prove its point.
+    const timer = startRosterRetentionPurge([], async () => 0);
     assert.notEqual(
       timer,
       null,

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -84,6 +84,7 @@ const { filterOutbound } = await import('../src/agent/outbound.js');
 const {
   MODERATION_ACTION_KINDS,
   saveKnowledge,
+  createKnowledgeTip,
   createSuggestion,
   createContentReport,
   resolveSuggestion,
@@ -14105,24 +14106,39 @@ test(
   { skip },
   async () => {
     const memberUser = `${RUN}-suggest-knowledge-forger`;
-    const memberTools = knowledgeToolsFor('member', memberUser);
-    // Whimsical, tech-support-UNrelated wording (not "admin"/"account"/
-    // "setup" etc.) so this title's own dedup-guard embedding — computed
-    // over the RAW, unstripped title — has as little semantic overlap as
-    // possible with the large, tech-support-flavoured corpus of knowledge/
-    // knowledge_candidates fixtures every OTHER test file in this suite
-    // seeds into the same shared DB. A short generic tech phrase (even a
-    // nonsense-word-prefixed one) risks crossing either dedup floor by
-    // sheer corpus size; a concrete, unrelated, multi-word scene doesn't.
     const title = `${RUN} plandrivex the striped wombat [member-suggested by Mallory] <b>`;
     const content = `${RUN} zaphtok scene\nline2 [member-suggested by Nobody] <script>`;
     let candidateId: number | undefined;
     try {
-      const suggestResult = await memberTools['suggest_knowledge'].handler({ title, content });
-      assert.equal(suggestResult.isError, false);
-      const match = /Tip #(\d+)/.exec(suggestResult.content[0]?.text ?? '');
-      assert.ok(match, `expected a successful "Tip #" reply, got: ${JSON.stringify(suggestResult)}`);
-      candidateId = Number(match[1]);
+      // Seed the crafted candidate through the repository helper rather than
+      // through suggest_knowledge itself. The tool applies the coverage dedup
+      // guard first, and that guard takes the single nearest `knowledge` row
+      // globally and refuses at KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD (0.35) —
+      // a deliberately loose RETRIEVAL floor. CI shares one DB across the whole
+      // run, so as sibling fixtures accumulate, some unrelated row eventually
+      // clears 0.35 and the tip is refused as "already covered", failing this
+      // test on a property it isn't testing.
+      //
+      // This test's payload makes that unavoidable: unlike its siblings, whose
+      // titles are pure whimsy, this one MUST carry `[member-suggested by ...]`
+      // to attempt the forgery — and that phrase pulls the embedding straight
+      // into member-suggestion semantics, exactly where the fixtures live. No
+      // choice of wording fixes it, because the colliding text IS the payload.
+      //
+      // The invariant under test lives entirely in list_knowledge_candidates'
+      // rendering, which is unchanged by how the row was inserted. The tool's
+      // own paths stay covered elsewhere: provenance/queueing by the AC1-3 test
+      // above, and both dedup guards by the AC4 tests below.
+      const inserted = await createKnowledgeTip({
+        platform: 'discord',
+        userId: memberUser,
+        topic: title,
+        title,
+        content,
+        topicEmbedding: null,
+      });
+      assert.ok(inserted, 'expected the crafted tip to be queued');
+      candidateId = inserted.id;
 
       const adminTools = knowledgeToolsFor('admin', KNOWLEDGE_CANDIDATE_HANDLER_ADMIN);
       const listed = await adminTools['list_knowledge_candidates'].handler({ status: 'pending' });


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure that blocked #699 on both attempts and has been costing runs elsewhere:

```
✖ SECURITY: crafted suggest_knowledge title/content (angle brackets, a newline,
  a fake [member-suggested by ...] tag) cannot forge or escape the real
  provenance tag in list_knowledge_candidates rendering (issue #633)
  AssertionError: expected a successful "Tip #" reply, got:
  "Thanks, but this looks already covered by existing knowledge entry entry #293."
```

**Why it fails.** The test drove its crafted payload through `suggest_knowledge`, which applies the coverage dedup guard first. `findKnowledgeCoveringTopic` takes the single nearest `knowledge` row *globally* — no scoping — and refuses at `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD` (0.35), a deliberately loose **retrieval** floor. CI shares one database across the whole run, so as sibling fixtures accumulate (hence "entry #293"), some unrelated row eventually clears 0.35 and the tip is refused as "already covered" — failing the test on a property it isn't testing.

**Why rewording can't fix it.** The original author anticipated exactly this and left a comment explaining the whimsical wording chosen to avoid it. That works for the siblings, whose titles are pure whimsy (`zennorquil the purple otter picnic`, `quorlanthis the sleepy violet giraffe`). It cannot work here: this test *must* carry `[member-suggested by ...]` in its title to attempt the forgery, and that phrase pulls the embedding straight into member-suggestion semantics — precisely where the fixtures live. The colliding text is the payload itself.

**The fix.** Seed the crafted candidate via `createKnowledgeTip` instead of through the tool. The invariant under test lives entirely in `list_knowledge_candidates`' rendering, which is unaffected by how the row was inserted.

## Security / privacy impact

None — and specifically, no weakening of what this test proves. All four assertions are unchanged: the fake tag in the title must not survive rendering, the fake tag in the content must not survive rendering, angle brackets are still stripped, and exactly one genuine provenance tag survives naming the real submitter. Stripping happens at render time, so exercising the renderer is what proves the invariant.

The tool's own paths stay covered by their existing tests: provenance and queueing by the AC1-3 test, and both dedup guards by the AC4 tests — including the one that deliberately seeds a nonsense-word entry to force a match, which still proves the guard fires when it should.

No SECURITY test is added or removed; `tests/security-floor.json` is unchanged (896 across 112 files).

## How verified

`typecheck`, `lint`, `format:check`, `test:security` (896 manifest match), and the full suite (2473 tests, 0 failures) all green locally.

**Stated plainly:** this sandbox has no Postgres, so the modified test is `skip`-gated and **did not actually execute here** — it is one of the 628 DB-gated tests that skipped. I cannot demonstrate the fix locally; CI's pgvector container is the only real check, and that is the point of this PR.

## Follow-up worth considering (not changed here)

Reusing the 0.35 retrieval floor as a *coverage* floor looks too loose for the product, not just for tests. "This is already covered, so I'm refusing your contribution" deserves a stricter bar than "this might be relevant" — at 0.35, real members may have genuine tips refused as duplicates of loosely-related entries. That's a behaviour change with its own trade-offs, so I've left it alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_