### PR TITLE
Measure the pipeline loops: reconstruct a per-loop outcome ledger

### DIFF
--- a/.github/workflows/pipeline-outcomes.yml
+++ b/.github/workflows/pipeline-outcomes.yml
@@ -1,0 +1,130 @@
+name: Pipeline outcomes
+
+# Weekly self-measurement for the agent loops (see scripts/pipeline-outcomes.mjs).
+#
+# The pipeline has seven loops that fix, revise, resolve and merge PRs, and
+# nothing measured any of them: a loop could escalate on a one-command fix, die
+# mid-turn without pushing, or thrash for weeks, and the only trace was a marker
+# comment on one PR that nobody aggregates. "Is this loop earning its tokens?"
+# had no answer, so every change to a loop was argued from anecdote.
+#
+# This reconstructs the record from evidence that ALREADY exists — the marker
+# comments the loops post when they engage, checkpoint-recover, or escalate. No
+# new state, no writes to any PR, no LLM, no Max pool: the same read-only
+# deterministic shape as changelog-coverage.yml, and like it, the tracking issue
+# auto-closes when there is nothing to act on.
+#
+# Reads PR titles/bodies/comments as jq data only and runs no PR-controlled
+# code — `scripts/pipeline-outcomes.mjs` comes from the checked-out default
+# branch, never from a PR head.
+
+on:
+  schedule:
+    - cron: '23 20 * * 1' # 20:23 UTC Monday (~08:23 NZ Tuesday)
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: 'Days of history to report on (default 14).'
+        type: string
+        required: false
+
+permissions:
+  contents: read # checkout + run the report script
+  issues: write # open/update/close the single tracking issue
+  pull-requests: read # gh pr list / gh pr view
+
+concurrency:
+  group: pipeline-outcomes
+  cancel-in-progress: true
+
+env:
+  ISSUE_TITLE: '📊 Pipeline loop outcomes: loops that did not finish on their own'
+  WINDOW_DAYS: ${{ inputs.window_days || '14' }}
+  # Bounds the API calls: PRs updated longer ago than the window can hold no
+  # in-window markers, so there is nothing to gain by fetching them.
+  SCAN_LIMIT: '80'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # no git credential needed after checkout
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Collect PR comment history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -d "-${WINDOW_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+          gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit "$SCAN_LIMIT" \
+            --json number,updatedAt \
+            --jq "[.[] | select(.updatedAt >= \"$cutoff\") | .number] | .[]" > numbers.txt
+          echo "Scanning $(wc -l < numbers.txt) PR(s) updated since $cutoff."
+          : > prs.ndjson
+          while read -r n; do
+            [ -n "$n" ] || continue
+            gh pr view "$n" --repo "$GITHUB_REPOSITORY" \
+              --json number,title,url,createdAt,comments >> prs.ndjson
+          done < numbers.txt
+          jq -s '.' prs.ndjson > prs.json
+
+      - name: Build the report
+        id: report
+        run: |
+          set -euo pipefail
+          node scripts/pipeline-outcomes.mjs --window-days "$WINDOW_DAYS" < prs.json > report.md
+          cat report.md
+          # Always publish to the run summary — free, and no notification noise.
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          # Only nag when a loop actually failed to finish on its own; a clean
+          # window closes the issue instead (same self-clearing contract as
+          # changelog-coverage.yml).
+          if grep -q '^### PRs where a loop did not finish' report.md; then
+            echo "actionable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "actionable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update the tracking issue
+        if: steps.report.outputs.actionable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            cat report.md
+            printf '\n_Refreshed %s by the pipeline-outcomes workflow; auto-closes when every loop in the window finished on its own._\n' \
+              "$(date -u +%Y-%m-%dT%H:%MZ)"
+          } > issue-body.md
+          num="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search 'Pipeline loop outcomes in:title' \
+            --json number,title --jq "[.[] | select(.title==\"$ISSUE_TITLE\")][0].number // empty")"
+          if [ -n "$num" ]; then
+            gh issue edit "$num" --repo "$GITHUB_REPOSITORY" --body-file issue-body.md
+            echo "Updated tracking issue #$num."
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" --body-file issue-body.md
+            echo "Opened tracking issue."
+          fi
+
+      - name: Close the tracking issue when every loop finished cleanly
+        if: steps.report.outputs.actionable == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          num="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search 'Pipeline loop outcomes in:title' \
+            --json number,title --jq "[.[] | select(.title==\"$ISSUE_TITLE\")][0].number // empty")"
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --repo "$GITHUB_REPOSITORY" \
+              --body "✅ Every pipeline loop that engaged in the last ${WINDOW_DAYS} days finished on its own — no escalations, no checkpoint recoveries. Closing; the workflow reopens a fresh issue if that changes."
+            gh issue close "$num" --repo "$GITHUB_REPOSITORY"
+            echo "Closed tracking issue #$num."
+          else
+            echo "Clean window and no open tracking issue — nothing to do."
+          fi

--- a/.github/workflows/pipeline-outcomes.yml
+++ b/.github/workflows/pipeline-outcomes.yml
@@ -86,7 +86,13 @@ jobs:
         run: |
           set -euo pipefail
           cutoff="$(date -u -d "-${WINDOW_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+          # sort:updated-desc matters (issue #750 review): `gh pr list` orders by
+          # CREATION date by default, so the newest-$SCAN_LIMIT slice would drop
+          # an older PR that a loop touched recently — exactly the PR whose
+          # markers this report needs — and the undercount would be silent. At
+          # this repo's throughput that is a live risk, not a theoretical one.
           gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit "$SCAN_LIMIT" \
+            --search "sort:updated-desc" \
             --json number,updatedAt \
             --jq "[.[] | select(.updatedAt >= \"$cutoff\") | .number] | .[]" > numbers.txt
           echo "Scanning $(wc -l < numbers.txt) PR(s) updated since $cutoff."

--- a/.github/workflows/pipeline-outcomes.yml
+++ b/.github/workflows/pipeline-outcomes.yml
@@ -56,6 +56,30 @@ jobs:
         with:
           node-version: 24
 
+      # Reject a non-numeric window before anything uses it. NOT because the
+      # dispatch input is a shell-injection vector — it isn't: it reaches the
+      # steps as an ENVIRONMENT VARIABLE, and bash never re-scans the result of
+      # a parameter expansion for command substitution, so `$(...)` in the
+      # value stays inert text (verified; `date` simply rejects it as an
+      # invalid date). GitHub's documented script-injection hazard is
+      # `${{ }}` interpolated directly into a `run:` body, which splices
+      # attacker text into the script SOURCE before bash parses it — this
+      # workflow never does that, and must not start.
+      # The real problems a bad value causes are mundane: `date` fails with an
+      # opaque message mid-job, and the report renders "last NaN days". Fail
+      # fast with a clear reason instead, and keep the guard here so a future
+      # refactor toward a `run:`-body interpolation is already covered.
+      - name: Validate the window
+        run: |
+          set -euo pipefail
+          case "$WINDOW_DAYS" in
+            ''|*[!0-9]*)
+              echo "::error::window_days must be a positive integer (got '$WINDOW_DAYS')"; exit 1 ;;
+          esac
+          if [ "$WINDOW_DAYS" -lt 1 ] || [ "$WINDOW_DAYS" -gt 365 ]; then
+            echo "::error::window_days must be between 1 and 365 (got '$WINDOW_DAYS')"; exit 1
+          fi
+
       - name: Collect PR comment history
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -216,6 +216,28 @@ Launch each in its own session with the `/loop` skill. Each is written to
 **exit cleanly doing nothing when there is no work** — that keeps idle wake-ups
 cheap.
 
+### Measuring the loops
+
+`pipeline-outcomes.yml` (weekly, read-only, no LLM) answers the question the
+pipeline previously could not: **is each loop earning its tokens?** It
+reconstructs a per-loop record from the marker comments the loops already post
+— engaged, checkpoint-recovered, escalated — so there is no new state to keep
+in sync and nothing new written to any PR. `scripts/pipeline-outcomes.mjs` does
+the counting and is unit-tested against synthetic payloads.
+
+The column that matters most is **Recovered**: an agent that committed work and
+then ended its turn without pushing, rescued by the loop's deterministic
+checkpoint step. Every one of those is a prompt/harness defect in that loop —
+not a code defect in the PR — and it is the failure mode that has cost the most
+here (PRs #606 and #609 both escalated `needs-human` with completed work
+stranded on the runner). **Escalated** is the loop correctly giving up; a loop
+sitting at a high escalation rate is either mis-scoped or being handed work it
+cannot do.
+
+The tracking issue only opens when a loop failed to finish on its own, and
+auto-closes on a clean window — the same self-clearing contract as
+`changelog-coverage.yml`, so a quiet pipeline stays quiet.
+
 ### 1 · PR review
 
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2786,6 +2786,23 @@ number could reach an unrelated person).
       prompt-injected" guarantee, leave `AUTOMERGE_MODE` unset (or require a human
       approving *review* in branch protection, which the automated verdict is
       not) — then a human merges everything, as before.
+- [ ] **The pipeline's outcome ledger trusts one comment author, deliberately**
+      (`pipeline-outcomes.yml` + `scripts/pipeline-outcomes.mjs`). The weekly
+      report reconstructs each loop's record from the marker comments the loops
+      post, and those markers are plain text in a public thread, so *who posted
+      them* is the whole trust boundary — it decides both the numbers and
+      whether the tracking issue auto-closes on an apparently "clean" window.
+      Markers count only from `github-actions`/`github-actions[bot]` (both `gh`
+      renderings — GraphQL and REST differ, and matching one makes the gate
+      silently match nothing). `claude[bot]` is excluded **on purpose**: every
+      real marker is written by a deterministic `GITHUB_TOKEN` step, while the
+      revise agent uniquely holds `Bash(gh pr comment:*)`, runs under that
+      identity, and reads prompt-injectable PR content — so admitting it would
+      let an injected agent fabricate rows, which is worse than no gate because
+      the gate implies the rows are trustworthy. Pinned by `SECURITY:` tests
+      (issue #750). The workflow itself is read-only (`contents: read`,
+      `issues: write`, `pull-requests: read`), never checks out a PR head, and
+      runs no PR-controlled code.
 - [ ] **If enabling `redeploy_bot`**: the exact-match sudoers line in
       docs/DEPLOYMENT.md is added (opt-in — omit it and the tool simply fails
       clean with no new host surface granted).

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// Pipeline outcome ledger (see .github/workflows/pipeline-outcomes.yml).
+//
+// The self-improving pipeline has seven agent loops that fix, revise, resolve
+// and merge PRs, and until now NOTHING measured them. A loop could burn an
+// escalation on a one-command fix, die mid-turn without pushing, or thrash for
+// weeks, and the only trace was a marker comment on one PR that nobody
+// aggregates. "Is this loop earning its tokens?" was unanswerable.
+//
+// This reconstructs the ledger from evidence that ALREADY exists: every loop
+// stamps a marker HTML comment when it engages, recovers committed-but-unpushed
+// work, or escalates to a human. Counting those markers over a window gives a
+// per-loop success/failure record with no new writes, no new state to keep in
+// sync, and no LLM in the path — the same read-only, deterministic shape as
+// scripts/check-changelog-coverage.mjs.
+//
+// Reads `gh pr view --json number,title,url,createdAt,comments` output for a
+// set of PRs (a JSON array) on stdin; prints a Markdown report. Always exits 0
+// — the caller decides what to do with the report.
+//
+// Usage:
+//   ... build prs.json ... | node scripts/pipeline-outcomes.mjs [--window-days N]
+//
+// Reading the report:
+//   * Engaged      — the loop started work on a PR (attempt markers).
+//   * Recovered    — the agent COMMITTED but never pushed, and the workflow's
+//                    deterministic checkpoint step rescued the work. Every one
+//                    of these is an agent that ended its turn early (usually
+//                    "waiting" for a command that never reports back), which is
+//                    a prompt/harness defect, not a code defect. A rising
+//                    Recovered count is the signal to fix the loop itself.
+//   * Escalated    — the loop gave up and labelled `needs-human`.
+//   * Clean        — engaged, neither recovered nor escalated.
+// ---------------------------------------------------------------------------
+
+/**
+ * Loops that stamp markers, in report order. `attempt` is what counts as
+ * "engaged"; auto-merge has no attempt marker (it merges silently on success
+ * and only ever comments when it CAN'T), so its blocked/human-ready notices are
+ * counted as engagements — a non-zero count there is by definition friction.
+ */
+const LOOPS = [
+  {
+    name: 'autofix',
+    attempt: '<!-- pipeline-autofix-attempt -->',
+    checkpoint: '<!-- pipeline-autofix-checkpoint -->',
+    escalation: '<!-- pipeline-autofix-escalation -->',
+  },
+  {
+    name: 'revise',
+    attempt: '<!-- pipeline-pr-revise-attempt -->',
+    checkpoint: '<!-- pipeline-pr-revise-checkpoint -->',
+    escalation: '<!-- pipeline-pr-revise-escalation -->',
+  },
+  {
+    name: 'conflict-resolver',
+    attempt: '<!-- pipeline-pr-conflict-attempt -->',
+    checkpoint: '<!-- pipeline-pr-conflict-checkpoint -->',
+    escalation: '<!-- pipeline-pr-conflict-escalation -->',
+  },
+  {
+    name: 'auto-merge',
+    attempt: '<!-- pipeline-automerge-blocked -->',
+    checkpoint: null,
+    escalation: '<!-- pipeline-automerge-human-ready -->',
+  },
+];
+
+import { readFileSync } from 'node:fs';
+
+const windowArg = process.argv.find((a) => a.startsWith('--window-days'));
+const windowDays = windowArg
+  ? Number(windowArg.split('=')[1] ?? process.argv[process.argv.indexOf(windowArg) + 1])
+  : 14;
+
+let prs;
+try {
+  prs = JSON.parse(readFileSync(0, 'utf8')); // fd 0 = stdin
+} catch {
+  console.error('pipeline-outcomes: expected an array of `gh pr view --json ...` objects on stdin.');
+  process.exit(0); // never fail the workflow on a bad/empty pipe
+}
+if (!Array.isArray(prs)) prs = [prs];
+
+const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+const inWindow = (iso) => iso && Date.parse(iso) >= cutoff;
+
+const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0 }]));
+/** PRs worth a human glance: escalations and silent-death recoveries. */
+const notable = [];
+
+for (const pr of prs) {
+  const comments = Array.isArray(pr?.comments) ? pr.comments : [];
+  for (const loop of LOOPS) {
+    const has = (marker) =>
+      marker &&
+      comments.filter((c) => inWindow(c?.createdAt) && String(c?.body ?? '').includes(marker)).length;
+
+    const engaged = has(loop.attempt) || 0;
+    const recovered = has(loop.checkpoint) || 0;
+    const escalated = has(loop.escalation) || 0;
+    if (!engaged && !recovered && !escalated) continue;
+
+    const row = tally.get(loop.name);
+    // A checkpoint or escalation without an attempt marker still means the loop
+    // ran (the conflict resolver's older runs predate its attempt marker), so
+    // count the engagement rather than losing it.
+    row.engaged += Math.max(engaged, recovered, escalated);
+    row.recovered += recovered;
+    row.escalated += escalated;
+
+    if (recovered || escalated) {
+      notable.push({
+        number: pr.number,
+        title: pr.title ?? '',
+        url: pr.url ?? '',
+        loop: loop.name,
+        recovered,
+        escalated,
+      });
+    }
+  }
+}
+
+const rows = LOOPS.map((loop) => ({ name: loop.name, ...tally.get(loop.name) })).filter(
+  (row) => row.engaged > 0,
+);
+
+if (rows.length === 0) {
+  console.log(`No pipeline loop engaged in the last ${windowDays} days — nothing to report.`);
+  process.exit(0);
+}
+
+const pct = (n, d) => (d === 0 ? '—' : `${Math.round((n / d) * 100)}%`);
+
+console.log(`## Pipeline loop outcomes — last ${windowDays} days\n`);
+console.log('| Loop | Engaged | Recovered (agent stopped early) | Escalated to human | Clean |');
+console.log('| --- | --- | --- | --- | --- |');
+for (const row of rows) {
+  const clean = Math.max(0, row.engaged - row.escalated - row.recovered);
+  console.log(
+    `| ${row.name} | ${row.engaged} | ${row.recovered} (${pct(row.recovered, row.engaged)}) | ` +
+      `${row.escalated} (${pct(row.escalated, row.engaged)}) | ${clean} (${pct(clean, row.engaged)}) |`,
+  );
+}
+
+if (notable.length > 0) {
+  console.log('\n### PRs where a loop did not finish on its own\n');
+  for (const item of notable.sort((a, b) => b.number - a.number)) {
+    const what = [
+      item.escalated ? `escalated ${item.escalated}×` : '',
+      item.recovered ? `checkpoint-recovered ${item.recovered}×` : '',
+    ]
+      .filter(Boolean)
+      .join(', ');
+    console.log(`- #${item.number} — **${item.loop}** ${what} — ${item.title}`);
+  }
+}
+
+console.log(
+  '\n> A **Recovered** row is an agent that committed work then ended its turn without pushing — ' +
+    'a prompt/harness defect in that loop, not a code defect in the PR. **Escalated** is the loop ' +
+    'correctly giving up. Both are cheaper to fix than to keep paying for.',
+);

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -34,6 +34,8 @@
 //   * Clean        — engaged, neither recovered nor escalated.
 // ---------------------------------------------------------------------------
 
+import { readFileSync } from 'node:fs';
+
 /**
  * Loops that stamp markers, in report order. `attempt` is what counts as
  * "engaged"; auto-merge has no attempt marker (it merges silently on success
@@ -67,8 +69,6 @@ const LOOPS = [
   },
 ];
 
-import { readFileSync } from 'node:fs';
-
 const DEFAULT_WINDOW_DAYS = 14;
 const windowArg = process.argv.find((a) => a.startsWith('--window-days'));
 const requestedWindow = windowArg
@@ -93,7 +93,7 @@ if (!Array.isArray(prs)) prs = [prs];
 const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
 const inWindow = (iso) => iso && Date.parse(iso) >= cutoff;
 
-const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0 }]));
+const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0, clean: 0 }]));
 /** PRs worth a human glance: escalations and silent-death recoveries. */
 const notable = [];
 
@@ -120,9 +120,19 @@ for (const pr of prs) {
     // engagements with this outcome", not slices of a pie, and can legitimately
     // sum past 100%. Splitting them into exclusive buckets would hide the
     // double-failure case, which is the one most worth seeing.
-    row.engaged += Math.max(engaged, recovered, escalated);
+    const engagements = Math.max(engaged, recovered, escalated);
+    row.engaged += engagements;
     row.recovered += recovered;
     row.escalated += escalated;
+    // Clean is accumulated PER PR, never derived by subtracting loop totals
+    // (issue #750 review). Because the two failure kinds overlap, aggregate
+    // subtraction double-counts a double-failure PR and cancels out genuinely
+    // clean engagements from OTHER PRs: one clean conflict-resolver PR plus one
+    // #609-style attempt+checkpoint+escalation PR gave engaged=2, recovered=1,
+    // escalated=1 → "0 clean", hiding a real clean run. A single engagement
+    // that both recovered and escalated is ONE failed engagement, hence
+    // max() rather than a sum.
+    row.clean += Math.max(0, engagements - Math.max(recovered, escalated));
 
     if (recovered || escalated) {
       notable.push({
@@ -152,10 +162,9 @@ console.log(`## Pipeline loop outcomes — last ${windowDays} days\n`);
 console.log('| Loop | Engaged | Recovered (agent stopped early) | Escalated to human | Clean |');
 console.log('| --- | --- | --- | --- | --- |');
 for (const row of rows) {
-  const clean = Math.max(0, row.engaged - row.escalated - row.recovered);
   console.log(
     `| ${row.name} | ${row.engaged} | ${row.recovered} (${pct(row.recovered, row.engaged)}) | ` +
-      `${row.escalated} (${pct(row.escalated, row.engaged)}) | ${clean} (${pct(clean, row.engaged)}) |`,
+      `${row.escalated} (${pct(row.escalated, row.engaged)}) | ${row.clean} (${pct(row.clean, row.engaged)}) |`,
   );
 }
 

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -93,6 +93,19 @@ if (!Array.isArray(prs)) prs = [prs];
 const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
 const inWindow = (iso) => iso && Date.parse(iso) >= cutoff;
 
+/**
+ * Only the pipeline's own bot identities can contribute a marker (issue #750
+ * review). Markers are plain text in a public comment thread, so without this
+ * any commenter could inflate "escalated" or manufacture a clean window — and
+ * this report now drives an auto-closing tracking issue, so a spoofed row is
+ * not merely cosmetic. Both renderings are accepted for the same reason
+ * pipeline-pr-automerge.yml accepts both: gh's GraphQL comment authors render
+ * as "github-actions" while REST renders "github-actions[bot]", and matching
+ * only one made an identity gate silently match nothing.
+ */
+const MARKER_AUTHORS = new Set(['github-actions', 'github-actions[bot]', 'claude', 'claude[bot]']);
+const fromPipeline = (comment) => MARKER_AUTHORS.has(comment?.author?.login ?? '');
+
 const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0, clean: 0 }]));
 /** PRs worth a human glance: escalations and silent-death recoveries. */
 const notable = [];
@@ -102,7 +115,9 @@ for (const pr of prs) {
   for (const loop of LOOPS) {
     const has = (marker) =>
       marker &&
-      comments.filter((c) => inWindow(c?.createdAt) && String(c?.body ?? '').includes(marker)).length;
+      comments.filter(
+        (c) => fromPipeline(c) && inWindow(c?.createdAt) && String(c?.body ?? '').includes(marker),
+      ).length;
 
     const engaged = has(loop.attempt) || 0;
     const recovered = has(loop.checkpoint) || 0;

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -69,10 +69,17 @@ const LOOPS = [
 
 import { readFileSync } from 'node:fs';
 
+const DEFAULT_WINDOW_DAYS = 14;
 const windowArg = process.argv.find((a) => a.startsWith('--window-days'));
-const windowDays = windowArg
+const requestedWindow = windowArg
   ? Number(windowArg.split('=')[1] ?? process.argv[process.argv.indexOf(windowArg) + 1])
-  : 14;
+  : DEFAULT_WINDOW_DAYS;
+// A missing or non-numeric value used to render as "last NaN days" and match
+// nothing — a confusing empty report rather than an obvious error. Fall back
+// to the default instead; the workflow validates the input separately, so this
+// only catches a hand-run invocation.
+const windowDays =
+  Number.isFinite(requestedWindow) && requestedWindow > 0 ? requestedWindow : DEFAULT_WINDOW_DAYS;
 
 let prs;
 try {
@@ -106,6 +113,13 @@ for (const pr of prs) {
     // A checkpoint or escalation without an attempt marker still means the loop
     // ran (the conflict resolver's older runs predate its attempt marker), so
     // count the engagement rather than losing it.
+    //
+    // Recovered and Escalated are deliberately NOT mutually exclusive: one
+    // engagement can be checkpoint-recovered AND then escalated (that is
+    // exactly what happened on #609), so their percentages are each "share of
+    // engagements with this outcome", not slices of a pie, and can legitimately
+    // sum past 100%. Splitting them into exclusive buckets would hide the
+    // double-failure case, which is the one most worth seeing.
     row.engaged += Math.max(engaged, recovered, escalated);
     row.recovered += recovered;
     row.escalated += escalated;
@@ -161,5 +175,7 @@ if (notable.length > 0) {
 console.log(
   '\n> A **Recovered** row is an agent that committed work then ended its turn without pushing — ' +
     'a prompt/harness defect in that loop, not a code defect in the PR. **Escalated** is the loop ' +
-    'correctly giving up. Both are cheaper to fix than to keep paying for.',
+    'correctly giving up. Both are cheaper to fix than to keep paying for. The two are not ' +
+    'mutually exclusive (one engagement can be recovered *and* then escalated), so those ' +
+    'percentages are shares of engagements rather than slices of a pie and may sum past 100%.',
 );

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -94,16 +94,29 @@ const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
 const inWindow = (iso) => iso && Date.parse(iso) >= cutoff;
 
 /**
- * Only the pipeline's own bot identities can contribute a marker (issue #750
- * review). Markers are plain text in a public comment thread, so without this
- * any commenter could inflate "escalated" or manufacture a clean window — and
- * this report now drives an auto-closing tracking issue, so a spoofed row is
- * not merely cosmetic. Both renderings are accepted for the same reason
+ * Only the identity that actually POSTS markers can contribute one (issue #750
+ * review, second pass). Markers are plain text in a public comment thread, so
+ * without this any commenter could inflate "escalated" or manufacture a clean
+ * window — and this report drives an auto-closing tracking issue, so a spoofed
+ * row is not merely cosmetic.
+ *
+ * `claude[bot]` is deliberately NOT here, and that exclusion is the whole
+ * point. Every marker across autofix/revise/conflict/auto-merge is written by
+ * a DETERMINISTIC step using GITHUB_TOKEN, so it always lands as
+ * github-actions; no loop ever posts a marker as claude. Meanwhile the revise
+ * agent — uniquely among the loops — holds `Bash(gh pr comment:*)` (so it can
+ * explain a principled refusal), runs under the claude[bot] identity, and
+ * reads untrusted, prompt-injectable PR content. Allowing claude[bot] would
+ * therefore hand the one injectable identity in the pipeline the ability to
+ * fabricate ledger rows, which is worse than having no gate at all because the
+ * gate implies the rows are trustworthy.
+ *
+ * Both github-actions renderings are accepted for the same reason
  * pipeline-pr-automerge.yml accepts both: gh's GraphQL comment authors render
  * as "github-actions" while REST renders "github-actions[bot]", and matching
  * only one made an identity gate silently match nothing.
  */
-const MARKER_AUTHORS = new Set(['github-actions', 'github-actions[bot]', 'claude', 'claude[bot]']);
+const MARKER_AUTHORS = new Set(['github-actions', 'github-actions[bot]']);
 const fromPipeline = (comment) => MARKER_AUTHORS.has(comment?.author?.login ?? '');
 
 const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0, clean: 0 }]));

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -148,10 +148,34 @@ test('SECURITY: a marker posted by anyone other than the pipeline bots is ignore
   );
 });
 
-test('both gh renderings of the bot identity are accepted, so the identity gate never silently matches nothing', () => {
-  for (const login of ['github-actions', 'github-actions[bot]', 'claude', 'claude[bot]']) {
+test('both gh renderings of the marker-posting identity are accepted, so the identity gate never silently matches nothing', () => {
+  // GraphQL renders "github-actions", REST renders "github-actions[bot]";
+  // matching only one is how an identity gate ends up matching nothing at all.
+  for (const login of ['github-actions', 'github-actions[bot]']) {
     const out = run([pr(101, ['<!-- pipeline-autofix-attempt -->'], recent(), login)]);
     assert.match(out, /\| autofix \| 1 \|/, `${login} must be recognised as a pipeline author`);
+  }
+});
+
+test('SECURITY: a marker posted as claude[bot] is ignored — the revise agent uniquely holds `gh pr comment`, runs under that identity, and reads prompt-injectable PR content, so a marker from it is never authentic (issue #750 review)', () => {
+  // Every real marker is written by a DETERMINISTIC step using GITHUB_TOKEN,
+  // so it always lands as github-actions. Counting claude[bot] would let a
+  // prompt-injected revise agent fabricate ledger rows — worse than no gate,
+  // because the gate implies the rows can be trusted.
+  for (const login of ['claude', 'claude[bot]']) {
+    const out = run([
+      pr(
+        102,
+        ['<!-- pipeline-pr-revise-escalation -->', '<!-- pipeline-pr-revise-checkpoint -->'],
+        recent(),
+        login,
+      ),
+    ]);
+    assert.match(
+      out,
+      /No pipeline loop engaged/,
+      `a marker attributed to ${login} must contribute nothing to the ledger`,
+    );
   }
 });
 

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -93,6 +93,39 @@ test('pipeline-outcomes treats an auto-merge blocked notice as friction worth re
   assert.match(out, /\| auto-merge \| 1 \|/);
 });
 
+test('Clean counts a genuinely clean PR even when a SIBLING PR of the same loop both recovered and escalated (issue #750 review)', () => {
+  // Regression: Clean used to be derived by subtracting loop totals
+  // (engaged - recovered - escalated). Because the two failure kinds overlap
+  // on a single engagement, a #609-style attempt+checkpoint+escalation PR
+  // subtracted TWICE and cancelled out the clean engagement on an unrelated
+  // PR of the same loop — reporting "0 clean" when one genuinely clean run
+  // existed, which is precisely the signal this report exists to give.
+  const out = run([
+    pr(1, ['<!-- pipeline-pr-conflict-attempt -->']),
+    pr(2, [
+      '<!-- pipeline-pr-conflict-attempt -->',
+      '<!-- pipeline-pr-conflict-checkpoint -->',
+      '<!-- pipeline-pr-conflict-escalation -->',
+    ]),
+  ]);
+  assert.match(
+    out,
+    /\| conflict-resolver \| 2 \| 1 \(50%\) \| 1 \(50%\) \| 1 \(50%\) \|/,
+    'the clean engagement on PR #1 must survive the double failure on PR #2',
+  );
+});
+
+test('a single engagement that both recovered and escalated counts as ONE failed engagement, not two', () => {
+  const out = run([
+    pr(3, [
+      '<!-- pipeline-autofix-attempt -->',
+      '<!-- pipeline-autofix-checkpoint -->',
+      '<!-- pipeline-autofix-escalation -->',
+    ]),
+  ]);
+  assert.match(out, /\| autofix \| 1 \| 1 \(100%\) \| 1 \(100%\) \| 0 \(0%\) \|/);
+});
+
 test('pipeline-outcomes falls back to the default window when --window-days is non-numeric, instead of reporting "NaN days" and matching nothing (issue #750 review)', () => {
   const out = run([pr(90, ['<!-- pipeline-autofix-attempt -->'])], ['--window-days', 'not-a-number']);
   assert.doesNotMatch(out, /NaN/, 'a bad window must never render as "last NaN days"');

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -93,6 +93,13 @@ test('pipeline-outcomes treats an auto-merge blocked notice as friction worth re
   assert.match(out, /\| auto-merge \| 1 \|/);
 });
 
+test('pipeline-outcomes falls back to the default window when --window-days is non-numeric, instead of reporting "NaN days" and matching nothing (issue #750 review)', () => {
+  const out = run([pr(90, ['<!-- pipeline-autofix-attempt -->'])], ['--window-days', 'not-a-number']);
+  assert.doesNotMatch(out, /NaN/, 'a bad window must never render as "last NaN days"');
+  assert.match(out, /last 14 days/, 'it falls back to the documented default');
+  assert.match(out, /\| autofix \| 1 \|/, 'and still counts in-window markers');
+});
+
 test('pipeline-outcomes survives malformed input rather than failing the workflow', () => {
   const result = spawnSync('node', [SCRIPT], { input: 'not json at all', encoding: 'utf8' });
   assert.equal(result.status, 0, 'a bad pipe must never fail the caller');

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -24,11 +24,11 @@ function run(prs: unknown, args: string[] = []): string {
   return result.stdout;
 }
 
-const pr = (number: number, bodies: string[], createdAt = recent()) => ({
+const pr = (number: number, bodies: string[], createdAt = recent(), login = 'github-actions[bot]') => ({
   number,
   title: `PR ${number}`,
   url: `https://example.invalid/${number}`,
-  comments: bodies.map((body) => ({ body, createdAt })),
+  comments: bodies.map((body) => ({ body, createdAt, author: { login } })),
 });
 
 test('pipeline-outcomes reports nothing when no loop engaged', () => {
@@ -137,6 +137,22 @@ test('pipeline-outcomes survives malformed input rather than failing the workflo
   const result = spawnSync('node', [SCRIPT], { input: 'not json at all', encoding: 'utf8' });
   assert.equal(result.status, 0, 'a bad pipe must never fail the caller');
   assert.match(result.stderr, /expected an array/);
+});
+
+test('SECURITY: a marker posted by anyone other than the pipeline bots is ignored, so a commenter cannot skew the ledger or manufacture a clean window (issue #750 review)', () => {
+  const spoofed = run([pr(100, ['<!-- pipeline-autofix-escalation -->'], recent(), 'random-user')]);
+  assert.match(
+    spoofed,
+    /No pipeline loop engaged/,
+    'a hand-written marker from an arbitrary commenter must contribute nothing',
+  );
+});
+
+test('both gh renderings of the bot identity are accepted, so the identity gate never silently matches nothing', () => {
+  for (const login of ['github-actions', 'github-actions[bot]', 'claude', 'claude[bot]']) {
+    const out = run([pr(101, ['<!-- pipeline-autofix-attempt -->'], recent(), login)]);
+    assert.match(out, /\| autofix \| 1 \|/, `${login} must be recognised as a pipeline author`);
+  }
 });
 
 test('pipeline-outcomes tolerates PRs with no comments field at all', () => {

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -1,0 +1,105 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * scripts/pipeline-outcomes.mjs — the pipeline's self-measurement (see the
+ * script header). It reconstructs each loop's outcomes from the marker
+ * comments the loops already post, so these tests pin the counting rules
+ * against synthetic PR payloads rather than live GitHub data.
+ */
+
+const SCRIPT = fileURLToPath(new URL('../scripts/pipeline-outcomes.mjs', import.meta.url));
+
+const recent = () => new Date(Date.now() - 60 * 60 * 1000).toISOString();
+const ancient = () => new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+
+function run(prs: unknown, args: string[] = []): string {
+  const result = spawnSync('node', [SCRIPT, ...args], {
+    input: JSON.stringify(prs),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, `script exited ${result.status}: ${result.stderr}`);
+  return result.stdout;
+}
+
+const pr = (number: number, bodies: string[], createdAt = recent()) => ({
+  number,
+  title: `PR ${number}`,
+  url: `https://example.invalid/${number}`,
+  comments: bodies.map((body) => ({ body, createdAt })),
+});
+
+test('pipeline-outcomes reports nothing when no loop engaged', () => {
+  const out = run([pr(1, ['just a normal human comment'])]);
+  assert.match(out, /No pipeline loop engaged/);
+});
+
+test('pipeline-outcomes counts an engagement, a checkpoint recovery and an escalation per loop', () => {
+  const out = run([
+    pr(10, ['<!-- pipeline-autofix-attempt -->\nattempt 1']),
+    pr(11, [
+      '<!-- pipeline-autofix-attempt -->\nattempt 1',
+      '<!-- pipeline-autofix-escalation -->\ngiving up',
+    ]),
+    pr(12, [
+      '<!-- pipeline-pr-revise-attempt -->\nattempt 1',
+      '<!-- pipeline-pr-revise-checkpoint -->\nrecovered work',
+    ]),
+  ]);
+  assert.match(out, /\| autofix \| 2 \| 0 \(0%\) \| 1 \(50%\) \| 1 \(50%\) \|/);
+  assert.match(out, /\| revise \| 1 \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
+});
+
+test('pipeline-outcomes lists the PRs where a loop did not finish, newest first', () => {
+  const out = run([
+    pr(20, ['<!-- pipeline-autofix-attempt -->', '<!-- pipeline-autofix-escalation -->']),
+    pr(30, ['<!-- pipeline-pr-conflict-checkpoint -->']),
+    pr(25, ['<!-- pipeline-autofix-attempt -->']),
+  ]);
+  const section = out.slice(out.indexOf('### PRs where a loop did not finish'));
+  assert.match(section, /- #30 — \*\*conflict-resolver\*\* checkpoint-recovered 1×/);
+  assert.match(section, /- #20 — \*\*autofix\*\* escalated 1×/);
+  assert.doesNotMatch(section, /#25/, 'a clean engagement is not "did not finish"');
+  assert.ok(
+    section.indexOf('#30') < section.indexOf('#20'),
+    'notable PRs are listed newest (highest number) first',
+  );
+});
+
+test('pipeline-outcomes ignores markers outside the window', () => {
+  const out = run([pr(40, ['<!-- pipeline-autofix-attempt -->'], ancient())]);
+  assert.match(out, /No pipeline loop engaged/);
+});
+
+test('pipeline-outcomes honours --window-days', () => {
+  const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+  const payload = [pr(50, ['<!-- pipeline-autofix-attempt -->'], eightDaysAgo)];
+  assert.match(run(payload, ['--window-days', '14']), /\| autofix \| 1 \|/);
+  assert.match(run(payload, ['--window-days', '3']), /No pipeline loop engaged/);
+});
+
+test('pipeline-outcomes counts a loop that escalated without an attempt marker as still having engaged', () => {
+  // The conflict resolver's escalation and checkpoint markers predate its
+  // attempt marker, so an escalation-only PR must not report "0 engaged, 1
+  // escalated" (which would render a nonsensical rate).
+  const out = run([pr(60, ['<!-- pipeline-pr-conflict-escalation -->\nunresolvable'])]);
+  assert.match(out, /\| conflict-resolver \| 1 \| 0 \(0%\) \| 1 \(100%\) \| 0 \(0%\) \|/);
+});
+
+test('pipeline-outcomes treats an auto-merge blocked notice as friction worth reporting', () => {
+  const out = run([pr(70, ['<!-- pipeline-automerge-blocked -->\ncould not merge'])]);
+  assert.match(out, /\| auto-merge \| 1 \|/);
+});
+
+test('pipeline-outcomes survives malformed input rather than failing the workflow', () => {
+  const result = spawnSync('node', [SCRIPT], { input: 'not json at all', encoding: 'utf8' });
+  assert.equal(result.status, 0, 'a bad pipe must never fail the caller');
+  assert.match(result.stderr, /expected an array/);
+});
+
+test('pipeline-outcomes tolerates PRs with no comments field at all', () => {
+  const out = run([{ number: 80, title: 'no comments key' }]);
+  assert.match(out, /No pipeline loop engaged/);
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -93,6 +93,7 @@
   "pendingActions.test.ts": 3,
   "pendingAlertQueue.test.ts": 3,
   "personas.test.ts": 1,
+  "pipelineOutcomes.test.ts": 1,
   "rateLimitNotice.router.test.ts": 2,
   "rbac.test.ts": 46,
   "redeploy.test.ts": 2,

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -93,7 +93,7 @@
   "pendingActions.test.ts": 3,
   "pendingAlertQueue.test.ts": 3,
   "personas.test.ts": 1,
-  "pipelineOutcomes.test.ts": 1,
+  "pipelineOutcomes.test.ts": 2,
   "rateLimitNotice.router.test.ts": 2,
   "rbac.test.ts": 46,
   "redeploy.test.ts": 2,


### PR DESCRIPTION
## Summary

The pipeline has seven agent loops that fix, revise, resolve and merge PRs, and **nothing measured any of them**. A loop could burn an escalation on a one-command fix, die mid-turn without pushing, or thrash for weeks, and the only trace was a marker comment on a single PR that nobody aggregates. "Is this loop earning its tokens?" had no answer, so every change to a loop was argued from anecdote.

This adds the missing evidence base without adding any new state.

### How it works

`scripts/pipeline-outcomes.mjs` reconstructs each loop's record from evidence that **already exists** — the marker comments every loop posts when it engages, checkpoint-recovers, or escalates. No new writes to any PR, no new state to keep in sync, no LLM, no Max pool. Same read-only deterministic shape as `scripts/check-changelog-coverage.mjs`.

`pipeline-outcomes.yml` runs it weekly, always publishes to the run summary (free, no notification noise), and keeps **one** tracking issue in sync only when a loop failed to finish on its own — auto-closing on a clean window, the same self-clearing contract as `changelog-coverage.yml`, so a quiet pipeline stays quiet.

### Reading the report

Run against real markers from the last day, it produces:

| Loop | Engaged | Recovered (agent stopped early) | Escalated to human | Clean |
| --- | --- | --- | --- | --- |
| autofix | 1 | 0 (0%) | 1 (100%) | 0 (0%) |
| revise | 2 | 0 (0%) | 2 (100%) | 0 (0%) |
| conflict-resolver | 2 | 1 (50%) | 0 (0%) | 1 (50%) |

**Recovered** is the column that matters: an agent that committed work and then ended its turn without pushing, rescued by that loop's deterministic checkpoint step. Each one is a prompt/harness defect in the loop — not a code defect in the PR — and it is the failure mode that has cost the most here (#606 and #609 both escalated `needs-human` with finished work stranded on the runner). **Escalated** is the loop correctly giving up.

Recovered and Escalated are deliberately **not** mutually exclusive — one engagement can be recovered *and then* escalated — so those percentages are shares of engagements rather than slices of a pie and may sum past 100%. Splitting them into exclusive buckets would hide the double-failure case, which is the one most worth seeing.

## Security posture

Reads PR titles/bodies/comments as jq/node data only and runs no PR-controlled code — the script comes from the checked-out default branch, never a PR head (the workflow triggers only on `schedule`/`workflow_dispatch`). Permissions are `contents: read`, `issues: write`, `pull-requests: read`.

**Marker authenticity** is the one real trust boundary, since markers are plain text in a public thread and decide both the numbers and whether the tracking issue auto-closes. Markers count only from `github-actions`/`github-actions[bot]` (both `gh` renderings — GraphQL and REST differ, and matching one makes the gate silently match nothing). `claude[bot]` is excluded deliberately: every real marker is written by a deterministic `GITHUB_TOKEN` step, while the revise agent uniquely holds `Bash(gh pr comment:*)`, runs under that identity, and reads prompt-injectable PR content — so admitting it would let an injected agent fabricate rows, which is worse than no gate because the gate implies the rows are trustworthy. Recorded in `docs/SECURITY.md`.

The `window_days` dispatch input reaches the steps via `env:` (never spliced into a `run:` body) and is validated to a positive integer in 1..365 before use.

## Tests

`tests/pipelineOutcomes.test.ts` — **15 tests**, two of them `SECURITY:`-prefixed (`security-floor.json` updated to match):

- Counting rules: per-loop engaged/recovered/escalated, the notable-PR list and ordering, window filtering and `--window-days`, an escalation-only PR still counting as engaged, auto-merge's blocked notice as friction.
- Regressions from review: `Clean` counted per-PR so a sibling double-failure can't cancel a genuinely clean engagement; a single engagement that both recovered and escalated counting as one failed engagement; non-numeric window falling back to the default instead of "NaN days".
- **SECURITY**: a marker from an arbitrary commenter contributes nothing; a marker attributed to `claude`/`claude[bot]` contributes nothing. Plus a test that every accepted `github-actions` rendering *is* recognised, so the gate can never silently zero out a row.
- Robustness: malformed stdin exits 0 rather than failing the caller; a PR with no `comments` field.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — clean
- `npm test` — full suite green apart from the known shared-table flake in `repeatQuestionShortcutRouter` (issue #719 class), which passes in isolation and which this diff cannot affect: there is no `src/` change here at all
- `npm run test:security` — manifest matches, updated in this diff for the two new `SECURITY:` tests

Touches `.github/workflows/`, `scripts/` and `docs/SECURITY.md`, so a human merge is required by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W3YHSwScRhzxhp8YuP5Q7