### PR TITLE
chore: give changelog coverage a durable skip ledger so the tracker converges

### DIFF
--- a/.github/workflows/changelog-autofill.yml
+++ b/.github/workflows/changelog-autofill.yml
@@ -215,16 +215,23 @@ jobs:
             voice EXACTLY before writing.
 
             The daily coverage check flagged the merged PRs missing an entry
-            (format `- [ ] #NNN (YYYY-MM-DD) — title`) into the file `gaps.md` at
+            (format `- #NNN (YYYY-MM-DD) — title`) into the file `gaps.md` at
             the repo root — run `cat gaps.md` to read the list.
 
             For EACH flagged PR:
             1. Decide if it is genuinely user- or operator-facing. The coverage
                check errs toward flagging, so some entries may be INTERNAL (CI,
                dependency bumps, tests, pipeline/tooling, pure refactors with no
-               observable behaviour change). SKIP those — do not invent an entry
-               for a change no user would notice. If you skip all of them, make
-               NO commit and stop (say so in your final line).
+               observable behaviour change). Do not invent an entry for a change
+               no user would notice — instead RECORD the skip: append the PR's
+               number to the "Skipped as internal" line of the skip-ledger HTML
+               comment in CHANGELOG.md's preamble (above the first `##` section;
+               create the comment in that spot if it's ever absent, copying its
+               existing explanatory text). The ledger is what lets the coverage
+               check converge — an unrecorded skip gets re-flagged, and re-judged
+               by this workflow, every single day. The preamble placement
+               matters: `whats_new` skips everything before the first `##`, so
+               members never see it.
             2. For a real one, read it: `gh pr view <N>` and `gh pr diff <N>` so
                the entry is accurate. Never guess from the title alone.
             3. Add ONE bullet under the correct dated section `## YYYY-MM-DD`
@@ -266,9 +273,9 @@ jobs:
             run. There is no wakeup, resume, or background continuation — when
             your turn ends, the job ends. Run every command synchronously to
             completion in THIS turn and act on its result; never end your turn to
-            "wait" for a command. Either push + open the PR in THIS turn, or (if
-            nothing is genuinely user-facing) make no commit and stop with one
-            line saying so.
+            "wait" for a command. Always push + open the PR in THIS turn: even
+            when every flagged PR is internal, the ledger appends are themselves
+            a CHANGELOG.md edit that must land for the tracker to converge.
           # Least-privilege tools:
           #   * Edit/Write/Read/Grep/Glob for the changelog (Write can't be scoped
           #     to one path — the ONLY-CHANGELOG.md rule is prompt-stated and then
@@ -321,7 +328,7 @@ jobs:
           num="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$AUTOFILL_BRANCH" \
             --json number --jq '.[0].number // empty')"
           if [ -z "$num" ]; then
-            echo "No autofill PR was opened — the agent judged nothing user-facing (or stopped before pushing). Nothing to do."
+            echo "No autofill PR was opened — the agent stopped before pushing. (Since the skip ledger landed, even an all-internal gap list should produce a ledger-append PR — check the agent log above.)"
             exit 0
           fi
           echo "Autofill PR #$num opened. Checking it changed only CHANGELOG.md…"

--- a/.github/workflows/changelog-coverage.yml
+++ b/.github/workflows/changelog-coverage.yml
@@ -6,8 +6,10 @@ name: Changelog coverage
 # list recently-merged PRs that aren't reflected in the changelog and keep a
 # single tracking issue in sync — opened/updated when there's a gap, closed when
 # there isn't. Heuristic (see scripts/check-changelog-coverage.mjs): it errs
-# toward flagging, so a genuinely-internal PR is ticked/ignored, not silently
-# dropped. Read-only except for that one issue; never touches code.
+# toward flagging, so a genuinely-internal PR is recorded in the skip ledger
+# (an HTML comment in CHANGELOG.md's preamble — the autofill agent appends to
+# it, and any `#NNN` in the file counts as documented), not silently dropped.
+# Read-only except for that one issue; never touches code.
 
 on:
   schedule:
@@ -60,7 +62,7 @@ jobs:
           set -euo pipefail
           {
             printf '%s merged PR(s) from the last %s days are not reflected in `CHANGELOG.md` (the file the `whats_new` tool reads).\n\n' "$(wc -l < gaps.md)" "$WINDOW_DAYS"
-            printf 'Add a user-legible entry for each — or tick the box if it is genuinely internal (CI / deps / tests / pipeline). This is a heuristic (see `scripts/check-changelog-coverage.mjs`), so an occasional prose-documented PR may appear until it ages out of the window.\n\n'
+            printf 'Add a user-legible entry for each — or, if one is genuinely internal (CI / deps / tests / pipeline), add its number to the skip-ledger HTML comment in `CHANGELOG.md`'"'"'s preamble (the autofill workflow does this automatically when it judges a PR internal). Ticking a box here does nothing durable: this body is regenerated on every refresh, and only `CHANGELOG.md` content feeds the check. This is a heuristic (see `scripts/check-changelog-coverage.mjs`), so an occasional prose-documented PR may appear until it ages out of the window.\n\n'
             printf '💡 The companion **changelog-autofill** workflow drafts these entries automatically — look for an open `%s` PR to review-and-merge instead of writing them by hand.\n\n' "$AUTOFILL_BRANCH"
             cat gaps.md
             printf '\n_Refreshed %s by the changelog-coverage workflow; auto-closes when the list is empty._\n' "$(date -u +%Y-%m-%dT%H:%MZ)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ is a NZ community, and the CI that opens most PRs runs in UTC (a day behind NZ
 for anything after ~noon NZST/NZDT). Get today's date with
 `TZ='Pacific/Auckland' date +%F` rather than a bare `date`.
 
+<!--
+changelog-coverage skip ledger — merged PRs judged INTERNAL (CI / deps /
+tests / pipeline / tooling), so they deliberately get no member-facing entry.
+Listing a PR number here satisfies scripts/check-changelog-coverage.mjs (any
+`#NNN` occurrence in this file counts as documented), which is what lets the
+daily tracking issue converge and auto-close. This comment sits in the H1
+preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
+to members. Append numbers; never remove them.
+Skipped as internal: #707 #725 #731
+-->
+
+
 ## 2026-07-27
 
 ### Added

--- a/scripts/check-changelog-coverage.mjs
+++ b/scripts/check-changelog-coverage.mjs
@@ -17,7 +17,11 @@
 //     --json number,title,mergedAt,body | node scripts/check-changelog-coverage.mjs [--window-days N]
 //
 // Coverage is judged by three signals, ANY of which counts as "documented":
-//   1. the PR's own number appears in CHANGELOG.md (`#123`), OR
+//   1. the PR's own number appears in CHANGELOG.md (`#123`) — including in the
+//      skip-ledger HTML comment in the preamble, which is exactly how a PR
+//      judged internal-but-not-matching-INTERNAL-below is recorded so the
+//      tracking issue can converge (the autofill agent appends to it; see
+//      changelog-autofill.yml), OR
 //   2. a `Closes #NNN` issue number from the PR body appears there, OR
 //   3. a distinctive identifier from the PR title (a snake_case tool name or an
 //      UPPER_SNAKE env var) appears there — the changelog often describes a
@@ -80,6 +84,10 @@ const gaps = prs
   .filter((pr) => !isDocumented(pr))
   .sort((a, b) => b.number - a.number);
 
+// Plain bullets, not `- [ ]` checkboxes: the tracking issue's body is
+// regenerated on every refresh and nothing reads ticks, so a checkbox is a
+// misleading affordance — the durable "internal, skip it" record is the
+// CHANGELOG.md skip ledger.
 for (const pr of gaps) {
-  console.log(`- [ ] #${pr.number} (${pr.mergedAt.slice(0, 10)}) — ${pr.title}`);
+  console.log(`- #${pr.number} (${pr.mergedAt.slice(0, 10)}) — ${pr.title}`);
 }


### PR DESCRIPTION
## Summary

Fixes the convergence defect behind #734: the changelog-coverage tracker could never auto-close, because a flagged PR judged *internal* by the autofill agent left no durable record of that judgment. Every day the tracker re-listed the same PRs (#707, #725, #731), the autofill agent re-read and re-skipped them, and the issue stayed open — a permanent daily agent run producing nothing. The issue body's "tick the box if it is genuinely internal" instruction was a dead end: the body is regenerated on every refresh (ticks wiped), and nothing reads ticks anyway.

## The fix — a skip ledger inside CHANGELOG.md

An HTML comment in the CHANGELOG preamble records PRs judged internal:

- **Zero checker changes needed**: `scripts/check-changelog-coverage.mjs` already counts any `#NNN` occurrence in the file as documented. Seeded with `#707 #725 #731`, which clears #734 at the next coverage run — verified by piping a simulated `gh pr list` payload through the checker (only an undocumented control PR is flagged).
- **Invisible to members**: `src/agent/changelog.ts` skips everything before the first `##` heading, so `whats_new` never surfaces the ledger — verified across all parsed sections, and `tests/changelog.test.ts` passes (3/3).
- **Fits the autofill workflow's existing guardrails**: the agent is already scope-gated to editing only CHANGELOG.md, so "append skipped numbers to the ledger" is one prompt paragraph — no new tool grants, and the fail-closed diff gate is untouched. The prompt's "skip all → no commit" rule becomes "always open the PR" since ledger appends are themselves an edit that must land.
- **The misleading checkbox affordance is removed**: the checker emits plain bullets, and the tracker body now explains the ledger instead of inviting ticks that do nothing.

This PR's own title is `chore:`-prefixed so the checker's INTERNAL rule excludes it from future flagging.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — clean
- `npm test` — 2632 tests, one failure: the known pre-existing `ordering: repeat-question shortcut` flake (#719 class), passes in isolation; this diff touches no runtime code that test exercises
- `npm run test:security` — 963/963, manifest matched (no SECURITY tests added or removed)
- Checker simulation + `whats_new` parse check as described above

Touches `.github/workflows/` and `scripts/`, so this is a governance-path PR — human merge required by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_