### PR TITLE
docs: add best-practice conformance slide; bring README up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Listing a PR number here satisfies scripts/check-changelog-coverage.mjs (any
 daily tracking issue converge and auto-close. This comment sits in the H1
 preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
-Skipped as internal: #707 #725 #731
+Skipped as internal: #707 #725 #731 #751
 -->
 
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ reviews, and builds its own features.
 **Member feedback loops**
 - **Rate answers** (helpful/unhelpful), file **content reports** and
   **suggestions** — each lands in a triageable queue instead of dying in
-  chat — and (admin-gated) **image generation** via the Grok CLI.
+  chat — and (admin-gated) **image generation** via the Grok Build CLI.
 
 **Platform-agnostic core** — Discord and WhatsApp are pluggable adapters; every
 privileged action is RBAC-gated, CONFIRM-guarded where destructive, and audited.
@@ -90,7 +90,7 @@ src/
   auth/rbac.ts            admin/user roles + per-role tool gating
   platforms/              PlatformAdapter interface + Discord/WhatsApp adapters
   storage/                Postgres pool, schema, migrations, embeddings, repo
-  media/                  image generation (Grok CLI) + voice-note transcription
+  media/                  image generation (Grok Build CLI) + voice-note transcription
   status/                 Anthropic status-page checker
   github/                 GitHub issue filing (suggest_issue)
   devTeam/                remote dev-team build-service client

--- a/README.md
+++ b/README.md
@@ -122,3 +122,5 @@ approved ones on a branch and opens a PR — **a human always merges**. See
 - [Pipeline](docs/PIPELINE.md) — the self-improving research/review/build loops
 - [Personas](docs/PERSONAS.md) — the bot's voice ("Dave")
 - [Standards](docs/STANDARDS.md) · [Red-team](docs/RED-TEAM.md)
+- [Slide deck](docs/SLIDE-DECK.md) — presentable 11-slide overview of the repo,
+  the pipeline, and how the design maps to agentic best practice

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ reviews, and builds its own features.
   (`save_knowledge`, candidate review queue).
 - **`check_status`**: reports Anthropic's live service status (its official
   status page) so "is it me or an incident?" gets an authoritative answer.
+- **`whats_new` / `catch_up`**: what changed in the bot lately (from the
+  changelog) and what the community discussed while you were away.
+- **Voice notes**: opt-in local transcription of WhatsApp and Discord voice
+  messages so spoken questions get answered too.
+- **Auto-answer mode** (Discord, opt-in): recognises repeat questions in
+  allowed channels and offers the KB answer without being addressed.
+
+**Community & members**
+- **Discord slash commands** (opt-in): `/kb`, `/whois`, `/projects`,
+  `/guidelines` — zero-model-call, ephemeral lookups.
+- **Peer help & discovery**: members share projects and interests
+  (`share_project`, `who_is_into`), and opt into a helper pool the bot can
+  match askers to (`find_helper`).
+- **Onboarding & welcomes**: opt-in welcome flows on both platforms;
+  gated-mode access requests land in a triageable queue.
+- **Privacy self-service**: `my_data` shows what's stored about you;
+  `forget_me` deletes it. Cross-platform identity linking is member-initiated.
 
 **Community tools (admins)**
 - **Moderation**: timeout / kick / warn / delete, plus opt-in **auto-moderation**
@@ -33,12 +50,21 @@ reviews, and builds its own features.
   a **Muted** role until an admin clears them.
 - **Engagement**: post announcements, native Discord **polls**, scheduled
   **events**, **threads**, emoji **reactions**, and assignable **cosmetic roles**.
-- **Community guidelines** members can read on demand; **admin digests** and
-  question digests surface what the community is asking about.
+- **Community guidelines** members can read on demand; **admin digests**,
+  question digests, and an opt-in **member-facing weekly digest** surface what
+  the community is asking about.
+- **Moderation appeals**: members can appeal a strike/action; admins resolve
+  from a queue. Member notes, roster views, and engagement stats give admins
+  context without raw data access.
+- **Super-admin ops**: pause/resume the bot, redeploy, usage stats, audit
+  view, policy toggles, plus confirmation-gated `suggest_issue` (files a
+  GitHub issue from chat) and `dev_team_dispatch` (sends an assess/deliver
+  job to a remote build service).
 
 **Member feedback loops**
 - **Rate answers** (helpful/unhelpful), file **content reports** and
-  **suggestions**, and (admin-gated) **image generation** via the Grok Build CLI.
+  **suggestions** — each lands in a triageable queue instead of dying in
+  chat — and (admin-gated) **image generation** via the Grok CLI.
 
 **Platform-agnostic core** — Discord and WhatsApp are pluggable adapters; every
 privileged action is RBAC-gated, CONFIRM-guarded where destructive, and audited.
@@ -58,12 +84,18 @@ privileged action is RBAC-gated, CONFIRM-guarded where destructive, and audited.
 src/
   config.ts               env loading + validation
   router.ts               inbound → agent → outbound orchestration
-  agent/                  auth, core turn loop, system prompt, personas, MCP tools
+  agent/                  auth, core turn loop, system prompt, personas, MCP tools, skills
   context/                offline context builder, docs ingest, export, knowledge refresh
   moderation/             bad-word/abuse scan, strikes, muted-role enforcement
   auth/rbac.ts            admin/user roles + per-role tool gating
   platforms/              PlatformAdapter interface + Discord/WhatsApp adapters
   storage/                Postgres pool, schema, migrations, embeddings, repo
+  media/                  image generation (Grok CLI) + voice-note transcription
+  status/                 Anthropic status-page checker
+  github/                 GitHub issue filing (suggest_issue)
+  devTeam/                remote dev-team build-service client
+scripts/                  CI gate helpers (security-test floor, changelog coverage, labels)
+tests/                    Node test-runner suites (SECURITY: invariants, knowledge eval, …)
 deploy/                   Ubuntu provisioning script + systemd unit
 docs/                     ARCHITECTURE, SECURITY, DEPLOYMENT, VISION, PIPELINE, PERSONAS, …
 ```
@@ -98,8 +130,14 @@ basic questions. See **[docs/SECURITY.md](docs/SECURITY.md)** and
 A multi-loop development pipeline proposes, hardens, and builds the bot's own
 features, coordinated entirely through GitHub issues + labels: a **research**
 loop files proposals, an **adversarial** loop reviews them against
-[VISION.md](docs/VISION.md), and a **build** loop (GitHub Actions) implements
-approved ones on a branch and opens a PR — **a human always merges**. See
+[VISION.md](docs/VISION.md), a **build** loop (GitHub Actions) implements
+approved ones on a branch and opens a PR, and an automated **review** loop
+vets it. Bounded support loops keep PRs moving without a human in the loop
+(one free CI rerun, CI-failure autofix, merge-conflict resolution,
+review-response revisions, zombie-state cleanup), and a deterministic,
+tightly gated **auto-merge** loop lands fully-vetted bot PRs — anything
+touching governance, CI, or the loops' own guardrails still **requires a
+human merge**, and branch protection on `main` is the backstop. See
 **[docs/PIPELINE.md](docs/PIPELINE.md)**.
 
 ## Important caveats
@@ -121,6 +159,8 @@ approved ones on a branch and opens a PR — **a human always merges**. See
   directions (not commitments)
 - [Pipeline](docs/PIPELINE.md) — the self-improving research/review/build loops
 - [Personas](docs/PERSONAS.md) — the bot's voice ("Dave")
+- [Community context](docs/COMMUNITY-CONTEXT.md) — auto-generated, anonymised
+  export of what the community discusses (aggregate-only, opt-in)
 - [Standards](docs/STANDARDS.md) · [Red-team](docs/RED-TEAM.md)
 - [Slide deck](docs/SLIDE-DECK.md) — presentable 11-slide overview of the repo,
   the pipeline, and how the design maps to agentic best practice

--- a/docs/SLIDE-DECK.md
+++ b/docs/SLIDE-DECK.md
@@ -1,7 +1,8 @@
 # Slide deck — `community-agent` repo overview
 
-A 10-slide walkthrough of the repo: what the bot does, how it's built, and the
-self-improving pipeline that develops it. Each slide has headline bullets plus
+An 11-slide walkthrough of the repo: what the bot does, how it's built, the
+self-improving pipeline that develops it, and how the design lines up with
+published agentic-engineering practice. Each slide has headline bullets plus
 a short talk track for the presenter. Sources: `README.md`,
 `docs/ARCHITECTURE.md`, `docs/SECURITY.md`, `docs/PIPELINE.md`,
 `docs/VISION.md`, `CLAUDE.md`.
@@ -18,7 +19,8 @@ a short talk track for the presenter. Sources: `README.md`,
   pipeline** that proposes, reviews, and builds its own features.
 
 > **Talk track:** frame the deck around the two halves — slides 2–5 cover the
-> product, slides 6–9 cover the pipeline that builds it, slide 10 wraps up.
+> product, slides 6–9 cover the pipeline that builds it, slide 10 wraps up,
+> and slide 11 maps the design onto published agentic best practice.
 
 ---
 
@@ -205,4 +207,41 @@ auto-merge ──merges fully-vetted bot PRs──► main   (humans merge the r
   backstops.
 
 > **Talk track:** end on the takeaway — the bot is useful, but the
-> reproducible asset is the pipeline pattern.
+> reproducible asset is the pipeline pattern. Slide 11 backs this up by
+> mapping the design onto published agentic-engineering practice.
+
+---
+
+## Slide 11 — How the design maps to agentic best practice
+
+Benchmarked against the published pattern vocabulary — Andrew Ng's four
+agentic design patterns and Anthropic's five workflow patterns (e.g. the
+"Graph Engineering for Multi-Agentic Systems" synthesis of both):
+
+- **Multi-agent with artifact contracts** — pipeline roles (research /
+  adversarial / build / review / revise) each catch a different error class,
+  and coordinate only through typed GitHub issues, labels, and PRs ("the repo
+  is the bus") — artifacts and shared state, never conversation transcripts.
+- **Evaluator-Optimizer with stopping rules** — build → review → revise is
+  the classic generate/evaluate loop; every loop has an attempt cap (2/2/1/3)
+  and escalates `needs-human` — the prescribed "escalate rather than retry a
+  third time." Deterministic checks (CI, 991 security tests) always run
+  before subjective LLM review.
+- **Explicit, immutable rubric** — `VISION.md` is the shared scoring rubric;
+  quality is tuned by editing it, not the loop prompts.
+- **Control matched to risk** — the highest-stakes actions (auto-merge,
+  groundskeeper, ci-retry) are deterministic no-LLM chains with hard gates;
+  bounded agents handle only the lower-risk fix/resolve/revise work; cheapest
+  mechanism always tries first (free machine rerun before any agent).
+- **Traceability test passed** — "every important output traces to a task, a
+  plan, an artifact, a source, an evaluator decision, and a bounded execution
+  record" maps 1:1 onto issue → proposal → PR → citations → review verdict →
+  CI run + attempt counters.
+- **Deliberate divergence** — no typed knowledge graph: memory is pgvector
+  RAG + relational state, the playbook's own "graph earns itself" waypoint;
+  graduate only when a measured failure demands it.
+
+> **Talk track:** the repo independently converged on (or consciously
+> implements) the published patterns — including the parts most teams skip:
+> stopping rules, artifact contracts, deterministic gates around LLM
+> judgement, and adding complexity only after a specific observed failure.


### PR DESCRIPTION
## Summary

Two documentation updates:

1. **Slide deck**: extends the deck merged in #751 with **Slide 11 — "How the design maps to agentic best practice"**, mapping the repo's architecture onto published agentic-engineering patterns (Andrew Ng's four design patterns, Anthropic's five workflow patterns): multi-agent roles with artifact contracts, evaluator-optimizer loops with attempt caps, control matched to risk, the traceability test, and the deliberate no-knowledge-graph divergence. Deck intro and slide 1 talk track updated from "10-slide" to 11.
2. **README refresh against the current codebase**: the what-it-does section now covers features shipped since the last README pass (whats_new/catch_up, voice-note transcription on both platforms, auto-answer mode, slash commands, peer help & project discovery, onboarding/welcomes, privacy self-service, identity linking, appeals, member digest, super-admin ops incl. suggest_issue and dev_team_dispatch); the repository layout adds `media/`, `status/`, `github/`, `devTeam/`, `scripts/`, `tests/`; the pipeline section no longer claims "a human always merges" and instead documents the review loop, bounded support loops, and the gated auto-merge with the human-merge governance backstop; the design-docs list gains COMMUNITY-CONTEXT.md and the slide deck.

Also records #751 in the changelog-coverage skip ledger as internal docs.

## Security / privacy impact

None. Documentation only — no code, configuration, schema, or data-access changes. README descriptions of security-relevant behaviour (RBAC, gating, auto-merge governance carve-out) were checked against `CLAUDE.md`, `docs/PIPELINE.md`, and `docs/ARCHITECTURE.md`.

## How verified

Docs-only change (`docs/SLIDE-DECK.md`, `README.md`, CHANGELOG preamble comment); no source, schema, or test files touched. Feature claims cross-checked against `src/agent/tools.ts` (99 registered tools), `.env.example` flags, and ARCHITECTURE.md sections; `npx prettier --check README.md` is clean.

https://claude.ai/code/session_01AT9TS4Dnab7ESWQ9JT9Wtf