### PR TITLE
Deflake the context-builder tests by bounding a run to its own corpus

### DIFF
--- a/src/context/builder.ts
+++ b/src/context/builder.ts
@@ -47,6 +47,18 @@ const CLUSTER_SIMILARITY_THRESHOLD = 0.85;
 /** How many (truncated) samples each summarisation call sees. */
 const MAX_SAMPLES_PER_SUMMARY = 12;
 
+/**
+ * The corpus one run clusters over. Injectable for the same reason
+ * `summarize` is: the real implementation reads the WHOLE `interactions`
+ * table in the window, so a test asserting "this cluster won the
+ * `maxSummaries` slot" is really asserting something about every row any
+ * concurrently-running test file happens to have inserted. Production always
+ * uses the default.
+ */
+export type ClusterCorpus = (
+  windowDays: number,
+) => Promise<Array<{ id: number; userId: string; content: string; embedding: number[] }>>;
+
 export type ClusterSummarizer = (samples: string[]) => Promise<{
   topic: string;
   summary: string;
@@ -195,10 +207,13 @@ export async function summarizeCluster(
  * One builder run. The scheduler (src/index.ts) gates this behind
  * CONTEXT_BUILDER_ENABLED and shouldRunContextBuilder; the run itself
  * enforces the usage guard, the k-floor, and the hard summary cap.
- * `summarize` is injectable so tests never spawn a real model call.
+ * `summarize` is injectable so tests never spawn a real model call;
+ * `fetchCorpus` is injectable so they can bound the run to their own rows
+ * rather than the whole shared table (see {@link ClusterCorpus}).
  */
 export async function runContextBuilder(
   summarize: ClusterSummarizer = summarizeCluster,
+  fetchCorpus: ClusterCorpus = recentInboundForClustering,
 ): Promise<BuilderResult> {
   const { windowDays, maxSummaries, minDistinctUsers } = config.contextBuilder;
 
@@ -225,7 +240,7 @@ export async function runContextBuilder(
     }
   }
 
-  const rows = await recentInboundForClustering(windowDays);
+  const rows = await fetchCorpus(windowDays);
   if (rows.length === 0) {
     return {
       digests: 0,

--- a/tests/contextBuilder.test.ts
+++ b/tests/contextBuilder.test.ts
@@ -2,10 +2,19 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 
 // Offline context builder (issue #51). DB-backed (skip without DATABASE_URL);
-// the summariser is injected so no real model call ever happens in tests.
+// the summariser is injected so no real model call ever happens in tests, and
+// the corpus is injected (see `ownCorpus`) so a run only ever clusters THIS
+// file's own rows.
+//
 // Vectors are hand-crafted one-hot axes (same technique as the
-// recentQuestionClusters tests) so clustering is deterministic and immune to
-// whatever real-embedding rows other test files insert.
+// recentQuestionClusters tests) so clustering here is deterministic. That
+// alone is NOT isolation, which the previous version of this comment claimed:
+// `runContextBuilder` reads the whole `interactions` table, test files run in
+// parallel against one Postgres, and a one-hot axis is a *shared* coordinate
+// — tests/knowledgeCandidateDedupEmbedCount.test.ts seeds axis 31 too, so its
+// rows landed in the same cluster as this file's axis-31 rows at cosine 1.0
+// and could win the `maxSummaries = 1` slot outright. `ownCorpus` is the
+// actual fix: pick the winner from our own rows or don't assert a winner.
 const hasDb = Boolean(process.env.DATABASE_URL);
 
 process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
@@ -38,10 +47,20 @@ const {
   listContextDigests,
   listKnowledgeCandidates,
   purgeUserData,
+  recentInboundForClustering,
   saveKnowledge,
 } = await import('../src/storage/repository.js');
 
 const RUN = `ctx${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+
+/**
+ * The REAL corpus read, narrowed to the rows `seed()` inserted for this run.
+ * Every seeded user id is `${RUN}-…`, so the filter is exact — and because
+ * this still calls `recentInboundForClustering`, its window/direction/
+ * embedding-not-null SQL stays covered rather than being stubbed away.
+ */
+const ownCorpus = async (days: number) =>
+  (await recentInboundForClustering(days)).filter((r) => r.userId.startsWith(RUN));
 
 after(async () => {
   if (hasDb) {
@@ -99,7 +118,7 @@ test(
     const result = await runContextBuilder(async (samples) => {
       calls.push(samples);
       return { topic: `${RUN}-topic-${calls.length}`, summary: 'aggregate summary of the theme' };
-    });
+    }, ownCorpus);
 
     assert.equal(calls.length, 1, 'HARD cap: exactly maxSummaries (1) model calls, no overrun');
     assert.equal(result.digests, 1);
@@ -127,6 +146,37 @@ test(
 );
 
 test(
+  'runContextBuilder defaults its corpus to the real recentInboundForClustering read — the seam the tests above inject is opt-in, not a stub production also gets',
+  { skip },
+  async () => {
+    // Deliberately called with NO corpus argument, so the default binding is
+    // what reads the DB. Every assertion here is monotone in foreign rows —
+    // other test files can add clusters but can never take ours away — so
+    // this covers the default path without reintroducing the winner race.
+    await seed(40, `${RUN}-m1`, 'which model should I start with');
+    await seed(40, `${RUN}-m2`, 'what model to pick first?');
+    await seed(40, `${RUN}-m3`, 'recommended starting model?');
+
+    const result = await runContextBuilder(async () => ({
+      topic: `${RUN}-default-corpus-topic`,
+      summary: 'aggregate summary',
+    }));
+
+    assert.equal(
+      result.attempted,
+      1,
+      'the cap admits exactly one cluster, and the default corpus found at least ours to fill it — ' +
+        'a default that read nothing would report skippedReason "no-data" and attempt 0',
+    );
+    assert.ok(result.clustersConsidered >= 1, 'the default read returned real rows to cluster');
+    assert.notEqual(result.skippedReason, 'no-data');
+
+    await pool.query(`DELETE FROM interactions WHERE conversation_id = $1`, [`${RUN}-chan`]);
+    await pool.query(`DELETE FROM context_digests WHERE topic = $1`, [`${RUN}-default-corpus-topic`]);
+  },
+);
+
+test(
   'runContextBuilder: `failed` counts only clusters whose summarize() threw, and `attempted` (not `clustersConsidered`) is the right total-failure denominator when the run is cap-truncated (issue #335)',
   { skip },
   async () => {
@@ -142,7 +192,7 @@ test(
 
     const result = await runContextBuilder(async () => {
       throw new Error('summarizer unavailable');
-    });
+    }, ownCorpus);
 
     assert.equal(result.attempted, 1, 'the cap limits this run to attempting exactly one cluster');
     assert.ok(
@@ -181,7 +231,7 @@ test(
         calls += 1;
         if (calls === 1) throw new Error('summarizer unavailable');
         return { topic: `${RUN}-partial-topic`, summary: 'aggregate summary' };
-      });
+      }, ownCorpus);
 
       assert.equal(result.attempted, 2);
       assert.equal(result.failed, 1, 'exactly one of the two attempted clusters failed');
@@ -208,10 +258,13 @@ test(
     await seed(13, `${RUN}-d3`, 'discord for events works');
     await seed(13, `${RUN}-d3`, '+1 discord events');
 
-    const result = await runContextBuilder(async () => ({
-      topic: `${RUN}-purge-topic`,
-      summary: 'a summary that was partly built over the purged user content',
-    }));
+    const result = await runContextBuilder(
+      async () => ({
+        topic: `${RUN}-purge-topic`,
+        summary: 'a summary that was partly built over the purged user content',
+      }),
+      ownCorpus,
+    );
     assert.ok(result.digests >= 1, 'a digest was built over the cluster');
 
     const before = await pool.query(`SELECT id FROM context_digests WHERE topic = $1`, [
@@ -250,7 +303,7 @@ test(
         summary: 'members keep asking about the code of conduct',
         candidate: { title: `${RUN} Code of conduct`, content: 'See the pinned #rules channel.' },
       };
-    });
+    }, ownCorpus);
     assert.equal(
       calls.length,
       1,
@@ -292,11 +345,14 @@ test(
     flag.enabled = false;
     let result;
     try {
-      result = await runContextBuilder(async () => ({
-        topic: `${RUN}-cd-topic`,
-        summary: 'summary',
-        candidate: { title: 'Code of conduct', content: 'See the pinned doc.' },
-      }));
+      result = await runContextBuilder(
+        async () => ({
+          topic: `${RUN}-cd-topic`,
+          summary: 'summary',
+          candidate: { title: 'Code of conduct', content: 'See the pinned doc.' },
+        }),
+        ownCorpus,
+      );
     } finally {
       flag.enabled = true;
     }
@@ -337,11 +393,14 @@ test(
     });
     await declineKnowledgeCandidate(priorCandidateId, 'admin-1');
 
-    const resultQueued = await runContextBuilder(async () => ({
-      topic: `${RUN}-dedup-queued-topic`,
-      summary: 'summary',
-      candidate: { title: 'new title', content: 'new content' },
-    }));
+    const resultQueued = await runContextBuilder(
+      async () => ({
+        topic: `${RUN}-dedup-queued-topic`,
+        summary: 'summary',
+        candidate: { title: 'new title', content: 'new content' },
+      }),
+      ownCorpus,
+    );
     assert.equal(resultQueued.digests, 1, 'the digest itself is still written');
     assert.equal(
       resultQueued.candidates,
@@ -362,11 +421,14 @@ test(
       scope: 'global',
     });
 
-    const resultAnswered = await runContextBuilder(async () => ({
-      topic: `${RUN} zylotrix onboarding steps`,
-      summary: 'summary',
-      candidate: { title: 'new title', content: 'new content' },
-    }));
+    const resultAnswered = await runContextBuilder(
+      async () => ({
+        topic: `${RUN} zylotrix onboarding steps`,
+        summary: 'summary',
+        candidate: { title: 'new title', content: 'new content' },
+      }),
+      ownCorpus,
+    );
     assert.equal(resultAnswered.digests, 1);
     assert.equal(
       resultAnswered.candidates,

--- a/tests/knowledgeCandidateDedupEmbedCount.test.ts
+++ b/tests/knowledgeCandidateDedupEmbedCount.test.ts
@@ -52,6 +52,7 @@ test(
     embeddingDim = config.db.embeddingDim;
     const pgvector = (await import('pgvector/pg')).default;
     const { runContextBuilder } = await import('../src/context/builder.js');
+    const { recentInboundForClustering } = await import('../src/storage/repository.js');
 
     // config is `as const` (deep-readonly at the type level only) — same
     // narrow-cast-and-mutate convention as tests/contextBuilder.test.ts,
@@ -82,12 +83,24 @@ test(
     await seed(31, `${RUN}-a2`, 'meetup date please?');
     await seed(31, `${RUN}-a3`, 'any update on the meetup?');
 
+    // The real corpus read, narrowed to this run's own rows. Without it the
+    // one `maxSummaries` slot is contested by every row any concurrently
+    // running test file has inserted — and axis 31 is not even unique to this
+    // file (tests/contextBuilder.test.ts seeds it too, at cosine 1.0), so the
+    // attempted cluster could be someone else's and carry a different embed()
+    // count than the one asserted here.
+    const ownCorpus = async (days: number) =>
+      (await recentInboundForClustering(days)).filter((r) => r.userId.startsWith(RUN));
+
     try {
-      const result = await runContextBuilder(async () => ({
-        topic: `${RUN}-embed-count-topic`,
-        summary: 'summary',
-        candidate: { title: 'title', content: 'content' },
-      }));
+      const result = await runContextBuilder(
+        async () => ({
+          topic: `${RUN}-embed-count-topic`,
+          summary: 'summary',
+          candidate: { title: 'title', content: 'content' },
+        }),
+        ownCorpus,
+      );
 
       assert.equal(result.digests, 1, 'the digest itself is still produced');
       assert.equal(embedCalls, 1, 'embed() is called at most once for this one attempted cluster');


### PR DESCRIPTION
## Summary

Two tests in `tests/contextBuilder.test.ts` failed CI on #702, a documentation-only PR:

- `context builder digests the top cross-user topic, drops sub-floor clusters, and never exceeds the summary cap (issue #51)` — "the single summary call went to the highest-count cluster (A)"
- `SECURITY: purging a user invalidates every digest built over their content — it cannot resurface (issue #51)` — expected `0`, got `1`

**Root cause.** `runContextBuilder` reads the *whole* `interactions` table in its window, test files run in parallel against one Postgres service container, and the file's own header comment claimed the hand-crafted one-hot axis vectors made it "immune to whatever real-embedding rows other test files insert". They don't — an axis is a shared coordinate, not a namespace. `tests/knowledgeCandidateDedupEmbedCount.test.ts` seeds **axis 31 too**, so its rows join this file's axis-31 cluster at cosine 1.0 and can win the `CONTEXT_BUILDER_MAX_SUMMARIES=1` slot outright.

That single mechanism explains both failures. The summariser is handed someone else's cluster, so no sample contains `meetup`; and the purge test's digest is then written over *foreign* interaction ids, so purging the victim leaves it standing — `1 !== 0`, the exact CI assertion.

**Fix.** `runContextBuilder` takes an injectable corpus (`ClusterCorpus`) defaulting to `recentInboundForClustering`, mirroring the `summarize` seam already there for the same reason. Production behaviour is unchanged — the default is the only binding it ever uses. Both test files pass an `ownCorpus` that calls the **real** `recentInboundForClustering` and narrows it to rows whose user id carries the file's own `RUN` prefix, so the window/direction/embedding-not-null SQL stays covered rather than stubbed away.

A new test calls `runContextBuilder` with no corpus argument so the default binding keeps its coverage. Its assertions are monotone in foreign rows — other files can add clusters, never remove ours — so it cannot reintroduce the race it guards against.

The stale "immune to" comment is replaced with what is actually true, naming the sibling file and the axis collision, so the next person doesn't re-derive this.

## Security / privacy impact

None. No change to auth, tool gating, RBAC tiers, outbound filtering, data-access scope, or stored data. The one production change is an optional parameter whose default preserves the existing call exactly; no runtime caller passes it.

The `SECURITY:` purge-invalidation test is **strengthened, not weakened** — it now reliably digests the cluster containing the victim's rows, which is the precondition its assertion was always meant to test. Under the old code a foreign cluster winning the slot made that test pass or fail for reasons unrelated to purge correctness. No `SECURITY:` test is added or removed, so `tests/security-floor.json` is unchanged.

## How verified

Against a local Postgres 16 + pgvector 0.6.0, with CI's env values (`DISCORD_GUILD_ID=ci-dummy-guild` etc.):

- **Deterministic reproduction, not inference.** Seeding 5 foreign axis-31 rows makes the pre-fix top-cluster test fail; at 8 rows the purge test fails as well — the same two failures, in the same order, as the CI run. With this change and the same rows present, both pass.
- `npm test` — 2474 tests, **2470 pass, 0 fail**, 4 skipped.
- `npm run test:security` — **896 `SECURITY:` tests ran, manifest total 896 across 112 files**.
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run format:check` — all clean.
- `npm run migrate:ci` applied the schema against the local pgvector instance before the DB-backed runs.

No changelog entry: this is internal test hygiene, matching #700's `Deflake …` precedent that the coverage check filters.

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_