### PR TITLE
Address #900 review nits: robust constraint regex + add the test to the typecheck ratchet

### DIFF
--- a/tests/schemaConstraintIdempotency.test.ts
+++ b/tests/schemaConstraintIdempotency.test.ts
@@ -76,10 +76,14 @@ test('schema.sql: every constraint re-add is preceded by its own DROP CONSTRAINT
 });
 
 test('schema.sql: shortcut_hits_kind_check permits every ShortcutKind, in one pair (regression: issue #874 row blocked all migrations)', () => {
-  const pairs = [
-    ...schema.matchAll(/ADD\s+CONSTRAINT\s+shortcut_hits_kind_check\s*\n?\s*CHECK\s*\([^)]*\)/g),
-  ];
+  // Matched to the statement terminator rather than to a closing paren: a
+  // `CHECK (kind IN (...))` has NESTED parens, so a `\([^)]*\)` pattern stops at
+  // the inner `IN (` list's paren and silently examines only part of the clause.
+  // That happened to cover every literal here, but it would quietly stop doing
+  // so if the clause shape ever changed (PR #900 review).
+  const pairs = [...schema.matchAll(/ADD\s+CONSTRAINT\s+shortcut_hits_kind_check[\s\S]*?;/g)];
   assert.equal(pairs.length, 1, 'exactly one shortcut_hits_kind_check re-add is expected');
+  assert.match(pairs[0][0], /\)\s*\)\s*;$/, 'the whole CHECK (... IN (...)) clause should be captured');
 
   // Derived from the `ShortcutKind` union rather than hardcoded here, so adding
   // a 7th kind to the type without widening the constraint fails THIS test

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -28,6 +28,7 @@
     "src/**/*.ts",
     "tests/backgroundJobCostAlert.test.ts",
     "tests/memberDigest.test.ts",
+    "tests/schemaConstraintIdempotency.test.ts",
     "tests/usageCostDigest.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Two follow-ups from #900's automated review. #900 merged before these were pushed, so they land separately. **Test-side only** — no `src/` or `schema.sql` change, and no behaviour change.

**1. The constraint regex under-matched.** `tests/schemaConstraintIdempotency.test.ts` matched the clause with `CHECK\s*\([^)]*\)`. A `CHECK (kind IN (...))` has **nested** parens, so `[^)]*` stops at the inner `IN (` list's closing paren, and the assertion only ever examined part of the clause.

I confirmed this empirically rather than taking it on faith — the match ended at `...'whatsapp_text_command')` and never included the statement's `;`:

```
matched text ends with: ..."slash_command', 'whatsapp_text_command')"
includes final `;`? false
```

Harmless today, because every kind literal happens to sit inside that inner list. But it would have silently stopped checking if the clause shape ever changed — a test that looks like coverage without fully being it, which is worse than no test. Now matched to the statement terminator, with an added assertion that the full `CHECK (... IN (...))` clause really was captured, so the pattern can't quietly under-match again.

**2. The test file was outside the typecheck ratchet.** It was created in #900 and never added to `tsconfig.tests.json`'s `include`. That's the exact miss the ratchet exists to prevent — `CLAUDE.md` calls bringing a file in "the unit of progress," and this one is type-clean, so it goes in now rather than accruing drift outside the net. Added in alphabetical position, per the one-per-line convention that keeps concurrent PRs in separate hunks.

Credit where due: both were flagged by the automated reviewer on #900, and both were right.

## Security / privacy impact

**None.** No `src/`, schema, or SQL change of any kind.

- No change to auth, tool gating, tier derivation, outbound filtering, CONFIRM-gating, SQL conversation scoping, or stored data. No RBAC, table, migration, or config change.
- The diff is two files: a test assertion made stricter, and one line added to a tsconfig `include` list.
- `SECURITY:` test count unchanged (1172 across 149 files), so `tests/security-floor.json` correctly needs no edit — this file declares no `SECURITY:` tests.
- Mild security-adjacent upside: the strengthened assertion means the guard protecting migrations from wedging (and a wedged migration blocks *all* future schema changes, including a security fix) can no longer silently degrade.

## How verified

Against merged `main` (`8779413`), with a real Postgres 16 + pgvector available:

| Gate | Result |
|---|---|
| `tests/schemaConstraintIdempotency.test.ts` | 3 pass / 0 fail |
| `npm run typecheck` (incl. `typecheck:tests`, **now covering this file**) | clean |
| `npm run lint` | clean |
| `npm run format:check` | clean |

`npm test` (3162 pass) and `npm run test:security` (1172 across 149 files) were green on this exact content before rebasing onto merged `main`; the rebase changed no file in this diff.

**Re-verified the drift guard still fires after the regex change** — this mattered, because a stricter match could have broken the very check it protects. Adding a fake 7th kind to the `ShortcutKind` union alone still fails with:

```
error: "shortcut_hits_kind_check must permit 'brand_new_kind'"
```

Typecheck passing with the file inside `tsconfig.tests.json` is itself the proof it's type-clean under the strict config — that's not asserted, it's enforced.

---

**Still outstanding, not in this PR:** audit **L13** — no `schema_migrations` ledger, the structural cause of the wedge class #900 fixed an instance of (every statement replays forever, so any non-idempotent statement is a latent wedge). Wants its own discussion. Also `#896`/`#899`/`#900` still need adding to `CHANGELOG.md`'s internal skip ledger.

---
_Generated by [Claude Code](https://claude.ai/code/session_019B8WC3ksmJrDbczjRK9584)_