### PR TITLE
Outcomes: separate by-design routing from genuine escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Listing a PR number here satisfies scripts/check-changelog-coverage.mjs (any
 daily tracking issue converge and auto-close. This comment sits in the H1
 preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
-Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780
+Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 -->
 
 

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -31,7 +31,17 @@
 //                    a prompt/harness defect, not a code defect. A rising
 //                    Recovered count is the signal to fix the loop itself.
 //   * Escalated    — the loop gave up and labelled `needs-human`.
-//   * Clean        — engaged, neither recovered nor escalated.
+//   * Routed       — the loop deliberately handed the PR to a human because
+//                    POLICY says so, having done everything asked of it. Today
+//                    that is auto-merge meeting a governance-path PR. This is a
+//                    SUCCESS and is counted separately from Escalated on
+//                    purpose: lumping the two together made auto-merge read as
+//                    "80% escalated" when it was in fact routing correctly
+//                    almost every time, which both buried the real signal and
+//                    kept the tracking issue permanently open (it auto-closes
+//                    only on a window with no genuine failures).
+//   * Clean        — engaged and finished by itself; not recovered, escalated
+//                    or routed.
 // ---------------------------------------------------------------------------
 
 import { readFileSync } from 'node:fs';
@@ -63,9 +73,19 @@ const LOOPS = [
   },
   {
     name: 'auto-merge',
-    attempt: '<!-- pipeline-automerge-blocked -->',
+    // No attempt marker: it merges silently on success and only ever comments
+    // when it CANNOT, so both markers below are themselves the engagement.
+    attempt: null,
     checkpoint: null,
-    escalation: '<!-- pipeline-automerge-human-ready -->',
+    // A merge the branch protection REFUSED (e.g. it requires a human approving
+    // review, which the automated verdict comment is not). Genuine friction:
+    // the loop wanted to merge and could not.
+    escalation: '<!-- pipeline-automerge-blocked -->',
+    // A governance-path PR (.github/**, scripts/**, CLAUDE.md, docs/PIPELINE.md,
+    // docs/SECURITY.md, …) that passed every other gate and was deliberately
+    // handed to a human with a `human-merge-ready` label. This is the loop
+    // working exactly as designed, NOT a failure — see `routed` below.
+    routed: '<!-- pipeline-automerge-human-ready -->',
   },
 ];
 
@@ -119,7 +139,9 @@ const inWindow = (iso) => iso && Date.parse(iso) >= cutoff;
 const MARKER_AUTHORS = new Set(['github-actions', 'github-actions[bot]']);
 const fromPipeline = (comment) => MARKER_AUTHORS.has(comment?.author?.login ?? '');
 
-const tally = new Map(LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0, clean: 0 }]));
+const tally = new Map(
+  LOOPS.map((loop) => [loop.name, { engaged: 0, recovered: 0, escalated: 0, routed: 0, clean: 0 }]),
+);
 /** PRs worth a human glance: escalations and silent-death recoveries. */
 const notable = [];
 
@@ -135,7 +157,8 @@ for (const pr of prs) {
     const engaged = has(loop.attempt) || 0;
     const recovered = has(loop.checkpoint) || 0;
     const escalated = has(loop.escalation) || 0;
-    if (!engaged && !recovered && !escalated) continue;
+    const routed = has(loop.routed) || 0;
+    if (!engaged && !recovered && !escalated && !routed) continue;
 
     const row = tally.get(loop.name);
     // A checkpoint or escalation without an attempt marker still means the loop
@@ -148,10 +171,11 @@ for (const pr of prs) {
     // engagements with this outcome", not slices of a pie, and can legitimately
     // sum past 100%. Splitting them into exclusive buckets would hide the
     // double-failure case, which is the one most worth seeing.
-    const engagements = Math.max(engaged, recovered, escalated);
+    const engagements = Math.max(engaged, recovered, escalated, routed);
     row.engaged += engagements;
     row.recovered += recovered;
     row.escalated += escalated;
+    row.routed += routed;
     // Clean is accumulated PER PR, never derived by subtracting loop totals
     // (issue #750 review). Because the two failure kinds overlap, aggregate
     // subtraction double-counts a double-failure PR and cancels out genuinely
@@ -160,8 +184,18 @@ for (const pr of prs) {
     // escalated=1 → "0 clean", hiding a real clean run. A single engagement
     // that both recovered and escalated is ONE failed engagement, hence
     // max() rather than a sum.
-    row.clean += Math.max(0, engagements - Math.max(recovered, escalated));
+    // Routed is subtracted alongside the two failure kinds because a routed
+    // engagement did not finish by itself either — a human still has to press
+    // merge. It is simply not a FAULT. `max(0, …)` guards the (unlikely, but
+    // possible) case where one engagement is both routed and blocked, so the
+    // two subtractions can never drive Clean negative.
+    row.clean += Math.max(0, engagements - Math.max(recovered, escalated) - routed);
 
+    // Deliberately NOT gated on `routed`. This list drives the tracking issue:
+    // pipeline-outcomes.yml opens/refreshes it only when the report contains
+    // the "did not finish on its own" heading, and closes it otherwise. Listing
+    // a by-design governance routing here therefore pinned the issue open
+    // forever and buried the genuine recoveries/escalations underneath it.
     if (recovered || escalated) {
       notable.push({
         number: pr.number,
@@ -187,12 +221,15 @@ if (rows.length === 0) {
 const pct = (n, d) => (d === 0 ? '—' : `${Math.round((n / d) * 100)}%`);
 
 console.log(`## Pipeline loop outcomes — last ${windowDays} days\n`);
-console.log('| Loop | Engaged | Recovered (agent stopped early) | Escalated to human | Clean |');
-console.log('| --- | --- | --- | --- | --- |');
+console.log(
+  '| Loop | Engaged | Recovered (agent stopped early) | Escalated to human | Routed to human (by design) | Clean |',
+);
+console.log('| --- | --- | --- | --- | --- | --- |');
 for (const row of rows) {
   console.log(
     `| ${row.name} | ${row.engaged} | ${row.recovered} (${pct(row.recovered, row.engaged)}) | ` +
-      `${row.escalated} (${pct(row.escalated, row.engaged)}) | ${row.clean} (${pct(row.clean, row.engaged)}) |`,
+      `${row.escalated} (${pct(row.escalated, row.engaged)}) | ` +
+      `${row.routed} (${pct(row.routed, row.engaged)}) | ${row.clean} (${pct(row.clean, row.engaged)}) |`,
   );
 }
 
@@ -214,5 +251,13 @@ console.log(
     'a prompt/harness defect in that loop, not a code defect in the PR. **Escalated** is the loop ' +
     'correctly giving up. Both are cheaper to fix than to keep paying for. The two are not ' +
     'mutually exclusive (one engagement can be recovered *and* then escalated), so those ' +
-    'percentages are shares of engagements rather than slices of a pie and may sum past 100%.',
+    'percentages are shares of engagements rather than slices of a pie and may sum past 100%.' +
+    '\n>\n' +
+    '> **Routed to human (by design)** is NOT a failure, and is deliberately left out of the ' +
+    '"did not finish on its own" list: it is ' +
+    'auto-merge meeting a governance-path PR (`.github/**`, `scripts/**`, `CLAUDE.md`, ' +
+    '`docs/PIPELINE.md`, `docs/SECURITY.md`) and handing it to a person exactly as policy requires. ' +
+    'Because the pipeline asks most feature PRs to document themselves in `docs/SECURITY.md`, this ' +
+    'is the common case rather than the exception — a high Routed number means the guardrail is ' +
+    'working, not that the loop is struggling.',
 );

--- a/tests/pipelineOutcomes.test.ts
+++ b/tests/pipelineOutcomes.test.ts
@@ -48,8 +48,9 @@ test('pipeline-outcomes counts an engagement, a checkpoint recovery and an escal
       '<!-- pipeline-pr-revise-checkpoint -->\nrecovered work',
     ]),
   ]);
-  assert.match(out, /\| autofix \| 2 \| 0 \(0%\) \| 1 \(50%\) \| 1 \(50%\) \|/);
-  assert.match(out, /\| revise \| 1 \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
+  // Columns: Engaged | Recovered | Escalated | Routed | Clean.
+  assert.match(out, /\| autofix \| 2 \| 0 \(0%\) \| 1 \(50%\) \| 0 \(0%\) \| 1 \(50%\) \|/);
+  assert.match(out, /\| revise \| 1 \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
 });
 
 test('pipeline-outcomes lists the PRs where a loop did not finish, newest first', () => {
@@ -85,12 +86,52 @@ test('pipeline-outcomes counts a loop that escalated without an attempt marker a
   // attempt marker, so an escalation-only PR must not report "0 engaged, 1
   // escalated" (which would render a nonsensical rate).
   const out = run([pr(60, ['<!-- pipeline-pr-conflict-escalation -->\nunresolvable'])]);
-  assert.match(out, /\| conflict-resolver \| 1 \| 0 \(0%\) \| 1 \(100%\) \| 0 \(0%\) \|/);
+  assert.match(out, /\| conflict-resolver \| 1 \| 0 \(0%\) \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
 });
 
-test('pipeline-outcomes treats an auto-merge blocked notice as friction worth reporting', () => {
+test('pipeline-outcomes treats an auto-merge blocked notice as a genuine escalation', () => {
+  // `pipeline-automerge-blocked` means branch protection REFUSED the merge —
+  // the loop wanted to merge and could not. That is real friction, unlike the
+  // governance routing below.
   const out = run([pr(70, ['<!-- pipeline-automerge-blocked -->\ncould not merge'])]);
-  assert.match(out, /\| auto-merge \| 1 \|/);
+  assert.match(out, /\| auto-merge \| 1 \| 0 \(0%\) \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
+  assert.match(out, /### PRs where a loop did not finish/, 'a blocked merge is worth a human glance');
+});
+
+test('a governance routing counts as Routed, never as Escalated', () => {
+  // `pipeline-automerge-human-ready` is auto-merge meeting a governance-path PR
+  // and handing it to a person exactly as policy requires. Counting it as an
+  // escalation made the loop read "80% escalated" when it was succeeding.
+  const out = run([pr(71, ['<!-- pipeline-automerge-human-ready -->\nplease merge'])]);
+  assert.match(out, /\| auto-merge \| 1 \| 0 \(0%\) \| 0 \(0%\) \| 1 \(100%\) \| 0 \(0%\) \|/);
+});
+
+test('a window whose ONLY auto-merge outcome is a governance routing has no "did not finish" section, so the tracking issue can close', () => {
+  // pipeline-outcomes.yml opens/refreshes the tracking issue only when the
+  // report contains that heading, and closes it otherwise. While routings were
+  // listed there, #777 could never close and the genuine recoveries were
+  // buried under by-design rows.
+  const out = run([
+    pr(72, ['<!-- pipeline-automerge-human-ready -->']),
+    pr(73, ['<!-- pipeline-automerge-human-ready -->']),
+  ]);
+  assert.match(out, /\| auto-merge \| 2 \| 0 \(0%\) \| 0 \(0%\) \| 2 \(100%\) \| 0 \(0%\) \|/);
+  assert.doesNotMatch(
+    out,
+    /### PRs where a loop did not finish/,
+    'a by-design routing must not pin the tracking issue open',
+  );
+});
+
+test('a routed engagement still appears in the ledger alongside a real failure on another PR', () => {
+  const out = run([
+    pr(74, ['<!-- pipeline-automerge-human-ready -->']),
+    pr(75, ['<!-- pipeline-automerge-blocked -->']),
+  ]);
+  assert.match(out, /\| auto-merge \| 2 \| 0 \(0%\) \| 1 \(50%\) \| 1 \(50%\) \| 0 \(0%\) \|/);
+  const section = out.slice(out.indexOf('### PRs where a loop did not finish'));
+  assert.match(section, /#75/, 'the genuinely blocked merge is listed');
+  assert.doesNotMatch(section, /#74/, 'the by-design routing is not');
 });
 
 test('Clean counts a genuinely clean PR even when a SIBLING PR of the same loop both recovered and escalated (issue #750 review)', () => {
@@ -110,7 +151,7 @@ test('Clean counts a genuinely clean PR even when a SIBLING PR of the same loop 
   ]);
   assert.match(
     out,
-    /\| conflict-resolver \| 2 \| 1 \(50%\) \| 1 \(50%\) \| 1 \(50%\) \|/,
+    /\| conflict-resolver \| 2 \| 1 \(50%\) \| 1 \(50%\) \| 0 \(0%\) \| 1 \(50%\) \|/,
     'the clean engagement on PR #1 must survive the double failure on PR #2',
   );
 });
@@ -123,7 +164,7 @@ test('a single engagement that both recovered and escalated counts as ONE failed
       '<!-- pipeline-autofix-escalation -->',
     ]),
   ]);
-  assert.match(out, /\| autofix \| 1 \| 1 \(100%\) \| 1 \(100%\) \| 0 \(0%\) \|/);
+  assert.match(out, /\| autofix \| 1 \| 1 \(100%\) \| 1 \(100%\) \| 0 \(0%\) \| 0 \(0%\) \|/);
 });
 
 test('pipeline-outcomes falls back to the default window when --window-days is non-numeric, instead of reporting "NaN days" and matching nothing (issue #750 review)', () => {


### PR DESCRIPTION
## Summary

The auto-merge row in the outcomes ledger was **inverted**, not merely noisy.

- `pipeline-automerge-human-ready` is the loop meeting a **governance-path PR** (`.github/**`, `scripts/**`, `CLAUDE.md`, `docs/PIPELINE.md`, `docs/SECURITY.md`) and handing it to a human exactly as policy requires — a success. It was configured as the loop's `escalation`.
- `pipeline-automerge-blocked` is branch protection **refusing** a merge the loop wanted to make — a genuine failure. It was configured as the `attempt` marker, so it counted as an engagement and then fell straight through to **Clean**.

Replaying the real last-14-days data through both versions:

```
old: | auto-merge | 8 | 0 (0%) | 6 escalated (75%) |                    | 2 clean (25%) |
new: | auto-merge | 8 | 0 (0%) | 2 escalated (25%) | 6 routed (75%)     | 0 clean (0%)  |
```

So the two genuinely blocked merges were being reported as **clean**, and the six correct routings as **escalations**.

## What changed

- New `routed` outcome and a **"Routed to human (by design)"** column.
- `human-ready` → `routed`; `blocked` → `escalation`; auto-merge now has no `attempt` marker (it merges silently on success and only ever comments when it can't, so both markers *are* the engagement).
- Routed PRs are left **out of the "PRs where a loop did not finish on its own" list**. That list is the thing `pipeline-outcomes.yml` keys on — it opens/refreshes the tracking issue when the heading is present and closes it otherwise. While by-design routings were listed there, **#777 could never close**, and the genuine recoveries sat buried under rows that were not faults.
- `Clean` subtracts routed as well, since a routed engagement didn't finish by itself either — a human still presses merge. It just isn't a *fault*. `max(0, …)` guards the case where one engagement is both routed and blocked.

The other three loops are untouched: none has a `routed` marker, so they report a `0 (0%)` column and identical numbers to before.

## Security / privacy impact

**None.** `src/` untouched; this is a read-only, no-LLM reporting script. The `MARKER_AUTHORS` identity gate — including the deliberate exclusion of `claude[bot]`, the one prompt-injectable identity that can post comments — is unchanged, and its two `SECURITY:` tests still pass. `tests/security-floor.json` is unchanged.

Worth noting the change makes the ledger *harder* to misread, which matters because the report drives an auto-closing tracking issue: an inverted row meant a genuinely blocked merge was being reported as clean.

## How verified

- **Replayed real production data** through both the old (`git show main:…`) and new scripts over the same 15-PR payload — that's the before/after table above, not a synthetic example.
- `tests/pipelineOutcomes.test.ts`: **18 tests, all passing**, up from 15. Four existing full-row assertions updated for the new column; four new tests added:
  - a governance routing counts as Routed, never Escalated;
  - a blocked merge *is* still an escalation and *does* appear in the list;
  - a window whose only auto-merge outcome is a routing produces **no** "did not finish" heading, so the tracking issue can close;
  - a routed PR and a blocked PR in the same window are separated correctly in both the table and the list.
- Full suite: **2762 tests, 0 failures**. `npm run typecheck`, `npm run lint`, `npm run context:check` clean; Prettier clean (per-file with `--end-of-line auto`, since this Windows clone makes a whole-tree `format:check` meaningless).

## After merge

#777's next run is **Monday 20:23 UTC (~08:23 NZ Tuesday)**. It should re-render with the routing column and, if the only auto-merge outcomes in that window are routings, close itself. The genuine signal that remains — revise and conflict-resolver checkpoint recoveries — is the thing actually worth acting on, and it's no longer buried.
