### PR TITLE
Replace the draft handshake with a bounded wait; it never fired a review

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -321,13 +321,7 @@ jobs:
                before proceeding.
             4. Open a pull request whose body starts with "Closes #${{ github.event.issue.number }}",
                summarising the change, its security/privacy impact, and how you verified
-               it. Open it as a DRAFT — use `gh pr create --draft` — and leave it
-               a draft; a later workflow step marks it ready for review once it
-               has attached your handoff note. This is a HANDSHAKE, not a
-               formality: the review worker skips drafts, so opening a
-               non-draft PR starts the review before your note exists and the
-               reviewer loses it (that is exactly what happened on PR #769).
-               Then relabel the issue `status:built`.
+               it. Then relabel the issue `status:built`.
             5. Do NOT merge — a human merges. If the proposal turns out infeasible or
                unsafe as specified, add the `needs-human` label and explain instead of
                forcing it.
@@ -747,46 +741,6 @@ jobs:
           fi
           gh pr comment "${PR}" --body-file "${out}" \
             || echo "::warning::Could not post the handoff note to PR #${PR}; continuing (best-effort)."
-
-      # Second half of the draft handshake — see the step above and
-      # docs/PIPELINE.md. The agent opens its PR as a DRAFT so the review worker
-      # (which skips drafts) cannot start before the handoff note is attached;
-      # marking it ready here is what actually releases it for review.
-      #
-      # This exists because the first live run proved the ordering: PR #769 was
-      # created at 14:10:51, the review job started at 14:10:55, and the handoff
-      # comment landed at 14:11:16 — the reviewer ran 21 seconds before the note
-      # existed and logged "reviewing from the diff alone". Posting earlier is
-      # not possible (the PR number only exists once the agent has created it),
-      # so the PR has to wait for the note instead.
-      #
-      # Runs even when the handoff step failed or wrote nothing: a missing note
-      # must never strand a finished PR in draft, where the review worker skips
-      # it AND the auto-merge loop cannot merge it. `!cancelled()` rather than
-      # `success()` for exactly that reason.
-      #
-      # A PR the agent opened non-draft anyway (prompt compliance is not a
-      # guarantee — this repo has the scars) is already being reviewed without
-      # the note; `gh pr ready` on it is a harmless no-op and we say so rather
-      # than failing. That is a graceful degradation to the previous behaviour,
-      # not a new failure mode.
-      - name: Mark the PR ready for review (release the draft handshake)
-        if: ${{ !cancelled() && env.HAS_TOKEN == 'true' && steps.verify.outputs.pr != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.verify.outputs.pr }}
-        run: |
-          set -uo pipefail
-          is_draft="$(gh pr view "${PR}" --json isDraft --jq '.isDraft' 2>/dev/null || echo unknown)"
-          if [ "${is_draft}" = "false" ]; then
-            echo "PR #${PR} was opened non-draft, so its review already started without the handoff note. Nothing to release."
-            exit 0
-          fi
-          if gh pr ready "${PR}"; then
-            echo "PR #${PR} marked ready for review — the review worker now fires with the handoff note in place."
-          else
-            echo "::error::Could not mark PR #${PR} ready for review. It is still a DRAFT, which means the review worker will skip it and the auto-merge loop cannot merge it. A maintainer must press 'Ready for review'."
-          fi
 
       # The action streams only init/result frames to the job log ("full
       # output hidden for security"); the turn-by-turn transcript lives in

--- a/.github/workflows/pipeline-pr-review.yml
+++ b/.github/workflows/pipeline-pr-review.yml
@@ -35,23 +35,6 @@ permissions:
 
 jobs:
   review:
-    # Skip DRAFT pull requests. This is the receiving half of the build
-    # worker's draft handshake (docs/PIPELINE.md, "Context sharing between cold
-    # sessions"): the build agent opens its PR as a draft, the build workflow
-    # attaches the handoff note, and only then marks it ready — which fires the
-    # `ready_for_review` event below with the note already in place.
-    #
-    # Without this the review simply outruns the note. PR #769: created
-    # 14:10:51, review started 14:10:55, handoff posted 14:11:16 — the reviewer
-    # ran 21 seconds early and reviewed from the diff alone.
-    #
-    # Two consequences, both intended. A HUMAN's draft PR is now reviewed when
-    # they mark it ready rather than while they are still writing it. And a
-    # RECOVERY PR (opened as a draft by the verify step in pipeline-build.yml
-    # when an agent stranded its work) is reviewed when a human opens it for
-    # review — which is what its own body already tells the reader will happen,
-    # and it can never auto-merge regardless.
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -91,18 +74,61 @@ jobs:
       # continue-on-error + a bare `|| true`: a missing, malformed or
       # unreadable note must leave the review completely unaffected. This is an
       # orientation nicety, never a precondition.
+      #
+      # WHY THIS POLLS, and why it is not a draft handshake. The note cannot
+      # exist when this job starts: the build workflow can only post it once the
+      # agent has created the PR, and creating the PR is what triggers this
+      # workflow. Measured on PR #769 — PR created 14:10:51, review started
+      # 14:10:55, note posted 14:11:16 — so the reviewer runs ~20s early.
+      #
+      # The first attempt at fixing this had the build agent open a DRAFT, post
+      # the note, then `gh pr ready` to release it, with this job skipping
+      # drafts. That is inert: `gh pr ready` runs with the job's GITHUB_TOKEN,
+      # and GitHub never starts workflows from GITHUB_TOKEN-created events — the
+      # same rule that forces the revise and conflict loops to use
+      # `workflow_dispatch`. The `opened` run skipped on the draft, no
+      # `ready_for_review` ever fired, and build PRs got NO review at all
+      # (#778). Polling here needs no new trigger, no new dispatch surface on
+      # this workflow, and no change to the build worker's PR contract.
+      #
+      # The wait is bounded and only paid where a note is actually expected: a
+      # BOT-authored PR that has no note yet. A human PR resolves immediately
+      # and waits zero seconds.
       - name: Resolve build handoff note (deterministic)
         id: handoff
         if: env.HAS_TOKEN == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          # 6 x 10s. The observed gap is ~20s; this tolerates a 3x slower
+          # build-workflow tail without making a note-less PR wait long.
+          HANDOFF_WAIT_TRIES: '6'
+          HANDOFF_WAIT_SECONDS: '10'
         run: |
           set -uo pipefail
           # `gh pr view --json comments` (not the issues-comments API) so this
           # needs only the pull-requests scope the job already holds.
-          note="$(gh pr view "$PR" --json comments --jq '.comments' 2>/dev/null \
-            | node scripts/handoff-note.mjs extract 2>/dev/null || true)"
+          read_note() {
+            gh pr view "$PR" --json comments --jq '.comments' 2>/dev/null \
+              | node scripts/handoff-note.mjs extract 2>/dev/null || true
+          }
+          # Only a bot PR can have a handoff note — the build worker is the only
+          # producer. Waiting on a human's PR would add latency for something
+          # that is never coming.
+          is_bot="$(gh pr view "$PR" --json author --jq '.author.is_bot' 2>/dev/null || echo false)"
+
+          note="$(read_note)"
+          if [ -z "${note}" ] && [ "${is_bot}" = "true" ]; then
+            i=1
+            while [ "${i}" -le "${HANDOFF_WAIT_TRIES}" ]; do
+              echo "No handoff note yet on bot PR #${PR}; the build workflow posts it just after opening the PR — waiting ${HANDOFF_WAIT_SECONDS}s (${i}/${HANDOFF_WAIT_TRIES})."
+              sleep "${HANDOFF_WAIT_SECONDS}"
+              note="$(read_note)"
+              [ -n "${note}" ] && break
+              i=$((i + 1))
+            done
+          fi
+
           if [ -z "${note}" ]; then
             echo "No build handoff note on PR #${PR} — reviewing from the diff alone."
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Listing a PR number here satisfies scripts/check-changelog-coverage.mjs (any
 daily tracking issue converge and auto-close. This comment sits in the H1
 preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
-Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770
+Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #780
 -->
 
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -224,28 +224,31 @@ defend, what it rejected, what it is unsure about — to a git-ignored
 marker-guarded PR comment; the review workflow resolves it deterministically
 and interpolates it into the review prompt.
 
-**The draft handshake.** The build agent opens its PR as a **draft**; the build
-workflow posts the handoff note and *then* marks the PR ready for review, which
-fires `ready_for_review` with the note already attached. The review job skips
-drafts, so it cannot start early.
+**The reviewer waits for the note.** The note cannot exist when the review job
+starts: the build workflow can only post it once the agent has created the PR,
+and creating the PR is what triggers the review. Measured on PR #769 — created
+14:10:51, review started 14:10:55, note posted 14:11:16 — the reviewer runs
+about 20 seconds early. So the review's resolve step **polls for up to 60s
+(6 × 10s), and only on a bot-authored PR that has no note yet**. A human PR
+resolves on the first read and waits zero seconds.
 
-This is not ceremony — it is the fix for a race the first live run exposed. On
-PR #769 the PR was created at 14:10:51, the review job started at 14:10:55, and
-the handoff comment landed at 14:11:16: the reviewer ran **21 seconds before the
-note existed** and logged "reviewing from the diff alone". Posting the note
-earlier is impossible (the PR number only exists once the agent has created the
-PR), so the PR waits for the note instead.
+**A draft handshake was tried first and does not work — do not re-add it.** The
+build agent opened a draft, the workflow posted the note and then ran
+`gh pr ready` to release it, with the review job skipping drafts. `gh pr ready`
+runs with the job's `GITHUB_TOKEN`, and **GitHub never starts workflows from
+GITHUB_TOKEN-created events** — the same rule that forces the revise and
+conflict loops through `workflow_dispatch`. The `opened` run skipped on the
+draft, no `ready_for_review` ever fired, and build PRs got **no review at all**
+(#778, and #775 before it). Polling needs no new trigger, adds no
+`workflow_dispatch` surface to the review workflow, and leaves the build
+worker's PR contract alone.
 
-Two deliberate consequences: a human's draft PR is reviewed when they mark it
-ready rather than while they are still writing it, and a **recovery PR** (opened
-as a draft by the verify step when an agent stranded its work) is reviewed when a
-human opens it for review — which is what its own body already promises, and it
-can never auto-merge in any case. The ready-marking step runs even when the
-handoff step failed or wrote nothing, because a missing note must never strand a
-finished PR in draft where neither the reviewer nor auto-merge will touch it. If
-the agent opens a non-draft PR anyway, the review simply starts without the note,
-exactly as it did before this existed — a graceful degradation, not a new failure
-mode.
+The remaining alternative, if the poll ever proves too slow, is to give this
+workflow a `workflow_dispatch` + `pr_number` input and have the build workflow
+dispatch it after posting — the established two-hop pattern here. That costs a
+second review run per build PR and needs checkout-ref handling (a dispatch run
+checks out the default branch, not the PR head), which is why the poll came
+first.
 
 **The note is untrusted data, and the containment is structural.** The build
 agent processes untrusted issue content, so an injected build agent could aim a


### PR DESCRIPTION
## Summary

The draft handshake from #770 **never fired a review**. Build PRs got no automated review at all — strictly worse than the race it was meant to fix. Observed on #778, and on #775 before it.

**Cause:** `gh pr ready` runs with the job's `GITHUB_TOKEN`, and GitHub never starts workflows from GITHUB_TOKEN-created events. So the `opened` run skipped on the draft, no `ready_for_review` event was ever produced, and nothing else was listening.

This repo already documents that rule — it is exactly why the revise and conflict loops go through `workflow_dispatch`. I read that comment while building #767 and walked into it anyway. That is the second time this feature has been broken by an assumption I did not check against a live run.

**Replaced with a bounded poll** in the review's resolve step: up to 6 × 10s, and only on a **bot-authored PR that has no note yet**. The measured gap is ~20s (PR #769: created 14:10:51, review started 14:10:55, note posted 14:11:16), so 60s tolerates a 3× slower build tail. A human PR resolves on the first read and waits zero seconds.

**Reverted along with it**, so the previous behaviour is fully restored:
- the build prompt's `gh pr create --draft` instruction,
- the "Mark the PR ready for review" step,
- the review job's `if: !github.event.pull_request.draft` skip — so human draft PRs and recovery PRs get their review back on `opened`.

`docs/PIPELINE.md` now records why the handshake must not be re-added, and names the remaining alternative (`workflow_dispatch` + `pr_number`, dispatched from the build workflow) with its two costs: a second review run per build PR, and checkout-ref handling, since a dispatch run checks out the default branch rather than the PR head. That is why the poll came first.

## Security / privacy impact

**None.** `src/` untouched. No change to the handoff note's containment — authorship restriction, marker position, `| ` quoting, the 4000-char cap and control-token stripping are all untouched, and `scripts/handoff-note.mjs` is not modified by this PR.

Restoring the draft skip's removal **returns** automated review to two cases that had silently lost it: human draft PRs, and recovery PRs opened as drafts by the verify step. That is a net increase in review coverage versus `main` today.

The poll reads only `gh pr view --json comments` and `--json author`, which the job's existing `pull-requests` scope already covers. No new permission, trigger, or dispatch surface.

## How verified

- **The failure is evidenced, not inferred.** `gh run list` for `feature/getting-started-skill-776` shows exactly one review run — event `pull_request`, conclusion `skipped` — and no `ready_for_review` run.
- **The consumer itself is confirmed working.** Reopening #775 and #778 with a user token (an event that *does* trigger) produced `Found a build handoff note (43 lines).` and `(44 lines).` respectively, and both reviews came back LGTM. So only the trigger was broken; extraction and framing are sound.
- Poll loop exercised in isolation with a stubbed reader: a bot PR with no note waits the full bounded run then proceeds; a human PR waits zero iterations.
- Both workflows re-parsed as YAML. Build steps end `… → Verify → run cost → Post handoff → Scrub`; the review job has no `if:` and its steps are `Inert → checkout → Resolve handoff → analyze → Post verdict → run cost`.
- `npm run context:check` passes; `tests/handoffNote.test.ts` + `tests/contextPack.test.ts` are 31/31. No test changed, so `tests/security-floor.json` is untouched.

**Not verified end to end:** the poll only exercises on a real build-worker run. The next approved issue is the check — the review log should read `Found a build handoff note (N lines).` on the *first* review, with no reopen needed.

**Both open build PRs (#775, #778) have already been reviewed** via the manual reopen, so nothing is currently stuck waiting on this.
