### PR TITLE
Split repository.ts: extract the dev-team watches domain (audit L14, 2/N)

### DIFF
--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -31,6 +31,7 @@ import { pageKeyOf } from '../context/docsIngest.js';
  */
 export * from './repository/preferences.js';
 export * from './repository/memberNotes.js';
+export * from './repository/devTeamWatches.js';
 
 // `export *` re-exports for CALLERS but does not bind the names in this
 // module's own scope, so anything still living here that uses an extracted
@@ -6984,63 +6985,4 @@ export async function answerFeedbackOriginSummary(
     autoAnswer: { helpful: Number(r.auto_helpful), unhelpful: Number(r.auto_unhelpful) },
     addressed: { helpful: Number(r.addressed_helpful), unhelpful: Number(r.addressed_unhelpful) },
   };
-}
-
-// --- Dev-team completion-DM watches (super-admin dev_team_dispatch) ----------
-
-export interface DevTeamWatchInput {
-  jobId: string;
-  requesterPlatform: Platform;
-  requesterUserId: string;
-  mode: string;
-  repo: string;
-}
-
-export interface DevTeamWatch {
-  jobId: string;
-  requesterPlatform: Platform;
-  requesterUserId: string;
-  mode: string;
-  repo: string;
-}
-
-/**
- * Record a durable watch so the requester gets a completion DM once the
- * dispatched job reaches a terminal state (see the poller in
- * src/backgroundJobs.ts). `ON CONFLICT (job_id) DO NOTHING` makes a repeated
- * dispatch of the same id idempotent rather than an error.
- */
-export async function insertDevTeamWatch(input: DevTeamWatchInput): Promise<void> {
-  await pool.query(
-    `INSERT INTO dev_team_watches (job_id, requester_platform, requester_user_id, mode, repo)
-     VALUES ($1, $2, $3, $4, $5)
-     ON CONFLICT (job_id) DO NOTHING`,
-    [input.jobId, input.requesterPlatform, input.requesterUserId, input.mode, input.repo],
-  );
-}
-
-/** Watches whose job has not yet had its completion DM sent, oldest first. */
-export async function listUnnotifiedDevTeamWatches(): Promise<DevTeamWatch[]> {
-  const { rows } = await pool.query(
-    `SELECT job_id, requester_platform, requester_user_id, mode, repo
-       FROM dev_team_watches
-      WHERE notified_at IS NULL
-      ORDER BY created_at ASC`,
-  );
-  return rows.map((r) => ({
-    jobId: r.job_id,
-    requesterPlatform: r.requester_platform as Platform,
-    requesterUserId: r.requester_user_id,
-    mode: r.mode,
-    repo: r.repo,
-  }));
-}
-
-/**
- * Stamp a watch as notified so its completion DM is never sent twice — the
- * poller calls this only AFTER a successful `sendDirectMessage`, so a failed
- * send leaves the row unnotified for the next tick to retry.
- */
-export async function markDevTeamWatchNotified(jobId: string): Promise<void> {
-  await pool.query(`UPDATE dev_team_watches SET notified_at = now() WHERE job_id = $1`, [jobId]);
 }

--- a/src/storage/repository/devTeamWatches.ts
+++ b/src/storage/repository/devTeamWatches.ts
@@ -1,0 +1,71 @@
+import type { Platform } from '../../platforms/types.js';
+import { pool } from '../db.js';
+
+/**
+ * Durable completion-DM watches for the super-admin `dev_team_dispatch` tool.
+ * The poller in src/backgroundJobs.ts reads the unnotified rows, DMs the
+ * requester when the dispatched job reaches a terminal state, and only then
+ * stamps `notified_at` — so a failed send retries on the next tick rather than
+ * being lost, and a succeeded one is never sent twice.
+ *
+ * Extracted verbatim from repository.ts (see repository.ts's header for why the
+ * split exists); `repository.ts` re-exports everything here, so every existing
+ * import site is unchanged.
+ */
+
+export interface DevTeamWatchInput {
+  jobId: string;
+  requesterPlatform: Platform;
+  requesterUserId: string;
+  mode: string;
+  repo: string;
+}
+
+export interface DevTeamWatch {
+  jobId: string;
+  requesterPlatform: Platform;
+  requesterUserId: string;
+  mode: string;
+  repo: string;
+}
+
+/**
+ * Record a durable watch so the requester gets a completion DM once the
+ * dispatched job reaches a terminal state (see the poller in
+ * src/backgroundJobs.ts). `ON CONFLICT (job_id) DO NOTHING` makes a repeated
+ * dispatch of the same id idempotent rather than an error.
+ */
+export async function insertDevTeamWatch(input: DevTeamWatchInput): Promise<void> {
+  await pool.query(
+    `INSERT INTO dev_team_watches (job_id, requester_platform, requester_user_id, mode, repo)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (job_id) DO NOTHING`,
+    [input.jobId, input.requesterPlatform, input.requesterUserId, input.mode, input.repo],
+  );
+}
+
+/** Watches whose job has not yet had its completion DM sent, oldest first. */
+export async function listUnnotifiedDevTeamWatches(): Promise<DevTeamWatch[]> {
+  const { rows } = await pool.query(
+    `SELECT job_id, requester_platform, requester_user_id, mode, repo
+       FROM dev_team_watches
+      WHERE notified_at IS NULL
+      ORDER BY created_at ASC`,
+  );
+  return rows.map((r) => ({
+    jobId: r.job_id,
+    requesterPlatform: r.requester_platform as Platform,
+    requesterUserId: r.requester_user_id,
+    mode: r.mode,
+    repo: r.repo,
+  }));
+}
+
+/**
+ * Stamp a watch as notified so its completion DM is never sent twice — the
+ * poller calls this only AFTER a successful `sendDirectMessage`, so a failed
+ * send leaves the row unnotified for the next tick to retry.
+ */
+export async function markDevTeamWatchNotified(jobId: string): Promise<void> {
+  await pool.query(`UPDATE dev_team_watches SET notified_at = now() WHERE job_id = $1`, [jobId]);
+}


### PR DESCRIPTION
## Summary

Second slice of the `repository.ts` carve-up begun in #804 (audit finding **L14** — `repository.ts` and `tools.ts` are the two god modules, and the merge-conflict hotspots the pipeline docs already complain about).

Moves the dev-team completion-DM watch queries into `src/storage/repository/devTeamWatches.ts`:

- `DevTeamWatchInput`, `DevTeamWatch` (interfaces)
- `insertDevTeamWatch`, `listUnnotifiedDevTeamWatches`, `markDevTeamWatchNotified`

**Pure code motion.** All five symbols are **byte-identical** to their previous definitions (verified mechanically against `origin/main`, not by eye), and `repository.ts` re-exports the new module alongside the existing two — so every import site and `tests/repository.test.ts` are untouched. `repository.ts` drops another ~60 lines.

### Why this domain next

Same criteria as 1/N, keeping each PR a reviewable move rather than a rewrite:

- **Fully self-contained** — its only dependencies are `pool` and the `Platform` type.
- **Owns one table** (`dev_team_watches`) that no other domain touches.
- **No conversation-scoped admin read**, so the 🔒 SQL-scoping invariant is not in play here. (That invariant lives in ~16 functions clustered in the reporting/feedback half; those will get their own dedicated PRs with the scoping called out explicitly, not smuggled in beside other work.)

### Applying #804's lesson

#804 was broken by a test that slices `repository.ts` **as source text** between two `// --- ` section banners — my extraction deleted one, which failed an assertion *before* that test's cleanup and cascaded into three more. Before removing this banner I grepped `tests/` for `indexOf('// --- `: the only test that introspects `repository.ts` is the member-projects HTTP scan, which #804 already made banner-agnostic, and the dev-team banner sat at the very end of the file. So this extraction cannot reproduce that failure mode.

## Security / privacy impact

None. Pure code motion — no SQL, logic, or signature change; no new dependency; no altered tool gating, identity derivation, or outbound filtering. Neither the moved table nor its queries carry a conversation-scoped admin read, so the 🔒 admin-scoping invariant is untouched. `tests/security-floor.json` is deliberately unchanged: no `SECURITY:` test was added or removed.

## How verified

All gates green locally against the current `main`:

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run context:check` — all exit 0.
- `npm test` — **2114 pass / 0 fail** / 721 skipped (skips are DB-gated; CI runs them against real pgvector — which is exactly where #804's breakage surfaced, so CI remains the real verdict).
- `npm run test:security` — exit 0, **1047** SECURITY tests matching the manifest.
- **Byte-identical check:** each moved function body and interface compared, whitespace-normalised, against `origin/main:src/storage/repository.ts` — all five report IDENTICAL.

Touches the 🔒 storage layer, so it needs a human merge.

---

**Campaign progress:** `preferences` + `memberNotes` (#804, merged) → `devTeamWatches` (this PR). Next up are the larger contiguous domains — interactions/memory, knowledge, members, moderation — after which `tools.ts` needs its shared closure context extracted first and is worth discussing before I touch the tool-gating spine.


---
_Generated by [Claude Code](https://claude.ai/code/session_019B8WC3ksmJrDbczjRK9584)_