### PR TITLE
WhatsApp: bump Baileys to 6.7.24 and bound the reconnect loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,16 @@ WHATSAPP_PROVIDER=baileys
 WHATSAPP_AUTH_DIR=./whatsapp-auth
 # Optional allowlist of numbers/groups the bot will respond to. Empty = all DMs.
 WHATSAPP_ALLOWED_JIDS=
+# How many consecutive reconnect attempts before the Baileys adapter STOPS
+# retrying. Backoff is 3s doubling to a 5-minute ceiling, so 20 spends roughly
+# an hour before giving up. Set 0 for the old unlimited behaviour.
+#
+# It is bounded because on 2026-07-29 WhatsApp refused the connection with
+# statusCode 405 (a refusal, NOT a logout) and the unbounded loop retried 73
+# times over ~6 hours. When the budget is exhausted the adapter logs one
+# actionable error and stays disconnected, so the sustained-disconnect alert
+# keeps nagging — restart the service to retry.
+WHATSAPP_MAX_RECONNECT_ATTEMPTS=20
 # Post a static welcome message to a group when someone joins it. Off by
 # default. This adds an UNPROMPTED, event-triggered automated group post to
 # the unofficial Baileys path (see docs/SECURITY.md) — operator-gated and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 
 ## 2026-07-29
 
+### Fixed
+- **WhatsApp reconnects after WhatsApp itself refuses the connection.** On the
+  morning of 29 July, WhatsApp began rejecting the bot's connection outright
+  (a refusal, not a logout — the pairing was never lost), and Dave was
+  unreachable on WhatsApp for about six hours. Discord was unaffected
+  throughout. The WhatsApp library has been updated to the release published
+  the same day, which addresses the rejection.
+- **The bot no longer retries forever when WhatsApp is refusing it.** Reconnect
+  attempts are now capped (~an hour of retrying by default) instead of looping
+  indefinitely; when the budget runs out it logs one clear, actionable error
+  and alerts an admin rather than retrying silently in the background.
+
 ### Added
 - **Community digest is now available on demand, not just as a weekly post**
   (#841): a new member-tier `community_digest` chat tool and a matching

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2516,6 +2516,22 @@ keep volume human-like, or switch to `WhatsAppCloudAdapter`
 deliberate, accepted trade-off for immediate, free operation; revisit it
 before scaling.
 
+**Reconnects are bounded** (`WHATSAPP_MAX_RECONNECT_ATTEMPTS`, default 20).
+On 2026-07-29 WhatsApp started refusing the connection with `statusCode: 405,
+loggedOut: false` — a refusal, not a logout, and not a network blip — and the
+then-unbounded retry loop reconnected **73 times over ~6 hours** at its
+5-minute backoff ceiling. Repeatedly re-attempting a connection the server is
+actively rejecting is precisely the un-human-like pattern this section warns
+about, so the loop now stops after a bounded budget (~1 h of backoff),
+logs one actionable error, and stays disconnected — which leaves the
+sustained-disconnect alert nagging a super admin rather than burying the
+problem under an endless warn stream. `0` restores unlimited retries.
+
+A `401` (`loggedOut`) close is handled separately and has **never** been
+retried: the linked device is gone and only `npm run whatsapp:link` restores
+it. That distinction is pinned by a `SECURITY:` test, because retrying a
+revoked session is the version of this that most plausibly attracts a ban.
+
 Enabling `WHATSAPP_WELCOME_ENABLED` adds an **unprompted, event-triggered
 automated group post** (a static message on `group-participants.update`) to
 this unofficial path — not a risk-free feature. It never DMs the joiner

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@whiskeysockets/baileys": "6.7.23",
+        "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "pg": "^8.22.0",
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "6.7.23",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-6.7.23.tgz",
-      "integrity": "sha512-UDbysXJpFKHC2S27qy4oABQc2uZekhUcCNi+Nvzev7wZkOhC72wqezzM2cfYB3PHJdy3Jadc2VkVv8eQeywIUw==",
+      "version": "6.7.24",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-6.7.24.tgz",
+      "integrity": "sha512-Ljq7si+gsNIE9d5dP69E99TTQp+BxxPgitWvmZMXExGc1Ctr0SCDLFZmxRLUDC5HB0/Itw5uk+HJeBONrLP99Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@whiskeysockets/baileys": "6.7.23",
+    "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
     "pg": "^8.22.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -303,6 +303,22 @@ const EnvSchema = z.object({
   WHATSAPP_PROVIDER: z.enum(['baileys', 'cloud', 'disabled']).default('baileys'),
   WHATSAPP_AUTH_DIR: z.string().default('./whatsapp-auth'),
   WHATSAPP_ALLOWED_JIDS: z.string().optional(),
+  // Cap on consecutive Baileys reconnect attempts before the adapter STOPS
+  // retrying (issue: the 2026-07-29 405 outage). The backoff is
+  // 3s·2^(n-1) capped at 5 min, so the default 20 spends roughly an hour
+  // retrying — long enough to ride out a genuine transient outage, far short
+  // of the 73 attempts over ~6 h that the unbounded loop actually ran.
+  //
+  // Why cap at all: a 405 is WhatsApp REFUSING the connection, not a network
+  // blip, and docs/SECURITY.md treats Baileys ToS/ban exposure as a real risk
+  // — indefinitely hammering a server that is actively rejecting us is the
+  // wrong posture. Giving up is also more visible than looping forever: the
+  // adapter stays disconnected, so health.ts's existing sustained-disconnect
+  // alert keeps notifying super admins.
+  //
+  // `0` means unlimited, preserving the old behaviour as an escape hatch for
+  // an operator who would rather retry forever than restart by hand.
+  WHATSAPP_MAX_RECONNECT_ATTEMPTS: z.coerce.number().int().min(0).default(20),
   // Welcome message posted to a group on group-participants.update (Baileys
   // only); off unless explicitly enabled.
   WHATSAPP_WELCOME_ENABLED: z
@@ -1204,6 +1220,7 @@ export const config = {
     provider: env.WHATSAPP_PROVIDER,
     authDir: env.WHATSAPP_AUTH_DIR,
     allowedJids: csv(env.WHATSAPP_ALLOWED_JIDS),
+    maxReconnectAttempts: env.WHATSAPP_MAX_RECONNECT_ATTEMPTS,
     welcome: {
       enabled: env.WHATSAPP_WELCOME_ENABLED ?? false,
       cooldownMinutes: env.WHATSAPP_WELCOME_COOLDOWN_MINUTES,

--- a/src/platforms/whatsapp/baileysAdapter.ts
+++ b/src/platforms/whatsapp/baileysAdapter.ts
@@ -227,8 +227,35 @@ export class BaileysAdapter implements PlatformAdapter {
     // reconnects would each build a socket and end() the other's (audit M5).
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectAttempts += 1;
+
+    // Bounded retry. Before this cap the loop was infinite, and on 2026-07-29
+    // that meant 73 consecutive `statusCode: 405` refusals over ~6 hours,
+    // every 5 minutes, with nobody reading the log. A 405 is WhatsApp
+    // REFUSING us rather than a network blip, and docs/SECURITY.md treats
+    // Baileys ToS/ban exposure as a live risk, so hammering a server that is
+    // actively rejecting the connection is the wrong posture.
+    //
+    // Giving up is also LOUDER than looping: `connected` stays false, so
+    // health.ts's sustained-disconnect check keeps alerting super admins, and
+    // the operator gets one unambiguous error naming the fix instead of an
+    // endless warn stream that looks like progress.
+    const maxAttempts = config.whatsapp.maxReconnectAttempts;
+    if (maxAttempts > 0 && this.reconnectAttempts > maxAttempts) {
+      logger.error(
+        { attempts: this.reconnectAttempts - 1, maxAttempts },
+        'WhatsApp reconnect attempts exhausted — giving up. The session is NOT logged out; ' +
+          'restart the service to retry (`sudo systemctl restart community-agent`). If it keeps ' +
+          'failing with statusCode 405, WhatsApp is refusing this client version — check for a ' +
+          'newer @whiskeysockets/baileys release.',
+      );
+      return;
+    }
+
     const delay = Math.min(3_000 * 2 ** (this.reconnectAttempts - 1), MAX_RECONNECT_DELAY_MS);
-    logger.warn({ attempt: this.reconnectAttempts, delayMs: delay }, 'Scheduling WhatsApp reconnect');
+    logger.warn(
+      { attempt: this.reconnectAttempts, delayMs: delay, maxAttempts: maxAttempts || 'unlimited' },
+      'Scheduling WhatsApp reconnect',
+    );
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.connect().catch((err) => {

--- a/tests/baileysReconnectCap.test.ts
+++ b/tests/baileysReconnectCap.test.ts
@@ -1,0 +1,135 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+// Bounded WhatsApp reconnect — the 2026-07-29 outage. WhatsApp began refusing
+// the connection with `statusCode: 405, loggedOut: false` and the adapter,
+// having no ceiling, retried 73 times over ~6 hours at the 5-minute backoff
+// cap. A 405 is a REFUSAL rather than a network blip, and docs/SECURITY.md
+// treats Baileys ToS/ban exposure as live, so the loop is now bounded by
+// WHATSAPP_MAX_RECONNECT_ATTEMPTS.
+//
+// ONE test per file, deliberately: `t.mock.module` only affects SUBSEQUENT
+// imports, so a second test in the same file would get this test's disposed
+// mock out of the module cache and build no sockets at all. Its sibling
+// tests/baileysReconnectLoggedOut.test.ts exists for the same reason.
+//
+// config.ts validates env at import time.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+// Small cap keeps the test fast and explicit; production defaults to 20
+// (~1 h of backoff). See config.ts for why it is bounded at all.
+process.env.WHATSAPP_MAX_RECONNECT_ATTEMPTS ??= '3';
+const MAX_ATTEMPTS = 3;
+
+type FakeSock = {
+  ev: EventEmitter;
+  user: { id: string };
+  end: () => void;
+  ended: boolean;
+  groupFetchAllParticipating: () => Promise<Record<string, unknown>>;
+};
+
+async function loadAdapter(t: { mock: { module: (specifier: string, opts: unknown) => void } }): Promise<{
+  adapter: { start: () => Promise<void>; isConnected: () => boolean } & Record<string, unknown>;
+  sockets: FakeSock[];
+}> {
+  const sockets: FakeSock[] = [];
+  t.mock.module('@whiskeysockets/baileys', {
+    defaultExport: () => {
+      const sock: FakeSock = {
+        ev: new EventEmitter(),
+        user: { id: `11122233344${sockets.length}@s.whatsapp.net` },
+        ended: false,
+        end() {
+          this.ended = true;
+        },
+        groupFetchAllParticipating: async () => ({}),
+      };
+      sockets.push(sock);
+      return sock;
+    },
+    namedExports: {
+      DisconnectReason: { loggedOut: 401 },
+      fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+      useMultiFileAuthState: async () => ({ state: { creds: {}, keys: {} }, saveCreds: async () => {} }),
+      downloadMediaMessage: async () => Buffer.from(''),
+      proto: {},
+    },
+  });
+  const { BaileysAdapter } = await import('../src/platforms/whatsapp/baileysAdapter.js');
+  return {
+    adapter: new BaileysAdapter() as unknown as {
+      start: () => Promise<void>;
+      isConnected: () => boolean;
+    } & Record<string, unknown>,
+    sockets,
+  };
+}
+
+function emitUpdate(sock: FakeSock, update: Record<string, unknown>): void {
+  sock.ev.emit('connection.update', update);
+}
+
+test('baileys reconnect is BOUNDED: it stops at the configured cap, stays stopped, and a successful connect restores the full budget (2026-07-29 405 outage)', async (t) => {
+  const { adapter, sockets } = await loadAdapter(t);
+  await adapter.start();
+  assert.equal(sockets.length, 1, 'start() built the first socket');
+
+  // Fake timers only AFTER startup: connect() is async and mocking setTimeout
+  // before the first socket exists stalls it.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  /** Close the newest socket with a non-loggedOut status, then fire its timer. */
+  const failAndAdvance = async () => {
+    emitUpdate(sockets[sockets.length - 1], {
+      connection: 'close',
+      lastDisconnect: { error: { output: { statusCode: 405 } } },
+    });
+    t.mock.timers.tick(10 * 60_000); // beyond MAX_RECONNECT_DELAY_MS (5 min)
+    await new Promise((resolve) => setImmediate(resolve)); // let connect() settle
+  };
+
+  // --- every attempt inside the budget reconnects -------------------------
+  for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+    await failAndAdvance();
+    assert.equal(sockets.length, i + 2, `attempt ${i + 1} built a replacement socket`);
+  }
+
+  // --- the attempt past the cap gives up ----------------------------------
+  await failAndAdvance();
+  assert.equal(
+    sockets.length,
+    MAX_ATTEMPTS + 1,
+    'once the budget is exhausted the adapter gives up instead of building another socket',
+  );
+
+  // --- and stays given up; no zombie timer revives the loop ---------------
+  t.mock.timers.tick(60 * 60_000);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(sockets.length, MAX_ATTEMPTS + 1, 'no pending timer resurrected the retry loop');
+  assert.equal(
+    adapter.isConnected(),
+    false,
+    'it reports disconnected, so health.ts’s sustained-disconnect alert keeps notifying super admins',
+  );
+
+  // --- a successful open resets the budget --------------------------------
+  // Drive one more connect by hand (the loop has given up) and open it.
+  await (adapter as unknown as { connect: () => Promise<void> }).connect();
+  const revived = sockets.length;
+  emitUpdate(sockets[sockets.length - 1], { connection: 'open' });
+  assert.equal(adapter.isConnected(), true, 'reconnected');
+
+  // The counter zeroed, so a fresh outage gets the FULL allowance again
+  // rather than the (already exhausted) remainder.
+  for (let i = 0; i < MAX_ATTEMPTS; i += 1) await failAndAdvance();
+  assert.equal(
+    sockets.length,
+    revived + MAX_ATTEMPTS,
+    'a successful connection restored the whole budget for the next outage',
+  );
+});

--- a/tests/baileysReconnectLoggedOut.test.ts
+++ b/tests/baileysReconnectLoggedOut.test.ts
@@ -1,0 +1,105 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+// A logged-out (401) close must NEVER schedule a reconnect. This is the case
+// the 2026-07-29 405 outage was NOT: 401 means WhatsApp revoked the linked
+// device, and retrying a revoked session is exactly the behaviour that puts
+// the account at risk (docs/SECURITY.md's Baileys ToS exposure). It needs
+// `npm run whatsapp:link`, and crucially the attempt CAP must not be what
+// stops it — the 401 branch must refuse to retry from the very first close.
+//
+// Original 405 context, for contrast. WhatsApp began refusing
+// the connection with `statusCode: 405, loggedOut: false` and the adapter,
+// having no ceiling, retried 73 times over ~6 hours at the 5-minute backoff
+// cap. A 405 is a REFUSAL rather than a network blip, and docs/SECURITY.md
+// treats Baileys ToS/ban exposure as live, so the loop is now bounded by
+// WHATSAPP_MAX_RECONNECT_ATTEMPTS.
+//
+// ONE test per file, deliberately: `t.mock.module` only affects SUBSEQUENT
+// imports, so a second test in the same file would get this test's disposed
+// mock out of the module cache and build no sockets at all. Its sibling
+// tests/baileysReconnectCap.test.ts exists for the same reason.
+//
+// config.ts validates env at import time.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+// Small cap keeps the test fast and explicit; production defaults to 20
+// (~1 h of backoff). See config.ts for why it is bounded at all.
+process.env.WHATSAPP_MAX_RECONNECT_ATTEMPTS ??= '3';
+const MAX_ATTEMPTS = 3;
+
+type FakeSock = {
+  ev: EventEmitter;
+  user: { id: string };
+  end: () => void;
+  ended: boolean;
+  groupFetchAllParticipating: () => Promise<Record<string, unknown>>;
+};
+
+async function loadAdapter(t: { mock: { module: (specifier: string, opts: unknown) => void } }): Promise<{
+  adapter: { start: () => Promise<void>; isConnected: () => boolean } & Record<string, unknown>;
+  sockets: FakeSock[];
+}> {
+  const sockets: FakeSock[] = [];
+  t.mock.module('@whiskeysockets/baileys', {
+    defaultExport: () => {
+      const sock: FakeSock = {
+        ev: new EventEmitter(),
+        user: { id: `11122233344${sockets.length}@s.whatsapp.net` },
+        ended: false,
+        end() {
+          this.ended = true;
+        },
+        groupFetchAllParticipating: async () => ({}),
+      };
+      sockets.push(sock);
+      return sock;
+    },
+    namedExports: {
+      DisconnectReason: { loggedOut: 401 },
+      fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+      useMultiFileAuthState: async () => ({ state: { creds: {}, keys: {} }, saveCreds: async () => {} }),
+      downloadMediaMessage: async () => Buffer.from(''),
+      proto: {},
+    },
+  });
+  const { BaileysAdapter } = await import('../src/platforms/whatsapp/baileysAdapter.js');
+  return {
+    adapter: new BaileysAdapter() as unknown as {
+      start: () => Promise<void>;
+      isConnected: () => boolean;
+    } & Record<string, unknown>,
+    sockets,
+  };
+}
+
+function emitUpdate(sock: FakeSock, update: Record<string, unknown>): void {
+  sock.ev.emit('connection.update', update);
+}
+
+test('SECURITY: a logged-out (401) close never schedules a reconnect, so a revoked session is not retried against WhatsApp', async (t) => {
+  const { adapter, sockets } = await loadAdapter(t);
+  await adapter.start();
+  assert.equal(sockets.length, 1);
+
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  emitUpdate(sockets[0], {
+    connection: 'close',
+    lastDisconnect: { error: { output: { statusCode: 401 } } },
+  });
+  // Far beyond any backoff the bounded-retry path would have scheduled.
+  t.mock.timers.tick(60 * 60_000);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(
+    sockets.length,
+    1,
+    'a loggedOut close must build no further socket — not even the first retry',
+  );
+  assert.equal(adapter.isConnected(), false);
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -46,6 +46,7 @@
   "backgroundJobsDisabled.test.ts": 2,
   "baileysAdapter.test.ts": 32,
   "baileysArchiving.test.ts": 2,
+  "baileysReconnectLoggedOut.test.ts": 1,
   "budgetCheckFailureRouter.test.ts": 4,
   "classifierModelTieringSet.test.ts": 1,
   "config.test.ts": 19,


### PR DESCRIPTION
## Summary

Production WhatsApp went down this morning. WhatsApp began **refusing** the connection with `statusCode: 405, loggedOut: false` — a refusal, not a logout. Dave was unreachable on WhatsApp for ~6 hours; Discord was unaffected throughout.

Diagnosis (live, before any change):

- **Not a logout.** `creds.json` intact and written *after* the failures began, and "Dave" was still listed under linked devices on the phone. The 2026-07-27 re-pair procedure was the wrong tool.
- **Last good connect** 2026-07-28 21:46:08 UTC; failing from 21:59 UTC.
- **73 consecutive 405s**, one every 5 minutes, retrying indefinitely.
- The sustained-disconnect alert *did* fire correctly at 22:04 UTC.

A service restart restored it immediately (connected, roster backfilled, zero 405s since). This PR addresses the cause and the thing that made it drag on unnoticed.

## 1 · Baileys 6.7.23 → 6.7.24

**6.7.24 was published 2026-07-29T00:57Z** — roughly three hours before the outage surfaced. A patch to the WhatsApp Web protocol client landing the same morning WhatsApp starts rejecting the previous one is the most probable fix.

**Deliberately not 6.17.16.** Despite the higher minor it is a **stale parallel line published 2025-03-04 — over a year older than 6.7.23**. I tried it first and it fails typecheck: its proto drops the `senderPn` / `participantPn` LID fields that `src/platforms/whatsapp/wire.ts` uses to resolve a sender's real phone number, so it would have regressed **sender identity resolution** — a security-spine behaviour. The live 6.x line is 6.7.x. (npm's version list is semver-sorted, which is exactly how 6.17.16 looks like "latest 6.x" at a glance.)

## 2 · Bound the reconnect loop

New `WHATSAPP_MAX_RECONNECT_ATTEMPTS` (default **20** ≈ 1 h of backoff; `0` = unlimited, preserving old behaviour).

The loop had no ceiling, so a refusal it could never recover from was retried forever. That is precisely the un-human-like pattern `docs/SECURITY.md`'s Baileys ToS section warns about, and it buried the problem under an endless warn stream that looked like progress. On exhaustion the adapter now logs **one actionable error** naming the fix and stays disconnected — so `health.ts`'s existing sustained-disconnect alert keeps nagging rather than the failure going quiet.

The **401 / loggedOut path is unchanged** and still never retries.

## Security / privacy impact

No RBAC, tool-gating, outbound-filtering or SQL-scoping change. Two things worth naming:

- **Sender identity resolution is untouched** — and the 6.17.16 attempt is exactly why that's called out: it would have silently changed how a LID sender's phone number is resolved. 6.7.24 keeps `senderPn`/`participantPn` and typechecks clean.
- **A new `SECURITY:` test** pins that a `401` close never schedules a reconnect. Retrying a revoked session is the variant of this most likely to attract a ban, and I did not want the new cap to become the thing that stops it. `tests/security-floor.json` updated (+1) in the same diff.

`docs/SECURITY.md`'s Baileys ToS section now documents the bound and the 405-vs-401 distinction.

## How verified

- **On the live host**: restart → `WhatsApp connected`, 1132 roster entries backfilled, **0** further 405s or reconnect schedules. Discord reconnected normally.
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run context:check` all clean on 6.7.24.
- WhatsApp-focused suites (`baileysAdapter`, `baileysReconnect`, `baileysReconnectCap`, `baileysReconnectLoggedOut`, `whatsappWire`): **105 tests, 0 failures**, with 6.7.24 actually installed (re-verified after a baseline run had reverted `node_modules`).
- Full suite: **2978 tests, 5 failures — all pre-existing.** Baseline on `main` at `7f9f9ee` is **6 failures** (verified by stashing): the four `memberDigest` ones are identical on both sides; the rest are the known no-local-Postgres flakes that vary run to run. None of the new tests failed and none of the failures relate to Baileys.
- New tests drive the real backoff with fake timers: every attempt inside the budget reconnects, the attempt past the cap builds no socket, no zombie timer revives the loop, `isConnected()` stays false so alerting continues, and a successful connect restores the full budget.

One structural note: the new tests are **one per file** because `t.mock.module` only affects *subsequent* imports — a second mocking test in the same file gets the first one's disposed mock from the module cache and builds no sockets. That's why `baileysReconnect.test.ts` only ever had one test.

## Deploy note

The running service is already healthy on 6.7.23 after the restart, so this is **not** an emergency deploy — but if 405s return, this is the fix. Deploy needs `npm ci` (lockfile changed). `.env` needs no edit: the new var has a default.

## Left alone deliberately

Four `memberDigest` tests fail on `main` right now, unrelated to this. Flagged, not fixed here.
