### PR TITLE
Make the PR-review verdict a typed artifact, not prose three loops re-parse

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -269,20 +269,41 @@ jobs:
             review_body="$(jq -r '.body' <<<"$latest_review")"
             review_at="$(jq -r '.createdAt' <<<"$latest_review")"
 
-            # Verdict = first 4 lines minus bullet lines, so a phrase inside a
-            # finding can't be misread as the verdict. The comment is GUARANTEED
-            # marker-first: the review workflow deterministically trims any
-            # agent preamble at post time (see pipeline-pr-review.yml), so the
-            # strict ^-anchored match above and this top-of-comment parse are
-            # unambiguous even when review commentary QUOTES the marker string
-            # further down (PR #656 review found substring-based extraction
-            # here was decoy-prone in both directions; anchoring the SHAPE at
-            # the source removes the ambiguity class entirely).
-            verdict="$(printf '%s' "$review_body" | head -n 4 | grep -vE '^[[:space:]]*[-*]' || true)"
-            if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
-               || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
-              echo "PR #$n: latest review verdict is not an LGTM approval — skip."
-              echo "::endgroup::"; continue
+            # Verdict via the canonical token the review workflow stamps on
+            # line 2 (see pipeline-pr-review.yml's "canonical verdict contract").
+            # This replaced a local prose regex that had DRIFTED from the other
+            # two consumers: it lacked #731's fix, so a review whose verdict the
+            # model rendered in bold (`**LGTM, ...**`) matched the bullet filter,
+            # left `verdict` empty, and this gate skipped a fully-approved PR
+            # forever. Reading one exact token removes that class — the token is
+            # written deterministically by the workflow, never by the model, and
+            # a review that QUOTES a token further down can't win because the
+            # authoritative one is always first.
+            # Keep both helpers identical across the three verdict consumers;
+            # tests/reviewVerdict.test.ts fails if any copy drifts.
+            canonical_verdict() {
+              grep -oiE '<!--[[:space:]]*verdict:(LGTM|CHANGES_REQUESTED|NEEDS_HUMAN)[[:space:]]*-->' |
+                head -1 | grep -oiE 'LGTM|CHANGES_REQUESTED|NEEDS_HUMAN' | tr '[:lower:]' '[:upper:]'
+            }
+            legacy_verdict() {
+              head -n 4 | grep -vE '^[[:space:]]*[-*][[:space:]]'
+            }
+            token="$(printf '%s' "$review_body" | canonical_verdict)"
+            if [ -n "$token" ]; then
+              if [ "$token" != "LGTM" ]; then
+                echo "PR #$n: latest review verdict is $token, not an LGTM approval — skip."
+                echo "::endgroup::"; continue
+              fi
+            else
+              # Pre-contract comment (posted before the token existed): fall
+              # back to the SHARED prose helper — which, unlike the local regex
+              # it replaces, carries the #731 bolded-verdict fix.
+              verdict="$(printf '%s' "$review_body" | legacy_verdict || true)"
+              if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
+                 || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
+                echo "PR #$n: latest review verdict is not an LGTM approval — skip."
+                echo "::endgroup::"; continue
+              fi
             fi
 
             # Freshness: the approval must be NEWER than the head commit, else a

--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -96,6 +96,11 @@ jobs:
             review itself: no preamble, no narration (e.g. never "Now I'll
             write the review"). Structure it as:
             - First line: "PR review (automated):"
+            - Second line: a machine-readable verdict token, EXACTLY one of
+              "<!-- verdict:LGTM -->", "<!-- verdict:CHANGES_REQUESTED -->", or
+              "<!-- verdict:NEEDS_HUMAN -->", alone on its line. It renders
+              invisibly on GitHub; the pipeline ROUTES on it, so it must agree
+              with the human-readable verdict you write on the next line.
             - A one-line verdict: "LGTM, looks good and ready for a human to merge",
               or "Changes requested", or "Needs a human decision".
             - Then the findings as short bullets, or "No issues found." if clean.
@@ -165,8 +170,61 @@ jobs:
             review="$(printf '%s\n' "$review" | tail -n +"$marker_line")"
           fi
 
+          # --- canonical verdict contract v1 --------------------------------
+          # Three workflows consume a review verdict (this one routes on it,
+          # auto-merge gates on it, revise re-verifies it). They used to parse
+          # the same free prose with three separate regexes, and they DRIFTED:
+          # the #731 "a bolded **verdict** is not a bullet" fix landed here and
+          # in revise but not in auto-merge, so a bolded **LGTM** was invisible
+          # to the merge gate and a fully-approved PR would sit forever.
+          # The fix is an artifact contract, not a better regex: this step —
+          # the one place the comment is composed — decides the verdict ONCE
+          # and stamps it as a canonical token, and every consumer reads that.
+          # Keep both helpers identical across the three workflows;
+          # tests/reviewVerdict.test.ts fails if any copy drifts.
+          canonical_verdict() {
+            grep -oiE '<!--[[:space:]]*verdict:(LGTM|CHANGES_REQUESTED|NEEDS_HUMAN)[[:space:]]*-->' |
+              head -1 | grep -oiE 'LGTM|CHANGES_REQUESTED|NEEDS_HUMAN' | tr '[:lower:]' '[:upper:]'
+          }
+          legacy_verdict() {
+            head -n 4 | grep -vE '^[[:space:]]*[-*][[:space:]]'
+          }
+
+          # Prefer the model's own token; fall back to the pre-contract prose
+          # heuristic when it omitted one. An unrecognisable verdict stays
+          # EMPTY on purpose — that is today's fail-safe behaviour (no label,
+          # no revise dispatch, and no LGTM for auto-merge to gate on), so a
+          # malformed review stalls visibly instead of routing by accident.
+          VERDICT_TOKEN="$(printf '%s' "$review" | canonical_verdict)"
+          if [ -z "$VERDICT_TOKEN" ]; then
+            prose="$(printf '%s' "$review" | legacy_verdict || true)"
+            if printf '%s' "$prose" | grep -qiE 'needs a human decision'; then
+              VERDICT_TOKEN=NEEDS_HUMAN
+            elif printf '%s' "$prose" | grep -qiE 'changes requested'; then
+              VERDICT_TOKEN=CHANGES_REQUESTED
+            elif printf '%s' "$prose" | grep -qiE 'lgtm|ready for a human to merge'; then
+              VERDICT_TOKEN=LGTM
+            fi
+            echo "::warning::Review omitted the verdict token; fell back to prose parsing (verdict='${VERDICT_TOKEN:-none}'). If this recurs, the review prompt has drifted."
+          fi
+
+          # Drop any token the model put on a line of its own, then inject
+          # exactly ONE authoritative token right after the marker line. The
+          # authoritative token is therefore always the FIRST one in the body,
+          # so a review that legitimately quotes a token mid-sentence (reviews
+          # of this very machinery do) can neither be mangled nor mistaken for
+          # the verdict.
+          printf '%s' "$review" |
+            grep -vE '^[[:space:]]*<!--[[:space:]]*verdict:[A-Za-z_]+[[:space:]]*-->[[:space:]]*$' \
+            > review-body.txt || true
+          {
+            head -n 1 review-body.txt
+            if [ -n "$VERDICT_TOKEN" ]; then printf '<!-- verdict:%s -->\n' "$VERDICT_TOKEN"; fi
+            tail -n +2 review-body.txt
+          } > review-stamped.txt
+
           # GitHub comment bodies cap ~65535 chars; keep well under.
-          printf '%s' "$review" | head -c 60000 > review.txt
+          head -c 60000 review-stamped.txt > review.txt
           gh pr comment "$PR" --body-file review.txt
 
           # Route on the verdict (the state machine's missing edge — see
@@ -178,29 +236,27 @@ jobs:
           # pipeline loop skips the PR. Failures are warnings, never a red
           # check — the review itself was posted successfully.
           #
-          # Verdict extraction (issue #222): the mandated format is a header
-          # line then a one-line verdict, with findings as `-`/`*` bullets
-          # after. Look only at the first few lines AND drop bullet lines, so a
-          # phrase like "previous changes requested were addressed" inside a
-          # finding can't misroute an LGTM into the revise loop (which then
-          # finds nothing, pushes no commit, and mislabels the PR needs-human —
-          # the exact stall the loop exists to prevent). Evaluate "needs a
-          # human decision" BEFORE "changes requested" so a needs-human verdict
-          # that happens to mention changes isn't sent to revise instead.
-          # The bullet filter requires whitespace AFTER the marker: a real
-          # markdown bullet is `- text`/`* text`, but a verdict the review
-          # model renders in BOLD starts `**Changes requested**` — marker
-          # then another asterisk, no space. The original `^[[:space:]]*[-*]`
-          # ate the bolded verdict line itself, so PR #730's Changes-requested
-          # verdict matched nothing and the revise dispatch silently never
-          # fired (and revise's own precheck, sharing the pattern, would have
-          # no-op'd on a manual dispatch too).
-          verdict="$(head -n 4 review.txt | grep -vE '^[[:space:]]*[-*][[:space:]]')"
-          if printf '%s' "$verdict" | grep -qiE 'needs a human decision'; then
-            gh pr edit "$PR" --add-label needs-human ||
-              echo "::warning::Could not add needs-human label"
-          elif printf '%s' "$verdict" | grep -qiE 'changes requested'; then
-            echo "Verdict requests changes — dispatching the revise worker."
-            gh workflow run pipeline-pr-revise.yml -R "${{ github.repository }}" -f pr_number="$PR" ||
-              echo "::warning::Could not dispatch pipeline-pr-revise.yml (missing on the default branch yet?)"
-          fi
+          # Route on the verdict decided above — no second parse of the posted
+          # text. Ordering ("needs a human" before "changes requested") used to
+          # matter because both were substring-matched against the same prose;
+          # the token is a single exact value, so that ambiguity is gone. The
+          # decoy risk the old parse guarded against (issue #222 — a finding
+          # bullet reading "previous changes requested were addressed") is
+          # likewise structural now: findings are never consulted.
+          case "$VERDICT_TOKEN" in
+            NEEDS_HUMAN)
+              gh pr edit "$PR" --add-label needs-human ||
+                echo "::warning::Could not add needs-human label"
+              ;;
+            CHANGES_REQUESTED)
+              echo "Verdict requests changes — dispatching the revise worker."
+              gh workflow run pipeline-pr-revise.yml -R "${{ github.repository }}" -f pr_number="$PR" ||
+                echo "::warning::Could not dispatch pipeline-pr-revise.yml (missing on the default branch yet?)"
+              ;;
+            LGTM)
+              echo "Verdict is LGTM — auto-merge will pick it up if it qualifies."
+              ;;
+            *)
+              echo "::warning::No usable verdict on PR #$PR — not routing. The review comment was still posted."
+              ;;
+          esac

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -122,19 +122,35 @@ jobs:
             and ([.labels[].name] | index("needs-human") | not)
           ' <<<"$info")"
           # The LATEST automated-review comment must still request changes —
-          # the superseded-run guard (see header). Match the verdict the SAME
-          # way pipeline-pr-review.yml routes it (issue #222): look only at the
-          # first few lines and drop `-`/`*` bullet lines, so a finding bullet
-          # like "previous changes requested were addressed" inside an LGTM
-          # review can't be mistaken for a pending Changes-requested verdict
-          # (which would spin up the reviser to find nothing and mislabel the
-          # PR needs-human — the exact stall this guard exists to prevent).
-          verdict_pending="$(jq -r '
-            [.comments[] | select(.body | contains("PR review (automated)"))] | last
-            | ((.body // "") | split("\n")[0:4]
-               | map(select(test("^[[:space:]]*[-*][[:space:]]") | not)) | join("\n")
-               | test("[Cc]hanges requested"))
+          # the superseded-run guard (see header). Read the canonical token the
+          # review workflow stamps on line 2 (see pipeline-pr-review.yml's
+          # "canonical verdict contract"), falling back to the shared prose
+          # helper for comments posted before the token existed. Both helpers
+          # must stay identical across the three verdict consumers; the three
+          # copies previously drifted (#731) and tests/reviewVerdict.test.ts
+          # now fails if they do again. Findings are never consulted, so the
+          # decoy case this guard was written for (issue #222 — a bullet
+          # reading "previous changes requested were addressed" spinning up the
+          # reviser to find nothing) is structurally impossible on the token
+          # path.
+          canonical_verdict() {
+            grep -oiE '<!--[[:space:]]*verdict:(LGTM|CHANGES_REQUESTED|NEEDS_HUMAN)[[:space:]]*-->' |
+              head -1 | grep -oiE 'LGTM|CHANGES_REQUESTED|NEEDS_HUMAN' | tr '[:lower:]' '[:upper:]'
+          }
+          legacy_verdict() {
+            head -n 4 | grep -vE '^[[:space:]]*[-*][[:space:]]'
+          }
+          review_body="$(jq -r '
+            [.comments[] | select(.body | contains("PR review (automated)"))] | last | (.body // "")
           ' <<<"$info")"
+          token="$(printf '%s' "$review_body" | canonical_verdict)"
+          if [ -n "$token" ]; then
+            if [ "$token" = "CHANGES_REQUESTED" ]; then verdict_pending=true; else verdict_pending=false; fi
+          elif printf '%s' "$review_body" | legacy_verdict | grep -qiE 'changes requested'; then
+            verdict_pending=true
+          else
+            verdict_pending=false
+          fi
           attempts="$(jq --arg m "$ATTEMPT_MARKER" -r \
             '[.comments[] | select(.body | contains($m))] | length' <<<"$info")"
           branch="$(jq -r '.headRefName' <<<"$info")"

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -216,6 +216,39 @@ Launch each in its own session with the `/loop` skill. Each is written to
 **exit cleanly doing nothing when there is no work** — that keeps idle wake-ups
 cheap.
 
+### The review-verdict contract
+
+Three workflows consume a PR-review verdict: `pipeline-pr-review.yml` routes on
+it, `pipeline-pr-automerge.yml` gates merges on it, and `pipeline-pr-revise.yml`
+re-verifies it is still pending. They each used to parse the same free prose
+with their own regex, and they drifted — the #731 fix ("a bolded
+`**Changes requested**` is not a markdown bullet") landed in two of the three,
+leaving auto-merge unable to see a bolded `**LGTM**`, so a fully-approved PR
+would sit unmerged forever with no error anywhere.
+
+The verdict is now a typed artifact rather than prose to re-parse:
+
+- The review model is asked to emit `<!-- verdict:LGTM -->`,
+  `<!-- verdict:CHANGES_REQUESTED -->` or `<!-- verdict:NEEDS_HUMAN -->` on
+  line 2. It renders invisibly on GitHub, so the comment still reads naturally.
+- `pipeline-pr-review.yml` — the only place a review comment is composed —
+  decides the verdict ONCE (token if present, else the prose fallback), strips
+  any model-emitted token that occupies a whole line, and stamps exactly one
+  authoritative token immediately after the `PR review (automated):` marker.
+  The stamp is written by the workflow, never by the model.
+- Consumers read that token. Because the authoritative one is always first, a
+  review that legitimately quotes a token mid-sentence — reviews of this very
+  machinery do — can neither be mangled nor mistaken for the verdict.
+- The prose fallback remains for comments posted before the contract existed,
+  and is now shared rather than reimplemented per workflow.
+
+Both shell helpers (`canonical_verdict`, `legacy_verdict`) must stay identical
+across the three workflows; `tests/reviewVerdict.test.ts` compares the copies
+and fails on drift, which is the specific regression that motivated the change.
+An unrecognisable verdict deliberately routes nowhere: no label, no revise
+dispatch, and nothing for auto-merge to approve, so a malformed review stalls
+visibly instead of guessing.
+
 ### 1 · PR review
 
 ```

--- a/tests/reviewVerdict.test.ts
+++ b/tests/reviewVerdict.test.ts
@@ -1,0 +1,176 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The review-verdict artifact contract (issue #731 follow-up).
+ *
+ * Three workflows consume a PR-review verdict: the review worker routes on it,
+ * the auto-merge loop gates on it, and the revise worker re-verifies it. Each
+ * used to parse the SAME free prose with its OWN regex, and they drifted: the
+ * #731 fix (a bolded `**Changes requested**` is not a markdown bullet) landed
+ * in review + revise but NOT in auto-merge, so a bolded `**LGTM**` stayed
+ * invisible to the merge gate and a fully-approved PR would sit forever.
+ *
+ * The fix is a contract rather than a better regex. The review workflow — the
+ * one place that composes the comment — normalises the verdict into a single
+ * canonical HTML-comment token on line 2, and every consumer reads THAT.
+ * These tests pin both halves: the shared shell helpers must stay identical
+ * across all three workflows, and their behaviour must survive the formatting
+ * variations a model actually produces.
+ */
+
+const workflow = (name: string) =>
+  readFileSync(fileURLToPath(new URL(`../.github/workflows/${name}`, import.meta.url)), 'utf8');
+
+const CONSUMERS = ['pipeline-pr-review.yml', 'pipeline-pr-automerge.yml', 'pipeline-pr-revise.yml'] as const;
+
+/**
+ * Pull a shell function body out of a workflow file and strip the YAML block
+ * indentation, so the three copies can be compared regardless of how deeply
+ * each one is nested in its own job/step.
+ */
+function extractFn(source: string, fnName: string): string {
+  const lines = source.split('\n');
+  const startIndex = lines.findIndex((line) => line.trim().startsWith(`${fnName}() {`));
+  assert.notEqual(startIndex, -1, `${fnName} not found`);
+  const body: string[] = [];
+  for (const line of lines.slice(startIndex)) {
+    body.push(line.trim());
+    if (line.trim() === '}') return body.join('\n');
+  }
+  assert.fail(`${fnName} has no closing brace`);
+}
+
+/** Run a snippet against a body on stdin and return trimmed stdout. */
+function runShell(snippet: string, body: string): string {
+  const result = spawnSync('bash', ['-c', snippet], { input: body, encoding: 'utf8' });
+  assert.equal(result.status, 0, `shell exited ${result.status}: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+const CANONICAL_FN = extractFn(workflow('pipeline-pr-review.yml'), 'canonical_verdict');
+const LEGACY_FN = extractFn(workflow('pipeline-pr-review.yml'), 'legacy_verdict');
+
+test('SECURITY: the canonical_verdict helper is byte-identical across all three verdict consumers — the drift that made a bolded LGTM invisible to auto-merge cannot recur silently (issue #731 follow-up)', () => {
+  for (const name of CONSUMERS) {
+    assert.equal(
+      extractFn(workflow(name), 'canonical_verdict'),
+      CANONICAL_FN,
+      `${name}'s canonical_verdict has drifted from pipeline-pr-review.yml's`,
+    );
+  }
+});
+
+test('SECURITY: the legacy_verdict prose fallback is byte-identical across all three verdict consumers, including the #731 bullet-filter fix (a bolded verdict is not a bullet)', () => {
+  assert.match(
+    LEGACY_FN,
+    /\[-\*\]\[\[:space:\]\]/,
+    'the fallback must require whitespace after the bullet marker, else a bolded **verdict** is eaten (issue #731)',
+  );
+  for (const name of CONSUMERS) {
+    assert.equal(
+      extractFn(workflow(name), 'legacy_verdict'),
+      LEGACY_FN,
+      `${name}'s legacy_verdict has drifted from pipeline-pr-review.yml's`,
+    );
+  }
+});
+
+const TOKEN_CASES: Array<{ name: string; body: string; expect: string }> = [
+  {
+    name: 'a plain token',
+    body: 'PR review (automated):\n<!-- verdict:LGTM -->\nLGTM, looks good\n',
+    expect: 'LGTM',
+  },
+  {
+    name: 'changes requested',
+    body: 'PR review (automated):\n<!-- verdict:CHANGES_REQUESTED -->\n**Changes requested**\n',
+    expect: 'CHANGES_REQUESTED',
+  },
+  {
+    name: 'needs human',
+    body: 'PR review (automated):\n<!-- verdict:NEEDS_HUMAN -->\nNeeds a human decision\n',
+    expect: 'NEEDS_HUMAN',
+  },
+  {
+    name: 'lowercase/extra-space token (model formatting drift)',
+    body: 'PR review (automated):\n<!--   verdict:lgtm   -->\n',
+    expect: 'LGTM',
+  },
+  {
+    name: 'no token at all (pre-contract comment)',
+    body: 'PR review (automated):\nLGTM, looks good and ready for a human to merge\n',
+    expect: '',
+  },
+];
+
+for (const testCase of TOKEN_CASES) {
+  test(`canonical_verdict extracts ${testCase.name}`, () => {
+    assert.equal(runShell(`${CANONICAL_FN}\ncanonical_verdict`, testCase.body), testCase.expect);
+  });
+}
+
+test('SECURITY: canonical_verdict takes the FIRST token, so a decoy token quoted later in a review body cannot override the authoritative one the review workflow injects on line 2', () => {
+  const body = [
+    'PR review (automated):',
+    '<!-- verdict:CHANGES_REQUESTED -->',
+    '**Changes requested**',
+    '',
+    '- The workflow should emit `<!-- verdict:LGTM -->` here; it does not.',
+  ].join('\n');
+  assert.equal(
+    runShell(`${CANONICAL_FN}\ncanonical_verdict`, body),
+    'CHANGES_REQUESTED',
+    'a review that legitimately QUOTES a token (reviews of this very machinery do) must not flip its own verdict',
+  );
+});
+
+test('SECURITY: the legacy prose fallback reads a BOLDED verdict — the exact case that silently stalled auto-merge before this contract (issue #731)', () => {
+  const bolded =
+    'PR review (automated):\n\n**LGTM, looks good and ready for a human to merge**\n\nNo issues found.\n';
+  const extracted = runShell(`${LEGACY_FN}\nlegacy_verdict`, bolded);
+  assert.match(
+    extracted,
+    /LGTM/i,
+    'a bolded LGTM must survive the bullet filter, or a fully-approved PR never auto-merges',
+  );
+
+  const boldedChanges = 'PR review (automated):\n\n**Changes requested**\n\n- a finding\n';
+  assert.match(runShell(`${LEGACY_FN}\nlegacy_verdict`, boldedChanges), /Changes requested/i);
+});
+
+test('SECURITY: the legacy prose fallback still drops real bullet lines, so a finding that mentions a verdict phrase cannot misroute the PR (issue #222)', () => {
+  const body = [
+    'PR review (automated):',
+    'LGTM, looks good and ready for a human to merge',
+    '',
+    '- the previous changes requested were addressed',
+  ].join('\n');
+  const extracted = runShell(`${LEGACY_FN}\nlegacy_verdict`, body);
+  assert.doesNotMatch(
+    extracted,
+    /changes requested/i,
+    'a finding bullet must never be read as the verdict — that spins up the reviser to find nothing',
+  );
+});
+
+test('every review-verdict consumer prefers the canonical token and keeps the prose fallback for pre-contract comments', () => {
+  for (const name of CONSUMERS) {
+    const source = workflow(name);
+    assert.match(source, /canonical_verdict/, `${name} must read the canonical token`);
+    assert.match(source, /legacy_verdict/, `${name} must keep the pre-contract prose fallback`);
+  }
+});
+
+test('the review worker instructs the model to emit the canonical token, and injects one deterministically regardless', () => {
+  const source = workflow('pipeline-pr-review.yml');
+  assert.match(source, /<!-- verdict:LGTM -->/, 'the prompt must show the model the exact token format');
+  assert.match(
+    source,
+    /VERDICT_TOKEN/,
+    'the post step must inject the authoritative token rather than trusting the model to have emitted one',
+  );
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -101,6 +101,7 @@
   "replyRetractionDisabled.test.ts": 2,
   "replyRetractionRouter.test.ts": 1,
   "repository.test.ts": 96,
+  "reviewVerdict.test.ts": 5,
   "router.test.ts": 8,
   "secrets.test.ts": 5,
   "securityGateCanary.test.ts": 1,


### PR DESCRIPTION
## Summary

Applies the "artifact contract at every handoff" principle to the pipeline's most-parsed handoff, and fixes a **live latent bug** found while doing it.

### The bug

Three workflows consume a PR-review verdict, each with its own regex over the same free prose:

| Consumer | Filter | Has #731's fix? |
|---|---|---|
| `pipeline-pr-review.yml` (routes) | `grep -vE '^[[:space:]]*[-*][[:space:]]'` | yes |
| `pipeline-pr-revise.yml` (re-verifies) | jq equivalent | yes |
| `pipeline-pr-automerge.yml` (gates merges) | `grep -vE '^[[:space:]]*[-*]'` | **no** |

#731 fixed "a bolded `**Changes requested**` is not a markdown bullet" in two of the three. Auto-merge kept the old filter, so a review whose verdict the model renders in bold — `**LGTM, looks good and ready for a human to merge**` — matches `^\s*[-*]`, gets dropped, leaves `verdict` empty, and the gate concludes "not an LGTM approval" and skips. **A fully-approved PR would sit unmerged forever, with no error on the PR, in the logs, or anywhere else.** Verified against the real filter before changing anything:

```
extracted verdict: [PR review (automated):]
RESULT: would SKIP — bolded LGTM is invisible to auto-merge
```

### The fix

A contract, not a better regex:

- The review model is asked to emit `<!-- verdict:LGTM -->` / `<!-- verdict:CHANGES_REQUESTED -->` / `<!-- verdict:NEEDS_HUMAN -->` on line 2. It renders invisibly, so the comment still reads naturally to humans.
- `pipeline-pr-review.yml` — the only place a review comment is composed — decides the verdict **once** (token if present, else the prose fallback), strips any whole-line token the model wrote, and stamps exactly one **authoritative** token after the `PR review (automated):` marker. The stamp is written by the workflow, never by the model.
- Consumers read that token. The authoritative one is always first, so a review that legitimately quotes a token mid-sentence — reviews of this very machinery do — can neither be mangled nor mistaken for the verdict.
- The prose fallback stays for comments posted before the contract existed, but is now **shared** rather than reimplemented three times, which is what fixes auto-merge's missing #731 patch.
- Routing no longer re-parses the posted text, so the #222 decoy class (a finding bullet reading like a verdict) is structurally impossible on the token path.
- An unrecognisable verdict routes nowhere — no label, no dispatch, nothing for auto-merge to approve — preserving today's fail-safe behaviour: it stalls visibly rather than guessing.

### Why not a shared script

`pipeline-pr-review.yml` runs on `pull_request` and therefore checks out **PR-controlled code**, in a job holding `pull-requests: write` and `actions: write`. Calling a repo script from that checkout would let a malicious PR rewrite the parser. The logic stays inline shell in all three workflows, and drift is prevented by a test instead.

## Tests

`tests/reviewVerdict.test.ts` (new, 12 tests) pins both halves:

- **Drift**: both shell helpers must be byte-identical across all three consumers — the exact failure that caused this bug — compared after dedenting so YAML nesting doesn't matter.
- **Behaviour**: the helpers are executed via `bash` against fixtures covering a plain token, all three verdicts, lowercase/extra-whitespace token drift, a missing token, a decoy token quoted in a finding, the **bolded-LGTM** case that stalled auto-merge, and the #222 finding-bullet decoy.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm test` — 2680 tests, **0 failures**
- `npm run test:security` — 989/989, manifest updated in this diff
- `npm run build` — clean
- The review workflow's stamping logic simulated end-to-end in bash against the three real-world cases (model emits token / model omits token with bolded LGTM / decoy token), confirming one authoritative token lands on line 2 in each

## Note for the reviewer

This PR modifies `pipeline-pr-review.yml`, so its own automated review will likely post "no output captured this run" — the documented self-modification case (the action runs the default branch's workflow version). That is expected here and not a failure; it reviews normally once merged.

Touches `.github/workflows/`, so a human merge is required by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7)_