### PR TITLE
Auto-merge loop closes the linked issue itself instead of trusting keyword auto-close

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -375,7 +375,7 @@ jobs:
                 issue_state="$(gh issue view "$closed_issue" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo '')"
                 if [ "$issue_state" = 'OPEN' ]; then
                   gh issue close "$closed_issue" --repo "$REPO" --reason completed \
-                    --comment "🤖 Closed by the auto-merge loop after merging PR #$n (deterministic close — GitHub's keyword auto-close is best-effort and skipped several issues on 2026-07-26)." \
+                    --comment "🤖 Closed by the auto-merge loop after merging PR #$n (deterministic close — GitHub's keyword auto-close is best-effort and has skipped issues before)." \
                     || echo "::warning::Could not close issue #$closed_issue after merging PR #$n — close it manually."
                 fi
               fi

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -359,6 +359,26 @@ jobs:
             if gh pr merge "$n" --repo "$REPO" "--$MERGE_METHOD" \
               --match-head-commit "$head_sha" --delete-branch; then
               echo "Merged PR #$n."
+              # Close the linked issue DETERMINISTICALLY rather than trusting
+              # GitHub's keyword auto-close. On 2026-07-26 three of five
+              # auto-merged PRs (#712, #721, #722) left their `Closes #N`
+              # issues open while two closed normally — same repo, same loop,
+              # same body format, so the platform's async issue-linkage is
+              # best-effort, not a contract. A closed-PR/open-issue zombie is
+              # invisible to the groundskeeper (which keys on status:building,
+              # not status:built) and wedges nothing but lies to every label
+              # scan. The number comes from the same `Closes #N` body match
+              # the eligibility gate above already required; skip silently if
+              # the platform got there first (the normal case).
+              closed_issue="$(jq -r '(.body // "") | capture("[Cc]loses #(?<num>[0-9]+)").num // empty' <<<"$struct")"
+              if [ -n "$closed_issue" ]; then
+                issue_state="$(gh issue view "$closed_issue" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo '')"
+                if [ "$issue_state" = 'OPEN' ]; then
+                  gh issue close "$closed_issue" --repo "$REPO" --reason completed \
+                    --comment "🤖 Closed by the auto-merge loop after merging PR #$n (deterministic close — GitHub's keyword auto-close is best-effort and skipped several issues on 2026-07-26)." \
+                    || echo "::warning::Could not close issue #$closed_issue after merging PR #$n — close it manually."
+                fi
+              fi
               # main advanced — rebase whatever now conflicts. A GITHUB_TOKEN
               # merge does NOT itself trigger the resolver's push-to-main
               # trigger, so dispatch its discover run explicitly (empty input =


### PR DESCRIPTION
## Summary

GitHub's `Closes #N` keyword auto-close proved best-effort today: of five auto-merged build-worker PRs, **three (#712, #721, #722) left their issues open** (#709, #718, #720 — all closed by hand) while two (#714's and #716's) closed normally. Same repo, same loop, same body format, same merging identity — intermittent outcome, so the platform's asynchronous issue-linkage cannot be what the pipeline's state machine depends on. A closed-PR/open-issue zombie carries `status:built` forever and is invisible to the groundskeeper, whose sweep keys on `status:building`.

After a successful merge, `pipeline-pr-automerge.yml` now extracts the issue number from the same `Closes #N` body match its eligibility gate already required, checks the issue is still open (the platform usually gets there first), and closes it with `--reason completed` plus a one-line provenance comment. A failed close degrades to a workflow warning, never a failed run.

## Security / privacy impact

No change to the bot's runtime — workflow-only. The loop's deterministic no-LLM posture is preserved: the PR body is read strictly as jq data from the `struct` the gate already fetched, no PR-controlled code executes, and the close targets only the issue number the merge gate itself validated (the same `[Cc]loses #[0-9]+` pattern, first match). The `issues: write` permission the workflow needs was already granted (used for `gh label create`). No change to any merge gate — this runs strictly *after* a merge that passed every existing check.

## How verified

- YAML parses; the modified step passes `bash -n`; Prettier clean.
- The `jq` capture expression verified against a sample body (`Closes #720` → `720`).
- Evidence trail verified against today's live history: the three unclosed issues and two closed ones enumerated above, all merged by this loop within a four-hour window.

Governance path (`.github/`), so this requires a human merge — covered by the owner's standing authorization for this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_