### PR TITLE
Split repository.ts: extract admin audit + shortcut hits (audit L14, 5/N)

### DIFF
--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -335,8 +335,6 @@ export async function recentConversationTail(
   }
 }
 
-/** A pooled connection or a transaction client — both expose `query`. */
-
 /**
  * Invalidate every context digest whose provenance refs include any of
  * `interactionIds`, deleting its still-*pending* knowledge candidates first

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -35,13 +35,17 @@ export * from './repository/shared.js';
 export * from './repository/devTeamWatches.js';
 // `export *` does not bind names into this module's own scope, and the
 // knowledge queries below use this floor directly — so import it explicitly.
-import { KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD } from './repository/shared.js';
+import { KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD, type Queryable } from './repository/shared.js';
+import { recordAdminAction } from './repository/adminAudit.js';
+import { sumShortcutHits } from './repository/shortcutHits.js';
 export * from './repository/accessRequests.js';
 export * from './repository/contextDigests.js';
 export * from './repository/memberDiscovery.js';
 export * from './repository/docsIngestFailures.js';
 export * from './repository/policies.js';
 export * from './repository/roster.js';
+export * from './repository/adminAudit.js';
+export * from './repository/shortcutHits.js';
 
 // `export *` re-exports for CALLERS but does not bind the names in this
 // module's own scope, so anything still living here that uses an extracted
@@ -332,7 +336,6 @@ export async function recentConversationTail(
 }
 
 /** A pooled connection or a transaction client — both expose `query`. */
-type Queryable = Pick<PoolClient, 'query'>;
 
 /**
  * Invalidate every context digest whose provenance refs include any of
@@ -2851,72 +2854,6 @@ export async function sumBackgroundJobCosts(
   );
   const byJob = rows.map((r) => ({ job: r.job as string, costUsd: Number(r.cost) }));
   return { total: byJob.reduce((sum, r) => sum + r.costUsd, 0), byJob };
-}
-
-// --- Shortcut hits -----------------------------------------------------------
-
-export type ShortcutKind = 'ack' | 'knowledge' | 'repeat_question' | 'repeat_max_turns';
-
-/**
- * Records a hit of one of the four env-gated turn-skipping shortcuts (issue
- * #440) — each avoids a `query()` call against the shared Max pool but was
- * previously visible only via a single `logger.debug`/`.info` line. Callers
- * are expected to fire this without awaiting and swallow rejections (mirrors
- * `recordBackgroundJobCost`'s convention) — a failed write must never block
- * or delay the shortcut's own reply.
- */
-export async function recordShortcutHit(kind: ShortcutKind): Promise<void> {
-  await pool.query(`INSERT INTO shortcut_hits (kind) VALUES ($1)`, [kind]);
-}
-
-export async function sumShortcutHits(
-  days = 7,
-): Promise<{ total: number; byKind: Array<{ kind: string; count: number }> }> {
-  const clampedDays = Math.min(Math.max(Math.trunc(days) || 7, 1), 365);
-  const { rows } = await pool.query(
-    `SELECT kind, count(*) AS n
-       FROM shortcut_hits
-      WHERE created_at > now() - $1::interval
-      GROUP BY kind ORDER BY kind`,
-    [`${clampedDays} days`],
-  );
-  const byKind = rows.map((r) => ({ kind: r.kind as string, count: Number(r.n) }));
-  return { total: byKind.reduce((sum, r) => sum + r.count, 0), byKind };
-}
-
-// --- Admin audit -----------------------------------------------------------
-
-export async function recordAdminAction(
-  input: {
-    platform: Platform;
-    actorUserId: string;
-    actorName?: string;
-    actionKind: string;
-    targetUserId?: string;
-    conversationId?: string;
-    params?: Record<string, unknown>;
-    result?: string;
-    success: boolean;
-  },
-  db: Queryable = pool,
-): Promise<void> {
-  await db.query(
-    `INSERT INTO admin_audit
-       (platform, actor_user_id, actor_name, action_kind, target_user_id,
-        conversation_id, params, result, success)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-    [
-      input.platform,
-      input.actorUserId,
-      input.actorName ?? null,
-      input.actionKind,
-      input.targetUserId ?? null,
-      input.conversationId ?? null,
-      JSON.stringify(input.params ?? {}),
-      input.result ?? null,
-      input.success,
-    ],
-  );
 }
 
 // --- Knowledge candidates (issue #102, the knowledge_candidates half of #51

--- a/src/storage/repository/adminAudit.ts
+++ b/src/storage/repository/adminAudit.ts
@@ -1,0 +1,49 @@
+import type { Platform } from '../../platforms/types.js';
+import { pool } from '../db.js';
+import type { Queryable } from './shared.js';
+
+/**
+ * The `admin_audit` trail: every privileged action the bot performs is recorded
+ * here, including the auto-enrol sentinel actor. Accepts an optional Queryable
+ * so a caller inside a transaction records its audit row atomically with the
+ * change it describes.
+ *
+ * Extracted verbatim from repository.ts (see its header for why the split
+ * exists); `repository.ts` re-exports everything here, so every existing import
+ * site is unchanged.
+ */
+
+// --- Admin audit -----------------------------------------------------------
+
+export async function recordAdminAction(
+  input: {
+    platform: Platform;
+    actorUserId: string;
+    actorName?: string;
+    actionKind: string;
+    targetUserId?: string;
+    conversationId?: string;
+    params?: Record<string, unknown>;
+    result?: string;
+    success: boolean;
+  },
+  db: Queryable = pool,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO admin_audit
+       (platform, actor_user_id, actor_name, action_kind, target_user_id,
+        conversation_id, params, result, success)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+    [
+      input.platform,
+      input.actorUserId,
+      input.actorName ?? null,
+      input.actionKind,
+      input.targetUserId ?? null,
+      input.conversationId ?? null,
+      JSON.stringify(input.params ?? {}),
+      input.result ?? null,
+      input.success,
+    ],
+  );
+}

--- a/src/storage/repository/shared.ts
+++ b/src/storage/repository/shared.ts
@@ -7,6 +7,16 @@
  * imports this floor and re-exports it — are unchanged.
  */
 
+import type { PoolClient } from 'pg';
+
+/**
+ * A pool or a checked-out transaction client — anything that can run a query.
+ * Functions take this so a caller inside a `BEGIN`/`COMMIT` can pass its client
+ * and have the write land atomically with the rest of its transaction. Shared
+ * here because both repository.ts and extracted domain modules use it.
+ */
+export type Queryable = Pick<PoolClient, 'query'>;
+
 /**
  * Relevance floor for `knowledge_search` hits, in cosine similarity
  * (`1 - (embedding <=> query)`, same units as `searchKnowledge`'s returned

--- a/src/storage/repository/shortcutHits.ts
+++ b/src/storage/repository/shortcutHits.ts
@@ -1,0 +1,41 @@
+import { pool } from '../db.js';
+
+/**
+ * Counters for the zero-model-call shortcut paths (ack, repeat-question,
+ * knowledge), which usageStats folds into its digest.
+ *
+ * Extracted verbatim from repository.ts (see its header for why the split
+ * exists); `repository.ts` re-exports everything here, so every existing import
+ * site is unchanged.
+ */
+
+// --- Shortcut hits -----------------------------------------------------------
+
+export type ShortcutKind = 'ack' | 'knowledge' | 'repeat_question' | 'repeat_max_turns';
+
+/**
+ * Records a hit of one of the four env-gated turn-skipping shortcuts (issue
+ * #440) — each avoids a `query()` call against the shared Max pool but was
+ * previously visible only via a single `logger.debug`/`.info` line. Callers
+ * are expected to fire this without awaiting and swallow rejections (mirrors
+ * `recordBackgroundJobCost`'s convention) — a failed write must never block
+ * or delay the shortcut's own reply.
+ */
+export async function recordShortcutHit(kind: ShortcutKind): Promise<void> {
+  await pool.query(`INSERT INTO shortcut_hits (kind) VALUES ($1)`, [kind]);
+}
+
+export async function sumShortcutHits(
+  days = 7,
+): Promise<{ total: number; byKind: Array<{ kind: string; count: number }> }> {
+  const clampedDays = Math.min(Math.max(Math.trunc(days) || 7, 1), 365);
+  const { rows } = await pool.query(
+    `SELECT kind, count(*) AS n
+       FROM shortcut_hits
+      WHERE created_at > now() - $1::interval
+      GROUP BY kind ORDER BY kind`,
+    [`${clampedDays} days`],
+  );
+  const byKind = rows.map((r) => ({ kind: r.kind as string, count: Number(r.n) }));
+  return { total: byKind.reduce((sum, r) => sum + r.count, 0), byKind };
+}


### PR DESCRIPTION
## Summary

Fifth slice of the `repository.ts` carve-up (audit **L14**), continuing #804, #807, #809, #810.

Unlike the previous four, these two domains are **consumed by code that stays in `repository.ts`**, so they exercise the explicit-import half of the facade pattern:

- **`repository/adminAudit.ts`** — `recordAdminAction`, the `admin_audit` trail. `autoEnrollMemberWithAudit` (still in `repository.ts`) calls it *inside its transaction*, so `repository.ts` imports it explicitly.
- **`repository/shortcutHits.ts`** — the zero-model-call shortcut counters. `usageStats` (still in `repository.ts`) folds `sumShortcutHits` into its digest, so that's imported explicitly too.

`export *` re-exports for *callers* but does not bind names in the re-exporting module's own scope — the same subtlety #804 hit with `getResponseStyle` and #809 hit with `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD`.

`repository.ts` is now **6,135 lines** — down from **7,137** at campaign start (−1,002, **14%**).

## One deliberate non-motion change

The private `Queryable` type alias (`Pick<PoolClient, 'query'>`) moves to `repository/shared.ts` and is now **exported**. `recordAdminAction` takes it, and two functions still in `repository.ts` do too, so it has to be shared. The alternative was duplicating the declaration — which is the debt this campaign exists to reduce.

The alias itself is **unchanged**; only its location and visibility. It's types-only, so there's no runtime surface change — but I'm calling it out explicitly rather than letting a "pure move" claim quietly cover it.

## Security / privacy impact

None. No SQL, logic, or signature change; no new dependency; no altered tool gating, identity derivation, or outbound filtering. `recordAdminAction` keeps its optional-`Queryable` shape, so the auto-enrol audit row still commits atomically with the member grant it describes. Neither domain carries a conversation-scoped admin read, so the 🔒 admin-scoping invariant is untouched. `tests/security-floor.json` unchanged: no `SECURITY:` test added or removed.

## How verified

All gates green locally against current `main`:

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run context:check` — all exit 0.
- `npm test` — **2114 pass / 0 fail** / 721 skipped (DB-gated; CI is the real verdict).
- `npm run test:security` — exit 0, **1047** SECURITY tests matching the manifest.
- **Byte-identical check:** all 3 moved functions compared whitespace-normalised against `origin/main` — **3 IDENTICAL, 0 differing**; `Queryable`'s alias text confirmed preserved.

Touches the 🔒 storage layer, so it needs a human merge.

---

**Campaign progress:** #804 → #807 → #809 → #810 → this PR. `repository.ts` 7,137 → 6,135.

**Remaining, in increasing order of care:**
1. **Member projects** — screens clean, but `tests/tools.test.ts` asserts the `// --- Member projects` banner exists *in `repository.ts`*; its own PR with that test edit as the focus.
2. **Background job costs** — coupled both ways (it calls `usageStats`), so it wants the same explicit-import treatment as this PR.
3. **The large contiguous blocks** — interactions/memory, knowledge (~1,200 lines, likely worth sub-splitting), members/identity-linking, moderation.
4. **The ~16 conversation-scoped 🔒 admin-read functions** — last, in their own dedicated PRs with the SQL scoping called out for explicit review.
5. **`tools.ts`** — needs its 4,577-line shared closure (`requireConfirm`, `callerScope`, `audited`, the rate-limit maps) extracted first; deliberately not started pending discussion, since it's the tool-gating spine.

**Still outstanding:** the cross-file test-pollution fix offered in #810's body. It reddened #809 (passed unchanged on retry) and forced a retry on `main`. It matters more from here, because the knowledge domain touches exactly the tables those global-matching assertions read.


---
_Generated by [Claude Code](https://claude.ai/code/session_019B8WC3ksmJrDbczjRK9584)_