### PR TITLE
Verdict parser: a bolded verdict is not a bullet

### DIFF
--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -187,7 +187,15 @@ jobs:
           # the exact stall the loop exists to prevent). Evaluate "needs a
           # human decision" BEFORE "changes requested" so a needs-human verdict
           # that happens to mention changes isn't sent to revise instead.
-          verdict="$(head -n 4 review.txt | grep -vE '^[[:space:]]*[-*]')"
+          # The bullet filter requires whitespace AFTER the marker: a real
+          # markdown bullet is `- text`/`* text`, but a verdict the review
+          # model renders in BOLD starts `**Changes requested**` — marker
+          # then another asterisk, no space. The original `^[[:space:]]*[-*]`
+          # ate the bolded verdict line itself, so PR #730's Changes-requested
+          # verdict matched nothing and the revise dispatch silently never
+          # fired (and revise's own precheck, sharing the pattern, would have
+          # no-op'd on a manual dispatch too).
+          verdict="$(head -n 4 review.txt | grep -vE '^[[:space:]]*[-*][[:space:]]')"
           if printf '%s' "$verdict" | grep -qiE 'needs a human decision'; then
             gh pr edit "$PR" --add-label needs-human ||
               echo "::warning::Could not add needs-human label"

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -132,7 +132,7 @@ jobs:
           verdict_pending="$(jq -r '
             [.comments[] | select(.body | contains("PR review (automated)"))] | last
             | ((.body // "") | split("\n")[0:4]
-               | map(select(test("^[[:space:]]*[-*]") | not)) | join("\n")
+               | map(select(test("^[[:space:]]*[-*][[:space:]]") | not)) | join("\n")
                | test("[Cc]hanges requested"))
           ' <<<"$info")"
           attempts="$(jq --arg m "$ATTEMPT_MARKER" -r \


### PR DESCRIPTION
## Summary

PR #730's automated review posted its verdict as `**Changes requested**` — bold markdown. The verdict extraction in `pipeline-pr-review.yml` drops "bullet lines" matching `^[[:space:]]*[-*]` before classifying, and a bold line starts with an asterisk, so **the filter ate the verdict itself**: the `changes requested` match found nothing and the revise-worker dispatch silently never fired. `pipeline-pr-revise.yml`'s precheck shares the pattern, so a manual dispatch would have no-op'd with "no pending verdict" — the formatting drift defeated both ends of the pipe. Earlier verdicts today (#711's) were unbolded, which is why the seam never showed until now.

The fix: a real markdown bullet is marker **plus whitespace** (`- text`, `* text`); bold is marker plus another asterisk. Both patterns now require the trailing whitespace (`^[[:space:]]*[-*][[:space:]]`), so bolded verdicts survive the filter while the misroute guard the filter exists for — a finding bullet like "previous changes requested were addressed" inside an LGTM review being mistaken for a pending verdict — still filters exactly as before.

Verified against the real shell/jq pipelines with all three cases: bolded verdict → routes; LGTM-with-bullet-mentioning-changes → still filtered; plain verdict → unchanged.

## Security / privacy impact

None to the bot runtime — workflow-only, two one-token regex changes. The change strictly *narrows* what the bullet filter drops, and the filter's security purpose (issue #222's misroute guard) is preserved and re-verified. No permission, trigger, or gate changes in either workflow.

## How verified

- Both YAML files parse; Prettier clean.
- The three behaviour cases above run against the actual `head/grep` pipeline (review side) and the actual `jq` expression's semantics (revise side).
- Root cause traced live: #730's verdict comment (bolded, 18:37Z), zero `pipeline-pr-revise-attempt` markers, and the revise workflow's run history showing its last run at 16:34Z — before the verdict.

Governance path (`.github/`) — human merge, covered by standing authorization. After merge, `pipeline-pr-revise.yml` will be dispatched manually for #730 so the missed verdict gets its revise attempt.

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_