### PR TITLE
Fix schema.sql migration wedge: one whatsapp_text_command row blocked all migrations

### DIFF
--- a/docs/agents/recipes.md
+++ b/docs/agents/recipes.md
@@ -97,6 +97,20 @@ unset is a silent breaking change for the running deployment.
 Run `npm run migrate` before `npm test` locally, or the DB tests fail with
 `relation does not exist` rather than skipping.
 
+**Widening an enum `CHECK` (a new `kind`, `status`, …):** edit the existing
+`DROP CONSTRAINT IF EXISTS` / `ADD CONSTRAINT` pair's value list **in place**.
+Never append a second pair for the same constraint name. `migrate()` replays the
+entire file as one multi-statement query, so both pairs run in order on every
+future migration; the earlier, narrower one is validated against live rows, and
+a single row using a value only the later pair allows aborts it — rolling back
+the whole migration. This is not theoretical: stacked
+`shortcut_hits_kind_check` pairs meant one WhatsApp `!`-command hit blocked
+every subsequent migration. **CI cannot catch it** (it always starts from an
+empty database), so `tests/schemaConstraintIdempotency.test.ts` guards it
+statically. Note `ADD CONSTRAINT` has no `IF NOT EXISTS` form — the preceding
+`DROP ... IF EXISTS` is what makes it re-runnable, and that test checks each
+one has it.
+
 ---
 
 ## Add a background job

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -924,24 +924,29 @@ CREATE TABLE IF NOT EXISTS shortcut_hits (
 CREATE INDEX IF NOT EXISTS shortcut_hits_created_at_idx
   ON shortcut_hits (created_at DESC);
 
--- Widens the kind enum to also cover the Discord slash commands (issue #744)
--- as a fifth, aggregate cost-avoidance kind — they are an equally real
--- zero-`query()`-call shortcut that #744 itself deferred tracking (issue
--- #863). Same idempotent DROP CONSTRAINT IF EXISTS / re-add convention as
--- member_projects above, safe to re-run against a table that already holds
--- rows for the original four kinds.
-ALTER TABLE shortcut_hits DROP CONSTRAINT IF EXISTS shortcut_hits_kind_check;
-ALTER TABLE shortcut_hits ADD CONSTRAINT shortcut_hits_kind_check
-  CHECK (kind IN ('ack', 'knowledge', 'repeat_question', 'repeat_max_turns', 'slash_command'));
-
--- Widens the kind enum again to cover WhatsApp's `!`-prefixed text commands
--- (issue #859) as a sixth kind — the WhatsApp counterpart to Discord's
--- slash_command above, and the same class of gap #863 closed for Discord
--- (issue #874). A distinct kind rather than reusing `slash_command`: that
--- value is documented as Discord-specific, so folding WhatsApp hits into it
--- would misname the mechanism and corrupt any per-kind analysis. Same
--- idempotent DROP CONSTRAINT IF EXISTS / re-add convention, safe to re-run
--- against a table that already holds rows for the original five kinds.
+-- Widens the kind enum beyond the four the CREATE TABLE above pins:
+--  - 'slash_command'         Discord slash commands (issues #744, #863) — an
+--                            equally real zero-`query()`-call shortcut.
+--  - 'whatsapp_text_command' WhatsApp's `!`-prefixed text commands (issues
+--                            #859, #874) — the WhatsApp counterpart. A
+--                            distinct kind rather than reusing
+--                            'slash_command': that value is documented as
+--                            Discord-specific, so folding WhatsApp hits into
+--                            it would misname the mechanism and corrupt any
+--                            per-kind analysis.
+--
+-- ONE drop/re-add pair, listing every kind. When you add a kind, EDIT the list
+-- below — never append a second DROP/ADD pair for this same constraint name.
+-- migrate() replays this whole file as a single multi-statement query on every
+-- run, so two pairs execute in order: the earlier, NARROWER one runs against
+-- live data and `ALTER TABLE ... ADD CONSTRAINT` validates existing rows, so a
+-- single row holding a kind that only the LATER pair allows aborts the
+-- statement — and because it is one query, the entire migration rolls back.
+-- That is not hypothetical: stacking these two pairs meant one
+-- 'whatsapp_text_command' row blocked every subsequent migration, with CI blind
+-- to it because CI always starts from an empty database. See
+-- tests/schemaConstraintIdempotency.test.ts, which fails if a constraint name
+-- is re-added more than once anywhere in this file.
 ALTER TABLE shortcut_hits DROP CONSTRAINT IF EXISTS shortcut_hits_kind_check;
 ALTER TABLE shortcut_hits ADD CONSTRAINT shortcut_hits_kind_check
   CHECK (kind IN ('ack', 'knowledge', 'repeat_question', 'repeat_max_turns', 'slash_command', 'whatsapp_text_command'));
@@ -1005,9 +1010,12 @@ ALTER TABLE knowledge_candidates ADD COLUMN IF NOT EXISTS knowledge_id BIGINT RE
 -- 'withdrawn' status already gives report filers. Non-destructive (the row
 -- is kept, never deleted) and distinct from an admin-initiated 'declined',
 -- same rationale as content_reports' own 'withdrawn' vs. 'dismissed' split.
--- Same idempotent DROP CONSTRAINT IF EXISTS / re-add convention as
--- shortcut_hits.kind above, safe to re-run against a table that already
--- holds rows in the original three statuses.
+-- Same single-pair DROP CONSTRAINT IF EXISTS / re-add convention as
+-- shortcut_hits.kind above, safe to re-run against a table already holding
+-- rows in any listed status. As there: to add a status, EDIT the list below
+-- rather than appending a second pair for this constraint name — a narrower
+-- earlier pair would abort the whole replayed migration once a row uses a
+-- status only the later pair allows.
 ALTER TABLE knowledge_candidates DROP CONSTRAINT IF EXISTS knowledge_candidates_status_check;
 ALTER TABLE knowledge_candidates ADD CONSTRAINT knowledge_candidates_status_check
   CHECK (status IN ('pending', 'accepted', 'declined', 'withdrawn'));

--- a/tests/schemaConstraintIdempotency.test.ts
+++ b/tests/schemaConstraintIdempotency.test.ts
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/**
+ * `migrate()` replays ALL of schema.sql as a SINGLE multi-statement query on
+ * every run (`pool.query(sql)` — there is no `schema_migrations` ledger, so
+ * nothing is ever skipped). Two consequences make this file's shape a
+ * correctness concern rather than a style one:
+ *
+ *  1. Statements execute in file order against LIVE data, and
+ *     `ALTER TABLE ... ADD CONSTRAINT` validates every existing row.
+ *  2. It is one query, so any failure rolls back the WHOLE migration — no
+ *     schema change lands at all.
+ *
+ * So if a constraint name gets a second DROP/ADD pair appended to widen an
+ * enum, the earlier, NARROWER pair still runs first on every future migration.
+ * One row holding a value only the later pair allows makes that earlier
+ * statement abort, and the whole migration fails from then on.
+ *
+ * That happened: `shortcut_hits_kind_check` had stacked pairs (a 5-kind one
+ * followed by a 6-kind one adding 'whatsapp_text_command'), so a single
+ * WhatsApp `!`-command hit — which issue #874 records in production — was
+ * enough to block every subsequent migration permanently.
+ *
+ * CI cannot catch that: it provisions an empty pgvector container per run, so
+ * `npm run migrate` there only ever exercises the fresh-database path, where
+ * stacked pairs are harmless. This test guards the invariant statically
+ * instead.
+ *
+ * Deliberately static (parses the SQL) rather than migrating a live DB twice
+ * with data present, which would reproduce it more directly but is the wrong
+ * trade here: it would need DDL locks and `shortcut_hits` rows in a suite whose
+ * FILES run in parallel, and `tests/repository.test.ts` asserts on a *global*
+ * `shortcutHits.total` delta — so a live version of this test would redden an
+ * unrelated file. Guarding the cause costs nothing and cannot flake.
+ */
+const schema = readFileSync(new URL('../src/storage/schema.sql', import.meta.url), 'utf8');
+
+test('schema.sql: no constraint name is ever re-added more than once (migrate() replays the whole file, so a stacked narrower pair breaks every future migration)', () => {
+  // Matches `ADD CONSTRAINT <name>` across newlines/extra whitespace, which is
+  // how these are actually written (name on the ALTER line, CHECK indented on
+  // the next).
+  const addedNames = [...schema.matchAll(/ADD\s+CONSTRAINT\s+([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]);
+
+  const seen = new Map<string, number>();
+  for (const name of addedNames) seen.set(name, (seen.get(name) ?? 0) + 1);
+  const duplicated = [...seen.entries()].filter(([, count]) => count > 1);
+
+  assert.deepEqual(
+    duplicated,
+    [],
+    `schema.sql re-adds these constraint names more than once: ${duplicated
+      .map(([name, count]) => `${name} (${count}x)`)
+      .join(', ')}. Widen the EXISTING pair's list in place instead of appending ` +
+      'a new DROP/ADD pair — the earlier, narrower one still runs on every ' +
+      'replay and will abort the whole migration once a row uses a value only ' +
+      'the later pair allows.',
+  );
+});
+
+test('schema.sql: every constraint re-add is preceded by its own DROP CONSTRAINT IF EXISTS (so a replay cannot fail on "already exists")', () => {
+  const names = [...schema.matchAll(/ADD\s+CONSTRAINT\s+([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]);
+  const dropped = new Set(
+    [...schema.matchAll(/DROP\s+CONSTRAINT\s+IF\s+EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]),
+  );
+
+  const missingDrop = names.filter((n) => !dropped.has(n));
+  assert.deepEqual(
+    missingDrop,
+    [],
+    `these constraints are added without a preceding DROP CONSTRAINT IF EXISTS: ${missingDrop.join(', ')}. ` +
+      'Unlike CREATE TABLE/INDEX, ADD CONSTRAINT has no IF NOT EXISTS form, so a bare ' +
+      'ADD fails on the second migrate() run.',
+  );
+});
+
+test('schema.sql: shortcut_hits_kind_check permits every ShortcutKind, in one pair (regression: issue #874 row blocked all migrations)', () => {
+  const pairs = [
+    ...schema.matchAll(/ADD\s+CONSTRAINT\s+shortcut_hits_kind_check\s*\n?\s*CHECK\s*\([^)]*\)/g),
+  ];
+  assert.equal(pairs.length, 1, 'exactly one shortcut_hits_kind_check re-add is expected');
+
+  // Derived from the `ShortcutKind` union rather than hardcoded here, so adding
+  // a 7th kind to the type without widening the constraint fails THIS test
+  // instead of failing at runtime on the first real insert.
+  const kindSource = readFileSync(
+    new URL('../src/storage/repository/shortcutHits.ts', import.meta.url),
+    'utf8',
+  );
+  const union = /export type ShortcutKind =([\s\S]*?);/.exec(kindSource);
+  assert.ok(union, 'could not locate the ShortcutKind union — update this test if it moved');
+  const kinds = [...union[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+  assert.ok(kinds.length >= 6, `expected to parse the ShortcutKind members, got ${kinds.length}`);
+
+  for (const kind of kinds) {
+    assert.match(pairs[0][0], new RegExp(`'${kind}'`), `shortcut_hits_kind_check must permit '${kind}'`);
+  }
+});


### PR DESCRIPTION
## Summary

**`main` today cannot migrate a production database that has recorded a single WhatsApp `!`-command hit.** This fixes that.

`migrate()` replays **all** of `schema.sql` as one multi-statement `pool.query()` on every run — there is no `schema_migrations` ledger, so nothing is ever skipped. `shortcut_hits_kind_check` had **two stacked** `DROP`/`ADD` pairs: a 5-kind one (adding `slash_command`, #863), then a 6-kind one (adding `whatsapp_text_command`, #874).

Both execute in file order on every migration, and `ALTER TABLE … ADD CONSTRAINT` validates existing rows. So once one `whatsapp_text_command` row exists, the earlier 5-kind statement aborts — and because it is a single query, **the entire migration rolls back**. From that point on, no schema change can ever land.

That row isn't hypothetical: #874 records exactly that kind in production.

**Why CI never caught it:** CI provisions an empty `pgvector` container per run, so `npm run migrate` there only ever exercises the fresh-database path, where stacked pairs are harmless. The bug is invisible to every gate we have.

**The fix:** collapse the two pairs into one listing all six kinds. The final schema state is byte-for-byte identical — only the redundant, actively harmful intermediate statement is gone.

### Fixing the cause, not just the instance

The old comments taught the broken convention verbatim — *"Same idempotent DROP CONSTRAINT IF EXISTS / re-add convention"* — which is how the second pair came to be appended in the first place, and which `knowledge_candidates_status_check` (#895) then copied. That one is safe **today only because it is still the sole pair for its constraint**; the next widening would reproduce this exact outage. Both comment blocks now say to edit the existing list in place, and explain why.

Also adds the rule to `docs/agents/recipes.md` under "Touch the database", since "add a new `kind`/`status`" is precisely the recipe that caused this.

### New regression test

`tests/schemaConstraintIdempotency.test.ts` fails if:
1. any constraint name is re-added more than once (the bug);
2. a re-add lacks its preceding `DROP … IF EXISTS` (that statement has no `IF NOT EXISTS` form, so it's what makes a replay safe at all);
3. `shortcut_hits_kind_check` stops covering every `ShortcutKind`.

The kind list is **parsed from the `ShortcutKind` union**, not hardcoded, so adding a 7th kind without widening the constraint fails this test rather than failing at runtime on the first real insert.

Deliberately **static** (parses the SQL) rather than migrating a live DB twice with data. That would reproduce it more directly, but it would need DDL locks and `shortcut_hits` rows in a suite whose *files* run in parallel — and `tests/repository.test.ts` asserts on a **global** `shortcutHits.total` delta, so a live version of this test would redden an unrelated file. Guarding the cause costs nothing and cannot flake.

## Security / privacy impact

**None.** No change to auth, tool gating, tier derivation, outbound filtering, CONFIRM-gating, SQL conversation scoping, or any stored value.

- No table, column, index, or data change. The only SQL change **removes** a statement; the resulting constraint definition is identical (verified via `pg_get_constraintdef` after migrating).
- No RBAC or tool-surface change. `SECURITY:` test count unchanged (1172 across 149 files), so `tests/security-floor.json` correctly needs no edit; the new test file declares no `SECURITY:` tests.
- Worth noting the *security* upside: while wedged, **no migration can land at all** — including one carrying a security fix. Restoring migrations restores that path.

## How verified

Against a real **Postgres 16 + pgvector**, in both directions — reproduction and recovery:

**Reproduce (pre-fix schema):**
1. fresh DB → `npm run migrate` → ✅
2. `INSERT INTO shortcut_hits (kind) VALUES ('whatsapp_text_command');`
3. `npm run migrate` → ❌ `check constraint "shortcut_hits_kind_check" … is violated by some row`

**Recover (this PR's schema, onto that same wedged database):**
4. `npm run migrate` → ✅
5. `npm run migrate` again → ✅ (idempotent)
6. row preserved; final constraint contains all six kinds

So this **un-wedges an already-broken database on the next deploy**, with no manual intervention or data loss.

**The test was verified to actually catch the bug**, not just to pass:
- against the pre-fix `schema.sql` → fails (2 of 3 tests)
- with a fake 7th kind added to the `ShortcutKind` type only → fails with `shortcut_hits_kind_check must permit 'brand_new_kind'`
- restored → passes

| Gate | Result |
|---|---|
| `npm run typecheck` (incl. `typecheck:tests`) | clean |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run migrate` | clean |
| `npm test` | 3162 pass / 0 fail |
| `npm run test:security` | 1172 across 149 files |
| `npm run build` | clean |
| `npm run context:check` | 41 paths, 52 entries |

---

**Follow-up, not in this PR:** the underlying fragility is audit item **L13** — no `schema_migrations` ledger, so every statement replays forever and any non-idempotent statement is a latent wedge. This PR removes the live instance and guards the specific class; a real migration ledger is the structural fix and wants its own discussion.

---
_Generated by [Claude Code](https://claude.ai/code/session_019B8WC3ksmJrDbczjRK9584)_