### PR TITLE
Start splitting repository.ts: extract preferences + member notes (audit L14, 1/N)

### DIFF
--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -69,7 +69,8 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/router.ts` — 🔒 The hot path: every inbound message lands here. Rate limits, budgets, tier resolution, confirm handling, moderation and the agent call are all sequenced in this file.
 - `src/status/` — Anthropic status-page check behind the "is it me or is Anthropic down?" answer, with its own cache so a common question costs nothing.
 - `src/storage/` — 🔒 Postgres + pgvector: the pool, schema/migrations, local embeddings, runtime policies, and the repository that owns every query. Admin-facing reads are conversation-scoped in SQL here.
-- `src/storage/repository.ts` — 🔒 Every SQL query in the product. Conversation scoping for admin reads is enforced in the queries themselves, not by callers.
+- `src/storage/repository.ts` — 🔒 The repository entry point every caller imports: still holds the not-yet-extracted queries, and re-exports the per-domain modules in `repository/`. Conversation scoping for admin reads is enforced in the queries themselves, not by callers.
+- `src/storage/repository/` — 🔒 Per-domain query modules being carved out of `repository.ts` one domain at a time (audit L14). Add a new query to its domain module here, not to `repository.ts`; everything is re-exported so import sites never change.
 - `src/usageAlert.ts` — Usage-threshold alerting to super admins with a debounce tracker shared by several other alert modules.
 - `src/usageCostDigest.ts` — The periodic cost digest (spend, cache hit rate) sent to super admins.
 - `src/util/` — Shared leaf helpers with no dependencies of their own; currently NZ-timezone rendering for member-facing times.

--- a/docs/agents/recipes.md
+++ b/docs/agents/recipes.md
@@ -80,7 +80,8 @@ unset is a silent breaking change for the running deployment.
 | File | Why |
 |---|---|
 | `src/storage/schema.sql` | Schema changes. **Every statement must be `IF NOT EXISTS`** — `migrate` is idempotent and re-runs on every deploy. |
-| `src/storage/repository.ts` | Every query in the product lives here. Admin-facing reads are **conversation-scoped in SQL**, not by the caller. |
+| `src/storage/repository/<domain>.ts` | Put a new query in its **domain module** (`preferences`, `memberNotes`, …). `repository.ts` re-exports them, so callers still import from `repository.js`. Admin-facing reads are **conversation-scoped in SQL**, not by the caller. |
+| `src/storage/repository.ts` | Only for a domain not yet extracted (the split is incremental — audit L14). A brand-new domain module also needs its `docs/agents/module-map.md` entry in the same diff. |
 | `tests/repository.test.ts` | DB tests skip cleanly without `DATABASE_URL` and run in CI against a real `pgvector/pgvector:pg16` service. |
 
 Run `npm run migrate` before `npm test` locally, or the DB tests fail with

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -7,6 +7,36 @@ import { embed } from './embeddings.js';
 import { config } from '../config.js';
 import { pageKeyOf } from '../context/docsIngest.js';
 
+/**
+ * THIS FILE IS BEING SPLIT, ONE DOMAIN AT A TIME (audit 2026-07-28 L14).
+ *
+ * It was ~7,100 lines — every SQL query in the product in one module — which
+ * made it both hard to navigate and the repo's worst merge-conflict hotspot,
+ * since nearly every feature PR appends to it. Per-domain modules now live in
+ * `./repository/` and are RE-EXPORTED from here, deliberately, so that all ~42
+ * import sites and `tests/repository.test.ts` keep working unchanged: callers
+ * still `import { … } from '.../repository.js'` and neither know nor care which
+ * file a function lives in. That is what lets the split proceed incrementally
+ * instead of as one unreviewable big-bang diff.
+ *
+ * WHEN YOU ADD A QUERY: put it in the matching `./repository/<domain>.ts` (or
+ * add a new domain module + `export *` line here, plus its
+ * `docs/agents/module-map.md` entry — `npm run context:check` enforces that).
+ * Only add to the body of THIS file if its domain has not been extracted yet.
+ *
+ * The extracted modules are verbatim moves — no behaviour change — and the
+ * security invariant is unchanged wherever it applies: admin-facing reads are
+ * conversation-scoped IN SQL (`AND conversation_id = ANY($n)`, `null` meaning
+ * super-admin/unrestricted), never by the caller. Keep that in the query.
+ */
+export * from './repository/preferences.js';
+export * from './repository/memberNotes.js';
+
+// `export *` re-exports for CALLERS but does not bind the names in this
+// module's own scope, so anything still living here that uses an extracted
+// function (getMyData reads the caller's standing style) imports it explicitly.
+import { getResponseStyle, type ResponseStyle } from './repository/preferences.js';
+
 export interface InteractionInput {
   platform: Platform;
   conversationId: string;
@@ -4297,69 +4327,6 @@ function mapMemberProjectRow(r: {
   };
 }
 
-// --- Member notes (admin-curated person-scoped context, issue #45) -----------
-
-export const MEMBER_NOTE_MAX_CHARS = 1000;
-
-export interface MemberNote {
-  id: number;
-  note: string;
-  createdBy: string;
-  createdAt: Date;
-}
-
-/**
- * Attach an admin-authored note to a member. Content is capped server-side;
- * target validation (the member must exist in community_users) lives in the
- * tool layer so the refusal message can be user-facing. Never in
- * knowledge_search or memory recall — this table has no embedding column by
- * design and is only read through listMemberNotes.
- */
-export async function addMemberNote(input: {
-  platform: Platform;
-  userId: string;
-  note: string;
-  createdBy: string;
-}): Promise<number> {
-  const { rows } = await pool.query(
-    `INSERT INTO member_notes (platform, user_id, note, created_by)
-     VALUES ($1,$2,$3,$4) RETURNING id`,
-    [input.platform, input.userId, input.note.slice(0, MEMBER_NOTE_MAX_CHARS), input.createdBy],
-  );
-  return Number(rows[0].id);
-}
-
-export async function listMemberNotes(platform: Platform, userId: string): Promise<MemberNote[]> {
-  const { rows } = await pool.query(
-    `SELECT id, note, created_by, created_at
-       FROM member_notes
-      WHERE platform = $1 AND user_id = $2
-      ORDER BY created_at DESC`,
-    [platform, userId],
-  );
-  return rows.map((r) => ({
-    id: Number(r.id),
-    note: r.note,
-    createdBy: r.created_by,
-    createdAt: r.created_at,
-  }));
-}
-
-/** Fetch one note by id, so the delete CONFIRM can show whose note it is. */
-export async function getMemberNote(
-  id: number,
-): Promise<{ platform: Platform; userId: string; note: string } | null> {
-  const { rows } = await pool.query(`SELECT platform, user_id, note FROM member_notes WHERE id = $1`, [id]);
-  if (rows.length === 0) return null;
-  return { platform: rows[0].platform as Platform, userId: rows[0].user_id, note: rows[0].note };
-}
-
-/** Delete one note by id. Returns false if no row matched. */
-export async function deleteMemberNote(id: number): Promise<boolean> {
-  const { rowCount } = await pool.query(`DELETE FROM member_notes WHERE id = $1`, [id]);
-  return (rowCount ?? 0) > 0;
-}
-
 // --- Server roster (join/leave persistence) ----------------------------------
 
 /**
@@ -5344,84 +5311,6 @@ export async function listReleaseWatchUpdatesSince(
     if (!byPage.has(page)) byPage.set(page, { pageTitle: page, sourceUrl: row.source_url });
   }
   return [...byPage.values()].slice(0, clampedLimit);
-}
-
-// --- Standing response-style preference (issue #126) ------------------------
-
-export type ResponseStyle = 'standard' | 'plain';
-
-/**
- * The caller's standing response-style preference, or 'standard' (today's
- * default behaviour) when they've never called `set_response_style`. A
- * single primary-key lookup, so this is a negligible per-turn cost.
- */
-export async function getResponseStyle(platform: Platform, userId: string): Promise<ResponseStyle> {
-  try {
-    const { rows } = await pool.query(
-      `SELECT style FROM response_style_prefs WHERE platform = $1 AND user_id = $2`,
-      [platform, userId],
-    );
-    return rows[0]?.style === 'plain' ? 'plain' : 'standard';
-  } catch (err) {
-    // Hot-path read on every turn: a DB hiccup must not fail the turn (issue
-    // #52) — degrade to the default reply style, same as getCodeAnswersPolicy.
-    logger.warn({ err, platform, userId }, 'Response-style read failed; using standard');
-    return 'standard';
-  }
-}
-
-/** Upsert the caller's response-style preference. */
-export async function setResponseStyle(
-  platform: Platform,
-  userId: string,
-  style: ResponseStyle,
-): Promise<void> {
-  await pool.query(
-    `INSERT INTO response_style_prefs (platform, user_id, style, updated_at)
-     VALUES ($1, $2, $3, now())
-     ON CONFLICT (platform, user_id) DO UPDATE SET style = $3, updated_at = now()`,
-    [platform, userId, style],
-  );
-}
-
-// --- Standing language preference (issue #189) -------------------------------
-
-export type LanguagePreference = 'auto' | 'en' | 'mi';
-
-/**
- * The caller's standing language preference, or 'auto' (today's per-message
- * mirroring default, issue #68) when they've never called
- * `set_language_preference`. A single primary-key lookup, same cost shape as
- * getResponseStyle.
- */
-export async function getLanguagePreference(platform: Platform, userId: string): Promise<LanguagePreference> {
-  try {
-    const { rows } = await pool.query(
-      `SELECT language FROM language_prefs WHERE platform = $1 AND user_id = $2`,
-      [platform, userId],
-    );
-    const language = rows[0]?.language;
-    return language === 'en' || language === 'mi' ? language : 'auto';
-  } catch (err) {
-    // Hot-path read on every turn: a DB hiccup must not fail the turn (issue
-    // #52) — degrade to 'auto', same as getResponseStyle.
-    logger.warn({ err, platform, userId }, 'Language-preference read failed; using auto');
-    return 'auto';
-  }
-}
-
-/** Upsert the caller's standing language preference. */
-export async function setLanguagePreference(
-  platform: Platform,
-  userId: string,
-  language: LanguagePreference,
-): Promise<void> {
-  await pool.query(
-    `INSERT INTO language_prefs (platform, user_id, language, updated_at)
-     VALUES ($1, $2, $3, now())
-     ON CONFLICT (platform, user_id) DO UPDATE SET language = $3, updated_at = now()`,
-    [platform, userId, language],
-  );
 }
 
 // --- Auto-moderation strikes -------------------------------------------------

--- a/src/storage/repository/memberNotes.ts
+++ b/src/storage/repository/memberNotes.ts
@@ -1,0 +1,77 @@
+import type { Platform } from '../../platforms/types.js';
+import { pool } from '../db.js';
+
+/**
+ * Admin-curated, person-scoped notes (issue #45). Deliberately NOT part of
+ * knowledge_search or memory recall: the table has no embedding column by
+ * design and is only ever read through listMemberNotes/getMemberNote, so an
+ * admin's private note about a member can never surface in a retrieval answer.
+ *
+ * Target validation (the member must exist in community_users) lives in the
+ * tool layer so the refusal can be user-facing — do not add it here.
+ *
+ * Extracted verbatim from repository.ts (see repository.ts's header for why the
+ * split exists); `repository.ts` re-exports everything here, so every existing
+ * import site is unchanged.
+ */
+
+export const MEMBER_NOTE_MAX_CHARS = 1000;
+
+export interface MemberNote {
+  id: number;
+  note: string;
+  createdBy: string;
+  createdAt: Date;
+}
+
+/**
+ * Attach an admin-authored note to a member. Content is capped server-side;
+ * target validation (the member must exist in community_users) lives in the
+ * tool layer so the refusal message can be user-facing. Never in
+ * knowledge_search or memory recall — this table has no embedding column by
+ * design and is only read through listMemberNotes.
+ */
+export async function addMemberNote(input: {
+  platform: Platform;
+  userId: string;
+  note: string;
+  createdBy: string;
+}): Promise<number> {
+  const { rows } = await pool.query(
+    `INSERT INTO member_notes (platform, user_id, note, created_by)
+     VALUES ($1,$2,$3,$4) RETURNING id`,
+    [input.platform, input.userId, input.note.slice(0, MEMBER_NOTE_MAX_CHARS), input.createdBy],
+  );
+  return Number(rows[0].id);
+}
+
+export async function listMemberNotes(platform: Platform, userId: string): Promise<MemberNote[]> {
+  const { rows } = await pool.query(
+    `SELECT id, note, created_by, created_at
+       FROM member_notes
+      WHERE platform = $1 AND user_id = $2
+      ORDER BY created_at DESC`,
+    [platform, userId],
+  );
+  return rows.map((r) => ({
+    id: Number(r.id),
+    note: r.note,
+    createdBy: r.created_by,
+    createdAt: r.created_at,
+  }));
+}
+
+/** Fetch one note by id, so the delete CONFIRM can show whose note it is. */
+export async function getMemberNote(
+  id: number,
+): Promise<{ platform: Platform; userId: string; note: string } | null> {
+  const { rows } = await pool.query(`SELECT platform, user_id, note FROM member_notes WHERE id = $1`, [id]);
+  if (rows.length === 0) return null;
+  return { platform: rows[0].platform as Platform, userId: rows[0].user_id, note: rows[0].note };
+}
+
+/** Delete one note by id. Returns false if no row matched. */
+export async function deleteMemberNote(id: number): Promise<boolean> {
+  const { rowCount } = await pool.query(`DELETE FROM member_notes WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+}

--- a/src/storage/repository/preferences.ts
+++ b/src/storage/repository/preferences.ts
@@ -1,0 +1,94 @@
+import type { Platform } from '../../platforms/types.js';
+import { logger } from '../../logger.js';
+import { pool } from '../db.js';
+
+/**
+ * Standing per-member preferences: response style (issue #126) and language
+ * (issue #189). Both are single primary-key lookups on the hot path — every
+ * turn reads them — so both reads deliberately DEGRADE TO THE DEFAULT rather
+ * than throwing when the DB hiccups (issue #52's fail-open convention, shared
+ * with getCodeAnswersPolicy): a preference lookup must never be what fails a
+ * reply. The writes are plain upserts and are allowed to throw.
+ *
+ * Extracted verbatim from repository.ts (see repository.ts's header for why the
+ * split exists); `repository.ts` re-exports everything here, so every existing
+ * import site is unchanged.
+ */
+
+// --- Standing response-style preference (issue #126) ------------------------
+
+export type ResponseStyle = 'standard' | 'plain';
+
+/**
+ * The caller's standing response-style preference, or 'standard' (today's
+ * default behaviour) when they've never called `set_response_style`. A
+ * single primary-key lookup, so this is a negligible per-turn cost.
+ */
+export async function getResponseStyle(platform: Platform, userId: string): Promise<ResponseStyle> {
+  try {
+    const { rows } = await pool.query(
+      `SELECT style FROM response_style_prefs WHERE platform = $1 AND user_id = $2`,
+      [platform, userId],
+    );
+    return rows[0]?.style === 'plain' ? 'plain' : 'standard';
+  } catch (err) {
+    // Hot-path read on every turn: a DB hiccup must not fail the turn (issue
+    // #52) — degrade to the default reply style, same as getCodeAnswersPolicy.
+    logger.warn({ err, platform, userId }, 'Response-style read failed; using standard');
+    return 'standard';
+  }
+}
+
+/** Upsert the caller's response-style preference. */
+export async function setResponseStyle(
+  platform: Platform,
+  userId: string,
+  style: ResponseStyle,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO response_style_prefs (platform, user_id, style, updated_at)
+     VALUES ($1, $2, $3, now())
+     ON CONFLICT (platform, user_id) DO UPDATE SET style = $3, updated_at = now()`,
+    [platform, userId, style],
+  );
+}
+
+// --- Standing language preference (issue #189) -------------------------------
+
+export type LanguagePreference = 'auto' | 'en' | 'mi';
+
+/**
+ * The caller's standing language preference, or 'auto' (today's per-message
+ * mirroring default, issue #68) when they've never called
+ * `set_language_preference`. A single primary-key lookup, same cost shape as
+ * getResponseStyle.
+ */
+export async function getLanguagePreference(platform: Platform, userId: string): Promise<LanguagePreference> {
+  try {
+    const { rows } = await pool.query(
+      `SELECT language FROM language_prefs WHERE platform = $1 AND user_id = $2`,
+      [platform, userId],
+    );
+    const language = rows[0]?.language;
+    return language === 'en' || language === 'mi' ? language : 'auto';
+  } catch (err) {
+    // Hot-path read on every turn: a DB hiccup must not fail the turn (issue
+    // #52) — degrade to 'auto', same as getResponseStyle.
+    logger.warn({ err, platform, userId }, 'Language-preference read failed; using auto');
+    return 'auto';
+  }
+}
+
+/** Upsert the caller's standing language preference. */
+export async function setLanguagePreference(
+  platform: Platform,
+  userId: string,
+  language: LanguagePreference,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO language_prefs (platform, user_id, language, updated_at)
+     VALUES ($1, $2, $3, now())
+     ON CONFLICT (platform, user_id) DO UPDATE SET language = $3, updated_at = now()`,
+    [platform, userId, language],
+  );
+}

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -12865,11 +12865,20 @@ test(
 
     const repositorySource = readFileSync(new URL('../src/storage/repository.ts', import.meta.url), 'utf8');
     const memberProjectsStart = repositorySource.indexOf('// --- Member projects');
-    const memberNotesStart = repositorySource.indexOf('// --- Member notes');
-    assert.ok(
-      memberProjectsStart !== -1 && memberNotesStart !== -1 && memberProjectsStart < memberNotesStart,
-    );
-    const repoRegion = repositorySource.slice(memberProjectsStart, memberNotesStart);
+    assert.ok(memberProjectsStart !== -1, 'the member-projects section banner must still exist');
+    // End the region at the NEXT section banner, whatever it happens to be —
+    // NOT at a hardcoded following section's name. repository.ts is being split
+    // domain-by-domain (audit L14), so naming the next section couples this
+    // assertion to an unrelated extraction: it used to end at
+    // `// --- Member notes`, and moving member notes to
+    // repository/memberNotes.ts made that indexOf return -1 and failed this
+    // test (plus, because the failure preceded this test's own cleanup, it
+    // orphaned a project row and cascaded into the next three line-count
+    // assertions). Deriving the end keeps the intent — "the member-projects
+    // query region issues no outbound HTTP" — stable across the split.
+    const nextSectionStart = repositorySource.indexOf('\n// --- ', memberProjectsStart + 1);
+    assert.ok(nextSectionStart !== -1, 'a section banner must follow the member-projects section');
+    const repoRegion = repositorySource.slice(memberProjectsStart, nextSectionStart);
     assert.doesNotMatch(repoRegion, /\bfetch\(|axios|http\.get\(|https\.get\(/);
 
     await pool.query(`DELETE FROM member_projects WHERE platform = 'discord' AND user_id = $1`, [userId]);


### PR DESCRIPTION
## Summary

First step of the incremental `repository.ts` carve-up (audit 2026-07-28 **L14**, the god-module finding). The file was ~7,100 lines — every SQL query in the product in one module — which makes it hard to navigate and the repo's worst merge-conflict hotspot, since nearly every feature PR appends to it.

This PR is deliberately **small and boring**: it establishes the pattern the remaining domains will follow, so the mechanism can be reviewed once on low-risk code rather than argued about mid-way through a 7,000-line refactor.

- **New per-domain modules** under `src/storage/repository/`: `preferences.ts` (response-style + language, issues #126/#189) and `memberNotes.ts` (#45). Both were already fully self-contained — they touch only `pool`, `logger` and the `Platform` type, and nothing else in the file calls into them except `getMyData`'s single read of `getResponseStyle` (now an explicit import).
- **`repository.ts` re-exports them** (`export *`), so all ~42 import sites and `tests/repository.test.ts` are **untouched**: callers keep importing from `repository.js` and neither know nor care which file a function lives in. That facade is the whole point — it's what lets this proceed one domain per PR instead of as one unreviewable big-bang diff.
- **Guidance for the next contributor** (usually a cold pipeline session): a header in `repository.ts` says to add new queries to the domain module, and the context pack (`module-map.md` + the DB recipe in `recipes.md`) now says the same.

### Why this axis

`repository.ts` is almost perfectly contiguous by table/domain and its functions are near-independent, so a domain split is genuinely mechanical. (`tools.ts` — the other L14 file — is a different problem: one 4,577-line closure where 99 tools share `caller`/`adapter` plus 8 security-critical helpers. It needs its shared context extracted first and is intentionally **not** in this PR.)

### Planned follow-ups (one PR each, same facade)

`interactions`/memory · `knowledge` (the ~1,200-line block, likely sub-split) · `members`/roles · `moderation` (warnings/reports/appeals) · `digests`+alert bookkeeping · `engagement` (interests/helper/projects/roster) · `stats`/audit/access · `devTeam` watches. Each will keep the 16 conversation-scoped 🔒 admin-read functions' `AND conversation_id = ANY($n)` scoping visible in the query, which is the one thing a domain move must not obscure.

## Security / privacy impact

**None — pure move, no behaviour change.** The eight extracted functions are byte-identical to their previous versions (verified by diffing each function body against the pre-split file); no SQL, logic, or signature changed. Neither extracted domain contains a conversation-scoped admin read, so the 🔒 scoping invariant isn't touched by this diff — it's called out in the new `repository.ts` header and the docs so the domains that *do* carry it keep it. No new dependency, no change to the pool, and `export *` cannot alter what a caller resolves.

## How verified

Full gate green locally against a fresh `npm ci`:

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run context:check`, `npm run build` — all exit 0.
- `npm test` — **2111 pass / 0 fail** / 718 skipped (DB-gated; CI runs them against real pgvector).
- `npm run test:security` — exit 0, 1042 SECURITY tests match the manifest (no `SECURITY:` test added, removed, or relocated, so `security-floor.json` is unchanged).
- **Verbatim check:** diffed each of the eight moved function bodies against `HEAD:src/storage/repository.ts` — all eight report IDENTICAL.

Touches `docs/` (a governance path), so it needs a human merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_019B8WC3ksmJrDbczjRK9584)_