### PR TITLE
memberDigest tests: stub the deps that were silently hitting Postgres

### DIFF
--- a/tests/memberDigest.test.ts
+++ b/tests/memberDigest.test.ts
@@ -731,6 +731,10 @@ test('makeDefaultMemberDigestRun: an only-interests week (zero topics, zero new 
     getDigests: async () => [],
     getNewKnowledgeTitles: async () => [],
     getNewProjectCount: async () => 0,
+    // Un-injected deps fall through to the REAL repository (see
+    // buildMemberDigestContent's `deps.x ?? <repo fn>` defaults), so a missing
+    // stub here is a silent live-Postgres dependency, not a no-op.
+    getMemberTipCount: async () => 0,
     getNewInterestCount: async () => 4,
     recordSent: async () => {
       recordCalled = true;
@@ -761,6 +765,10 @@ test('makeDefaultMemberDigestRun: getNewInterestCount is called with the exact s
       interestSince = since;
       return 0;
     },
+    // Un-injected deps fall through to the REAL repository (see
+    // buildMemberDigestContent's `deps.x ?? <repo fn>` defaults), so a missing
+    // stub here is a silent live-Postgres dependency, not a no-op.
+    getMemberTipCount: async () => 0,
     recordSent: async () => {},
   });
   await runOnce();
@@ -1307,6 +1315,10 @@ test("buildMemberDigestContent: with injected deps, gathers, applies the two-flo
     getNewKnowledgeTitles: async () => ['Setting up MCP auth'],
     getNewProjectCount: async () => 1,
     getMemberTipCount: async () => 0,
+    // Un-injected deps fall through to the REAL repository (see
+    // buildMemberDigestContent's `deps.x ?? <repo fn>` defaults), so a missing
+    // stub here is a silent live-Postgres dependency, not a no-op.
+    getNewInterestCount: async () => 0,
   });
   assert.equal(
     message,
@@ -1320,6 +1332,7 @@ test('buildMemberDigestContent: every input empty renders null, same as formatMe
     getNewKnowledgeTitles: async () => [],
     getNewProjectCount: async () => 0,
     getMemberTipCount: async () => 0,
+    getNewInterestCount: async () => 0,
   });
   assert.equal(message, null);
 });


### PR DESCRIPTION
## Summary

Four tests in `tests/memberDigest.test.ts` fail for anyone without a local Postgres:

```
error: 'connect ECONNREFUSED 127.0.0.1:5432'
  async countAcceptedMemberKnowledgeTipsSince (src/storage/repository/knowledgeCandidates.ts:353)
  async Promise.all (index 4)
  async buildMemberDigestContent (src/memberDigest.ts:193)
```

They are **not** marked `{ skip }` and are not meant to be DB-backed — they are dep-injected unit tests. They reach the database because they miss an injection.

`buildMemberDigestContent` defaults every dep to a real repository function (`deps.getX ?? <repo fn>`), so an un-injected dep isn't a no-op, it's a **live query**. Two features each added a dep and stubbed only their own, producing a mirror-image gap:

| Tests | Injected | Missing → ran for real |
|---|---|---|
| `makeDefaultMemberDigestRun` (×2) | `getNewInterestCount` | `getMemberTipCount` → `countAcceptedMemberKnowledgeTipsSince` |
| `buildMemberDigestContent` (×2) | `getMemberTipCount` | `getNewInterestCount` → `countInterestsPublishedSince` |

## Why it matters beyond a red local suite

CI passes today **only because its Postgres answers those queries**. So these four tests carry a hidden live-DB dependency they never declared — they aren't testing what their names claim (injected-dep unit behaviour), and if the underlying query changed shape they'd fail somewhere confusing.

It also breaks a promise `CLAUDE.md` makes explicitly:

> DB-touching tests skip cleanly (not fail) when `DATABASE_URL` is unset, so a contributor without local Postgres isn't blocked.

These don't skip — they fail. (Ironically the dummy `DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test'` that test files set is what defeats the skip guard: it's *set*, just not reachable — the same trap `ci.yml`'s `security-invariants` job already documents in its "DATABASE_URL is intentionally UNSET" comment.)

## What changed

The four missing stubs, plus a short comment at each site explaining that an un-injected dep falls through to the real repository. The comment is deliberate: the failure mode is **silent** — CI stays green — so this will recur the next time a dep is added unless the reason is written down where the next author is looking.

Test-only. No `src/` change, no `SECURITY:` test added or removed, `tests/security-floor.json` untouched.

## How verified

- `tests/memberDigest.test.ts` in isolation: **67 tests, 0 failures** (was 4 failures, reproducing deterministically — not a flake).
- Full local suite: **6 failures → 3**. The remaining three (two WebSearch dedup `SECURITY:` tests, one repeat-question ordering test) are a **different class** — they pass **3/3 in isolation** and only fail under full-suite load, so they're load-sensitive rather than missing-stub. Not touched here; worth their own look.
- `npm run typecheck`, `npm run lint`, Prettier all clean.
- Explicitly checked for duplicate object keys after patching (my first attempt introduced one by matching a non-unique anchor): a script walks each `makeDefaultMemberDigestRun(...)` / `buildMemberDigestContent(...)` call block and counts repeated dep keys — clean.

## Not done here

`buildMemberDigestContent`'s "default to the real repository" shape is the underlying footgun: forgetting a stub is invisible in CI. A stricter test helper that fills unspecified deps with throwing stubs would turn that into a loud, immediate failure. That's a bigger change than this fix warrants, so I've left it — happy to follow up if you want it.
