### PR TITLE
Add a deterministic branch-janitor sweep

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -32,7 +32,12 @@ on:
       dry_run:
         description: 'List what would be deleted without deleting'
         type: boolean
-        default: false
+        # true so a bare manual dispatch can never accidentally sweep live —
+        # a live manual run must say dry_run=false explicitly. The weekly
+        # cron supplies no inputs at all, so this default does NOT apply
+        # there: `inputs.dry_run` renders empty, != 'true', and the
+        # scheduled sweep runs live as intended.
+        default: true
       extra:
         description: 'Comma-separated branch names to also delete (rule 3)'
         type: string
@@ -90,7 +95,11 @@ jobs:
             fi
             # Rule 2: every PR with this head is MERGED (>=1 PR required).
             # States read strictly as jq data from the PR ledger.
-            states="$(gh pr list --repo "$REPO" --head "$b" --state all \
+            # --limit 100: the default (30) could silently truncate the state
+            # list for a branch with many reopened PRs, and a truncated list
+            # that happened to be all-MERGED would wrongly qualify a branch
+            # that still has an open/rejected PR beyond the cap.
+            states="$(gh pr list --repo "$REPO" --head "$b" --state all --limit 100 \
               --json state --jq 'map(.state) | unique | join(",")' 2>/dev/null || echo '')"
             if [ "$states" = 'MERGED' ]; then
               delete_ref "$b" 'all PRs merged'

--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -1,0 +1,120 @@
+name: Branch janitor
+
+# Deterministic, no-LLM cleanup of stale branches — same trust class as the
+# groundskeeper and auto-merge loops: reads branch/PR state only as data,
+# runs no branch-controlled code (no checkout of the branches it judges).
+#
+# WHY: the auto-merge loop only started deleting head branches on merge
+# recently (`--delete-branch`), and the user-driven squash merges before it
+# never did — by 2026-07-26 the repo had ~76 dead branches. Squash merges
+# also mean `merge-base --is-ancestor` finds almost nothing (1 of 76), so
+# the PR ledger, not git ancestry, is the reliable "this work landed" signal.
+#
+# DELETION RULES (a branch must clear one to be deleted; anything else stays):
+#   1. Ancestry-merged: its tip is an ancestor of the default branch.
+#   2. PR-merged: it is the head of at least one PR and EVERY PR with this
+#      head is MERGED (covers squash merges; a single open or closed-unmerged
+#      PR vetoes — an open PR is live work, a closed-unmerged one is a human
+#      rejection whose branch a human may still want).
+#   3. Explicitly named in the `extra` dispatch input by a maintainer —
+#      the escape hatch for branches rules 1-2 deliberately leave (e.g. a
+#      never-PR'd checkpoint branch whose content shipped via another PR).
+#      Never-PR'd branches and `-ckpt-` refs are otherwise NEVER touched.
+#
+# `main` (the default branch) is excluded structurally, and branch
+# protection on it is the enforceable backstop as everywhere else.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # weekly sweep, Monday 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting'
+        type: boolean
+        default: false
+      extra:
+        description: 'Comma-separated branch names to also delete (rule 3)'
+        type: string
+        default: ''
+
+concurrency:
+  group: branch-janitor
+  cancel-in-progress: false
+
+permissions:
+  contents: write # delete refs
+  pull-requests: read # read the PR ledger per branch
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      EXTRA: ${{ inputs.extra }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Sweep stale branches
+        run: |
+          set -euo pipefail
+          default="$(gh api "repos/$REPO" --jq '.default_branch')"
+          git fetch --prune origin "+refs/heads/*:refs/remotes/origin/*"
+          deleted=0; kept=0
+          delete_ref() {
+            local b="$1" why="$2"
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo "DRY RUN: would delete '$b' ($why)"
+            else
+              if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null; then
+                echo "Deleted '$b' ($why)"
+              else
+                echo "::warning::Failed to delete '$b' — skipping."
+                return 0
+              fi
+            fi
+            deleted=$((deleted+1))
+          }
+          for b in $(git for-each-ref 'refs/remotes/origin/**' --format='%(refname:lstrip=3)'); do
+            [ "$b" = "$default" ] && continue
+            [ "$b" = 'HEAD' ] && continue
+            # Rule 1: ancestry-merged into the default branch.
+            if git merge-base --is-ancestor "refs/remotes/origin/$b" "refs/remotes/origin/$default"; then
+              delete_ref "$b" 'ancestry-merged'
+              continue
+            fi
+            # Rule 2: every PR with this head is MERGED (>=1 PR required).
+            # States read strictly as jq data from the PR ledger.
+            states="$(gh pr list --repo "$REPO" --head "$b" --state all \
+              --json state --jq 'map(.state) | unique | join(",")' 2>/dev/null || echo '')"
+            if [ "$states" = 'MERGED' ]; then
+              delete_ref "$b" 'all PRs merged'
+              continue
+            fi
+            kept=$((kept+1))
+            echo "Kept '$b' (PR states: ${states:-none})"
+          done
+          # Rule 3: maintainer-named extras, validated to exist and to not be
+          # the default branch. Comma-separated; whitespace trimmed.
+          if [ -n "$EXTRA" ]; then
+            IFS=',' read -ra extras <<<"$EXTRA"
+            for raw in "${extras[@]}"; do
+              b="$(echo "$raw" | xargs)"
+              [ -z "$b" ] && continue
+              if [ "$b" = "$default" ]; then
+                echo "::warning::Refusing to delete the default branch via extra input."
+                continue
+              fi
+              if git show-ref --verify --quiet "refs/remotes/origin/$b"; then
+                delete_ref "$b" 'maintainer-named (extra input)'
+              else
+                echo "::warning::extra branch '$b' does not exist — skipping."
+              fi
+            done
+          fi
+          echo "Sweep done: $deleted deleted, $kept kept."

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -492,6 +492,18 @@ sessions:
   previously zombied forever (the 2026-07-20 incident: four zombie
   `status:building` issues, zero open PRs, the approved queue starved behind
   them).
+- `.github/workflows/branch-janitor.yml` — deterministic (no model, no Max
+  pool) weekly sweep deleting stale branches, same trust class as the
+  groundskeeper: a branch is deleted only when its tip is ancestry-merged
+  into the default branch, or when it is the head of at least one PR and
+  **every** PR with that head is MERGED (the squash-merge case — a single
+  open or closed-unmerged PR vetoes, since a closed-unmerged PR is a human
+  rejection whose branch a human may still want). Never-PR'd branches and
+  `-ckpt-` refs are never touched automatically; a maintainer can name
+  specific branches via the `extra` dispatch input, and `dry_run` previews a
+  sweep. Exists because squash merges leave no ancestry trail (1 of 76 stale
+  branches was ancestry-merged when this shipped) and the auto-merge loop
+  only started deleting head branches on merge late in the day.
 - `.github/workflows/pipeline-pr-review.yml` — fires on `pull_request`
   events; reviews the diff (security-focused), comments/approves, never merges.
   On a "Changes requested" verdict it dispatches the revise worker; on a

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2510,7 +2510,11 @@ number could reach an unrelated person).
       disk to retarget a push, so the tool restrictions are defence-in-depth, not
       the guarantee. Branch protection (server-side) is what actually guarantees
       nothing reaches `main` except through a PR that passed the required checks.
-      Enable it before relying on these loops.
+      Enable it before relying on these loops. (The branch janitor
+      (`branch-janitor.yml`) also holds `contents: write`, but is a much
+      narrower holder: deterministic shell only — no agent, no code execution
+      from judged branches — and its write capability is ref deletion, which
+      branch protection blocks for `main` like any other write.)
 - [ ] **Auto-merge posture (`pipeline-pr-automerge.yml`) is a conscious
       decision.** By default the pipeline requires a **human** to merge every PR,
       which is the backstop against the PR-review LLM itself being prompt-injected


### PR DESCRIPTION
## Summary

76 stale branches have accumulated (full list measurable via the workflow's `dry_run`): squash merges leave no ancestry trail — exactly **1 of 76** is ancestry-merged into `main` — the auto-merge loop only began deleting head branches on merge recently, and this session's git proxy refuses ref deletions, so cleanup needs to live where the credentials do.

`branch-janitor.yml` is a weekly (+ `workflow_dispatch`) sweep in the groundskeeper's trust class — no LLM, branch/PR state read strictly as data, no checkout of the branches it judges. Deletion rules, conservative by construction:

1. **Ancestry-merged** into the default branch.
2. **Every PR with that head is `MERGED`** (≥1 required) — the squash-merge case. One open or closed-unmerged PR vetoes: an open PR is live work; a closed-unmerged one is a human rejection whose branch a human may still want.
3. **Maintainer-named** via the `extra` dispatch input — the escape hatch for branches the rules deliberately leave (e.g. a never-PR'd checkpoint branch whose content shipped through another PR). Never-PR'd branches and `-ckpt-` refs are otherwise never touched.

`dry_run` previews a sweep without deleting. The default branch is excluded structurally and branch protection on `main` remains the enforceable backstop. Documented in `docs/PIPELINE.md`'s workflow inventory beside the groundskeeper.

## Security / privacy impact

No bot-runtime change. New workflow permissions are `contents: write` (delete refs — the minimum that can delete a branch) and `pull-requests: read`. No branch-controlled code executes: the sweep checks out only `main`'s workflow definition, reads other branches via `git for-each-ref`/`merge-base` and the PR ledger via `--json`/`--jq`, and branch names are only ever passed as arguments (never eval'd); the `extra` input refuses the default branch. Deleting a merged branch destroys no history reachable from `main`; rule-2 deletions destroy only commits whose content landed via a merged squash. The one genuinely destructive surface — deleting an unmerged branch — requires a human to name it explicitly in a dispatch.

## How verified

- YAML parses; the sweep step passes `bash -n`; Prettier clean.
- Rule logic measured against the live repo before writing: 76 non-`main` branches, 1 ancestry-merged, squash-merge dominance confirming the PR-ledger rule as the workhorse.
- First run will be dispatched with `dry_run: true` and the resulting list reviewed before the live sweep.

Governance path (`.github/`), so this requires a human merge — covered by the owner's standing authorization for this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_