### PR TITLE
Fix the handoff note's consumer: login shape and the review race

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -321,7 +321,13 @@ jobs:
                before proceeding.
             4. Open a pull request whose body starts with "Closes #${{ github.event.issue.number }}",
                summarising the change, its security/privacy impact, and how you verified
-               it. Then relabel the issue `status:built`.
+               it. Open it as a DRAFT — use `gh pr create --draft` — and leave it
+               a draft; a later workflow step marks it ready for review once it
+               has attached your handoff note. This is a HANDSHAKE, not a
+               formality: the review worker skips drafts, so opening a
+               non-draft PR starts the review before your note exists and the
+               reviewer loses it (that is exactly what happened on PR #769).
+               Then relabel the issue `status:built`.
             5. Do NOT merge — a human merges. If the proposal turns out infeasible or
                unsafe as specified, add the `needs-human` label and explain instead of
                forcing it.
@@ -741,6 +747,46 @@ jobs:
           fi
           gh pr comment "${PR}" --body-file "${out}" \
             || echo "::warning::Could not post the handoff note to PR #${PR}; continuing (best-effort)."
+
+      # Second half of the draft handshake — see the step above and
+      # docs/PIPELINE.md. The agent opens its PR as a DRAFT so the review worker
+      # (which skips drafts) cannot start before the handoff note is attached;
+      # marking it ready here is what actually releases it for review.
+      #
+      # This exists because the first live run proved the ordering: PR #769 was
+      # created at 14:10:51, the review job started at 14:10:55, and the handoff
+      # comment landed at 14:11:16 — the reviewer ran 21 seconds before the note
+      # existed and logged "reviewing from the diff alone". Posting earlier is
+      # not possible (the PR number only exists once the agent has created it),
+      # so the PR has to wait for the note instead.
+      #
+      # Runs even when the handoff step failed or wrote nothing: a missing note
+      # must never strand a finished PR in draft, where the review worker skips
+      # it AND the auto-merge loop cannot merge it. `!cancelled()` rather than
+      # `success()` for exactly that reason.
+      #
+      # A PR the agent opened non-draft anyway (prompt compliance is not a
+      # guarantee — this repo has the scars) is already being reviewed without
+      # the note; `gh pr ready` on it is a harmless no-op and we say so rather
+      # than failing. That is a graceful degradation to the previous behaviour,
+      # not a new failure mode.
+      - name: Mark the PR ready for review (release the draft handshake)
+        if: ${{ !cancelled() && env.HAS_TOKEN == 'true' && steps.verify.outputs.pr != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.verify.outputs.pr }}
+        run: |
+          set -uo pipefail
+          is_draft="$(gh pr view "${PR}" --json isDraft --jq '.isDraft' 2>/dev/null || echo unknown)"
+          if [ "${is_draft}" = "false" ]; then
+            echo "PR #${PR} was opened non-draft, so its review already started without the handoff note. Nothing to release."
+            exit 0
+          fi
+          if gh pr ready "${PR}"; then
+            echo "PR #${PR} marked ready for review — the review worker now fires with the handoff note in place."
+          else
+            echo "::error::Could not mark PR #${PR} ready for review. It is still a DRAFT, which means the review worker will skip it and the auto-merge loop cannot merge it. A maintainer must press 'Ready for review'."
+          fi
 
       # The action streams only init/result frames to the job log ("full
       # output hidden for security"); the turn-by-turn transcript lives in

--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -35,6 +35,23 @@ permissions:
 
 jobs:
   review:
+    # Skip DRAFT pull requests. This is the receiving half of the build
+    # worker's draft handshake (docs/PIPELINE.md, "Context sharing between cold
+    # sessions"): the build agent opens its PR as a draft, the build workflow
+    # attaches the handoff note, and only then marks it ready — which fires the
+    # `ready_for_review` event below with the note already in place.
+    #
+    # Without this the review simply outruns the note. PR #769: created
+    # 14:10:51, review started 14:10:55, handoff posted 14:11:16 — the reviewer
+    # ran 21 seconds early and reviewed from the diff alone.
+    #
+    # Two consequences, both intended. A HUMAN's draft PR is now reviewed when
+    # they mark it ready rather than while they are still writing it. And a
+    # RECOVERY PR (opened as a draft by the verify step in pipeline-build.yml
+    # when an agent stranded its work) is reviewed when a human opens it for
+    # review — which is what its own body already tells the reader will happen,
+    # and it can never auto-merge regardless.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Listing a PR number here satisfies scripts/check-changelog-coverage.mjs (any
 daily tracking issue converge and auto-close. This comment sits in the H1
 preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
-Skipped as internal: #707 #725 #731 #751 #767
+Skipped as internal: #707 #725 #731 #751 #767 #770
 -->
 
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -224,6 +224,29 @@ defend, what it rejected, what it is unsure about — to a git-ignored
 marker-guarded PR comment; the review workflow resolves it deterministically
 and interpolates it into the review prompt.
 
+**The draft handshake.** The build agent opens its PR as a **draft**; the build
+workflow posts the handoff note and *then* marks the PR ready for review, which
+fires `ready_for_review` with the note already attached. The review job skips
+drafts, so it cannot start early.
+
+This is not ceremony — it is the fix for a race the first live run exposed. On
+PR #769 the PR was created at 14:10:51, the review job started at 14:10:55, and
+the handoff comment landed at 14:11:16: the reviewer ran **21 seconds before the
+note existed** and logged "reviewing from the diff alone". Posting the note
+earlier is impossible (the PR number only exists once the agent has created the
+PR), so the PR waits for the note instead.
+
+Two deliberate consequences: a human's draft PR is reviewed when they mark it
+ready rather than while they are still writing it, and a **recovery PR** (opened
+as a draft by the verify step when an agent stranded its work) is reviewed when a
+human opens it for review — which is what its own body already promises, and it
+can never auto-merge in any case. The ready-marking step runs even when the
+handoff step failed or wrote nothing, because a missing note must never strand a
+finished PR in draft where neither the reviewer nor auto-merge will touch it. If
+the agent opens a non-draft PR anyway, the review simply starts without the note,
+exactly as it did before this existed — a graceful degradation, not a new failure
+mode.
+
 **The note is untrusted data, and the containment is structural.** The build
 agent processes untrusted issue content, so an injected build agent could aim a
 note at the reviewer. Nothing here tries to *detect* that — detection is
@@ -234,7 +257,12 @@ case and hide an attack from the one reader positioned to report it. Instead
 - **Authorship.** Only `github-actions[bot]`-authored comments are read back.
   The build agent's own `gh` posts as `claude[bot]`, so it cannot write directly
   into the channel it feeds — the same identity distinction the recovery-PR path
-  relies on.
+  relies on. Matched with the `[bot]` suffix normalised away, because GitHub
+  reports that one identity two ways: `.user.login` is `github-actions[bot]` on
+  the REST issues-comments API, `.author.login` is `github-actions` from
+  `gh pr view --json comments`. Comparing strictly against the REST spelling
+  rejected every genuine note on PR #769 — the producer worked and the consumer
+  silently saw nothing. Case remains strict.
 - **Position.** The marker must be line 1, so a comment that merely *quotes* the
   marker (a review of this machinery does) is not mistaken for the channel.
 - **Quoting.** Every line is emitted prefixed `| `. That makes the block

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2322,7 +2322,11 @@ in `scripts/handoff-note.mjs` (pinned by `tests/handoffNote.test.ts`):
 - **Authorship.** Only `github-actions[bot]` comments are read back. The build
   agent's `gh` posts as `claude[bot]`, so it cannot post into the channel it
   feeds — the same identity distinction the build workflow's recovery-PR path
-  relies on. Member and fork comments are likewise invisible.
+  relies on. Member and fork comments are likewise invisible. The comparison
+  normalises away a trailing `[bot]` (GitHub reports this identity as
+  `github-actions[bot]` on the REST API and `github-actions` via
+  `gh pr view --json comments`) but stays **case-sensitive** — the widening is
+  exactly the one spelling GitHub actually emits and nothing more.
 - **Position.** The marker must be line 1, so prose that merely quotes the
   marker is never mistaken for the channel.
 - **Quoting.** Every line is emitted `| `-prefixed, so it embeds as an

--- a/scripts/handoff-note.mjs
+++ b/scripts/handoff-note.mjs
@@ -144,6 +144,31 @@ export function render(raw) {
 }
 
 /**
+ * Compare two GitHub logins for the SAME identity, tolerating the `[bot]`
+ * suffix being present on one side and absent on the other.
+ *
+ * This is not cosmetic — it was a live bug. GitHub reports one bot identity two
+ * different ways depending on which API you ask:
+ *
+ *   gh api repos/…/issues/<n>/comments  →  .user.login   = "github-actions[bot]"
+ *   gh pr view <n> --json comments      →  .author.login = "github-actions"
+ *
+ * The review workflow uses the second form (it needs only the pull-requests
+ * scope), so a strict equality check against "github-actions[bot]" silently
+ * rejected every genuine note — the producer worked, the consumer saw nothing,
+ * and the failure looked exactly like "the build agent didn't write one".
+ *
+ * Suffix-stripping only; the comparison stays CASE-SENSITIVE. Case is left
+ * strict deliberately: nothing here needs it relaxed, and keeping it narrow
+ * means this fix widens the accepted set by exactly the one shape GitHub
+ * actually emits and nothing else.
+ */
+function sameIdentity(a, b) {
+  const strip = (s) => s.trim().replace(/\[bot\]$/, '');
+  return strip(a) === strip(b);
+}
+
+/**
  * Pull the newest handoff note out of a PR's comments.
  *
  * `comments` is the JSON array from either `gh api .../issues/<n>/comments`
@@ -159,7 +184,7 @@ export function extract(comments, { author = 'github-actions[bot]' } = {}) {
   if (!Array.isArray(comments)) return '';
   const authored = comments.filter((c) => {
     const login = c?.user?.login ?? c?.author?.login;
-    return typeof login === 'string' && login === author;
+    return typeof login === 'string' && sameIdentity(login, author);
   });
   // Newest wins: a revise-loop push can supersede an earlier note.
   for (let i = authored.length - 1; i >= 0; i -= 1) {

--- a/tests/handoffNote.test.ts
+++ b/tests/handoffNote.test.ts
@@ -62,6 +62,21 @@ test('extract returns the newest note, one quoted line at a time', () => {
   assert.equal(out, '| newer note');
 });
 
+test('extract accepts the login VALUE gh pr view actually emits, not just its shape', () => {
+  // Regression, found by the first live run (PR #769): the shape test below got
+  // the shape right and the VALUE wrong. `gh pr view --json comments` reports
+  // the bot WITHOUT the `[bot]` suffix, so strict equality rejected every real
+  // note — the producer worked, the consumer saw nothing, and the symptom was
+  // indistinguishable from the build agent simply not writing one.
+  //
+  //   gh api repos/…/issues/<n>/comments  →  .user.login   = "github-actions[bot]"
+  //   gh pr view <n> --json comments      →  .author.login = "github-actions"
+  const asPrViewEmitsIt = JSON.stringify([
+    { author: { login: 'github-actions' }, body: posted('real note') },
+  ]);
+  assert.equal(run('extract', asPrViewEmitsIt), '| real note');
+});
+
 test('extract accepts both the issues-API and gh-pr-view comment shapes', () => {
   const viaApi = run(
     'extract',


### PR DESCRIPTION
## Summary

The first live exercise of the #767 machinery (issue #768 → PR #769) worked on the producer side and failed on the consumer side. The build worker read the context pack, did the task, and wrote a genuinely useful handoff note; the workflow posted it correctly. Then the reviewer logged:

```
No build handoff note on PR #769 — reviewing from the diff alone.
```

Two independent bugs, both mine, both fixed here.

### 1 · The author login shape

GitHub reports one identity two different ways:

| Source | Field | Value |
|---|---|---|
| `gh api repos/…/issues/<n>/comments` | `.user.login` | `github-actions[bot]` |
| `gh pr view <n> --json comments` | `.author.login` | `github-actions` |

The review workflow deliberately uses the second form (it needs only the `pull-requests` scope the job already holds), and the extractor compared strictly against the first. Every genuine note was rejected.

The existing unit test is the interesting part of this failure: it asserted that the `author.login` *shape* is accepted, but used the REST *value* inside it. So it exercised the right field with a value that form never emits — it passed, and production failed. The regression test added here uses the value `gh pr view` actually emits.

The fix normalises a trailing `[bot]` and **keeps the comparison case-sensitive**. The existing `SECURITY:` assertion that `GitHub-Actions[Bot]` is rejected still holds and still passes — the accepted set widens by exactly the one spelling GitHub emits and nothing else.

### 2 · The review race

Even with the login fixed, the reviewer would have found nothing:

```
14:10:51  PR #769 created by the build agent
14:10:55  review job starts          <-- 4s later
14:11:16  handoff note posted        <-- 21s after the review started
```

The note cannot be posted earlier: the PR number only exists once the agent has created the PR, and the workflow step that renders and posts the note necessarily runs after the agent exits. So the PR waits for the note instead — a **draft handshake**:

```
build agent:  gh pr create --draft
workflow:     post handoff comment
workflow:     gh pr ready <PR>
                    |
           ready_for_review fires
                    v
review:       note already attached
```

with `pipeline-pr-review.yml` skipping drafts at the job level. No polling, no re-dispatch, no extra model calls.

**Failure modes, deliberately chosen:**

- The ready-marking step runs on `!cancelled()`, **not** `success()`. A missing or failed handoff must never strand a finished PR in draft, where the reviewer skips it *and* auto-merge cannot merge it. If marking ready itself fails, it raises a loud `::error::` naming the consequence.
- If the agent opens a non-draft PR anyway — prompt compliance is not a guarantee, and this repo has the scars — the review starts without the note exactly as it did before any of this existed. Graceful degradation, not a new failure mode. The step detects it and says so instead of failing.

**Two intended consequences of skipping drafts:** a human's draft PR is now reviewed when they mark it ready rather than while they are still writing it; and a recovery PR (opened as a draft by the verify step when an agent stranded its work) is reviewed when a human opens it for review — which is exactly what its own body already promises, and it can never auto-merge regardless.

## Security / privacy impact

**No runtime impact** — `src/` is untouched. Two pipeline-level notes:

- The authorship containment is **unchanged in strength**. `claude[bot]` (the build agent's own `gh` identity), members, and forks all remain invisible to the extractor; the normalisation only spans the `[bot]` suffix on the *same* identity. Case stays strict, and the `SECURITY:` test pinning that still passes.
- Skipping drafts removes an automated review that a recovery PR used to get on open. That is consistent with the recovery PR's stated contract ("a human opens it for review and a human merges it"), it cannot auto-merge (wrong author for that loop), and the review still runs on `ready_for_review`. Documented in `docs/PIPELINE.md` and `docs/SECURITY.md` §21 rather than left implicit.

## How verified

- **The bugs are evidenced from the live run, not inferred**: the login values in the table above were read back from both APIs against PR #769, and the timings are from the actual run records.
- `npm test` — **2735 tests, 2027 pass, 3 fail, 705 skipped**. Those 3 are pre-existing and reproduce identically on `main` at `e243a8d` (verified by stashing and re-running): they regex source text with `\n` on a CRLF Windows checkout. Ubuntu CI is unaffected.
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run context:check` — all clean. Prettier clean (checked per-file with `--end-of-line auto`, since the CRLF checkout makes a whole-tree `format:check` meaningless here).
- `tests/handoffNote.test.ts` is 17 tests, 8 of them `SECURITY:` — unchanged count, so `tests/security-floor.json` needs no edit and nothing was lowered.
- Both workflows re-parsed as YAML; the build job's step order is `verify → run cost → post handoff → mark ready → scrub`, and the review job's gate is `if: ${{ !github.event.pull_request.draft }}` with `ready_for_review` already among its triggers.

**One thing I want to flag rather than bury:** a full-suite run on this branch showed a 4th failure, `repeatQuestionShortcutRouter.test.ts`'s "a repeat-question shortcut reply is enqueued behind an in-flight turn" ordering assertion. It passes 3/3 in isolation, did not recur on a second full run, and nothing in this diff touches the router. It is a **load-sensitive flake**, and it almost certainly explains the unexplained third failure I reported on #767. Worth its own issue — the autofix loop already has machinery for exactly this class, but a genuinely flaky ordering test will keep costing runs.

**Not verified:** the handshake itself only executes on a real build-worker run. The next approved issue is the test — and unlike last time, the instrumentation will say so directly: the review job summary's **"handoff note present"** column should read `true`.
