### PR TITLE
Refuse WhatsApp LIDs as member ids (2026-08-01 phantom-member incident)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 -->
 
 
+## 2026-08-01
+
+### Fixed
+- **Members added by a WhatsApp "LID" are now refused instead of silently
+  failing.** WhatsApp gives each person a phone number *and* a privacy id
+  ("LID"). A LID looks like a long phone number, so one could be accepted as a
+  member id — but the bot only ever recognises people by phone number, so such
+  members were never actually recognised: they stayed gated guests while
+  appearing in the member list. Adding someone with a LID now fails with a clear
+  message saying to use their phone number instead. Four affected entries were
+  cleaned up; nobody lost real access.
+
 ## 2026-07-31
 
 ### Added

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1692,6 +1692,41 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
   them, so an aggregate over exactly those conversations exposes nothing they
   couldn't already read directly.
 
+### 6b. WhatsApp LIDs must never become member ids (2026-08-01 incident)
+
+WhatsApp exposes two identifiers for the same person: the **phone number**
+(E.164) and a **LID** (`<digits>@lid`, a privacy id). Only the phone number is a
+usable identity here — `resolveSenderId` resolves LID → phone via `senderPn`
+on every inbound message, so `community_users` lookups, RBAC and project
+membership all match on the phone number. A LID matches nothing.
+
+Strip `@lid` and a LID is just digits, so it used to pass `normalizeMemberId`'s
+old 7-15 digit E.164 check. Four members were created that way (2026-07-21,
+×2 on 2026-07-27, 2026-08-01) and were **permanently unmatchable**: they stayed
+gated guests while appearing in `community_users` as members. One went
+unnoticed for 11 days; another surfaced only when a project-membership check
+failed. The supply of LIDs is not hypothetical — `server_roster` for WhatsApp
+is LID-keyed (820 of 850 entries were 14-15 digits, because group participant
+metadata gives LIDs and nothing else), and `list_roster` exposes it to the
+model, so "add this person" naturally picks one up.
+
+`normalizeMemberId` now caps a WhatsApp id at **13 digits**
+(`MAX_WHATSAPP_ID_DIGITS`), below E.164's 15, because that is where the two
+populations separate in practice: real member numbers observed here are 10-12
+digits, every observed LID is 14-15. A 14+ digit id is refused as **ambiguous**
+with an actionable message. The deliberate cost is that a genuine 14-15 digit
+E.164 number is also refused; that is preferred to silently minting an identity
+that can never be matched — and that could be *messaged*, since `targetJid`
+routes a phone-shaped id to `<id>@s.whatsapp.net`, which for LID digits may be
+an unrelated real person's number. Pinned by `SECURITY:` tests using the four
+real ids from the incident.
+
+`isPhoneUserId` (5-16 digits) was deliberately **left unchanged**: it gates live
+routing (DM send, moderation actions, revoke authorship), so tightening it could
+silently stop serving an existing member with a long number. With the add-time
+gate closed and the phantom rows removed, no LID reaches it — a LID-only sender
+is already marked `lid:`-prefixed by `lidFallbackId` and rejected there.
+
 ### 7. Cross-platform identity linking (`link_member` / `unlink_member`)
 A member's Discord account and WhatsApp number are, by default, two unrelated
 `community_users` rows — `forget_me` on one silently leaves the other's data

--- a/src/auth/memberId.ts
+++ b/src/auth/memberId.ts
@@ -31,7 +31,8 @@ export const MAX_WHATSAPP_ID_DIGITS = 13;
  * leading '+', requires an all-digit id, and range-checks the length by
  * platform. Throws with an actionable message (pointing at the `platform`
  * argument) on a mismatch — Discord snowflakes are 17-20 digits, WhatsApp
- * E.164 numbers are 7-15.
+ * numbers are 7-{@link MAX_WHATSAPP_ID_DIGITS} (deliberately tighter than
+ * E.164's 15 — see that constant).
  */
 export function normalizeMemberId(platform: Platform, rawId: string): string {
   const id = rawId.trim().replace(/^\+/, '');
@@ -47,17 +48,31 @@ export function normalizeMemberId(platform: Platform, rawId: string): string {
         `If this is a WhatsApp number, pass platform: "whatsapp".`,
     );
   }
-  if (platform === 'whatsapp' && (id.length < 7 || id.length > MAX_WHATSAPP_ID_DIGITS)) {
-    // 14+ digits is refused as AMBIGUOUS, not merely malformed: that is the
-    // length band WhatsApp LIDs occupy, and a LID is indistinguishable from an
-    // E.164 number once the `@lid` suffix is stripped. See the constant below.
+  // The two out-of-range WhatsApp cases are deliberately SEPARATE, because they
+  // have different causes and so need different advice. Folding them together
+  // told an admin who fat-fingered a 5-digit id that it was "probably a LID
+  // copied from the roster" — a confident, wrong diagnosis, in exactly the
+  // situation this validation exists to make less confusing.
+  if (platform === 'whatsapp' && id.length > MAX_WHATSAPP_ID_DIGITS) {
+    // TOO LONG: refused as AMBIGUOUS rather than merely malformed. 14+ digits
+    // is the band WhatsApp LIDs occupy, and a LID is indistinguishable from an
+    // E.164 number once the `@lid` suffix is stripped. See the constant above.
     throw new Error(
       `"${rawId}" doesn't look like a WhatsApp number (expected 7-${MAX_WHATSAPP_ID_DIGITS} digits, ` +
-        `E.164 without +). If this is a Discord id, pass platform: "discord". ` +
+        `E.164 without +) — it is too long. If this is a Discord id, pass platform: "discord". ` +
         `If you copied it from the roster or a group listing, it is probably a WhatsApp LID ` +
         `(a privacy id), NOT a phone number — a member added under a LID can never be matched to ` +
         `a real sender, because inbound messages always resolve to the phone number. Use the ` +
         `person's actual phone number in E.164 form.`,
+    );
+  }
+  if (platform === 'whatsapp' && id.length < 7) {
+    // TOO SHORT: an ordinary typo — a partial number, or one missing its
+    // country code. Deliberately says nothing about LIDs, which are long.
+    throw new Error(
+      `"${rawId}" doesn't look like a WhatsApp number (expected 7-${MAX_WHATSAPP_ID_DIGITS} digits, ` +
+        `E.164 without +) — it is too short. Check for a missing country code (e.g. NZ 021 234 5678 -> 6421234567) ` +
+        `or a truncated number.`,
     );
   }
   return id;

--- a/src/auth/memberId.ts
+++ b/src/auth/memberId.ts
@@ -1,6 +1,31 @@
 import type { Platform } from '../platforms/types.js';
 
 /**
+ * Upper bound on a WhatsApp member id, deliberately BELOW E.164's 15-digit
+ * maximum.
+ *
+ * WhatsApp LIDs (privacy ids, the `<digits>@lid` form) occupy the 14-16 digit
+ * band, and once the `@lid` suffix is stripped a LID is just digits —
+ * indistinguishable from a long phone number. Accepting that band let four
+ * phantom members be created on 2026-07-21/27 and 2026-08-01: an admin (or the
+ * model, reading `list_roster`, which is LID-keyed) supplied a LID, it passed
+ * validation as a "number", and the row could never match a real sender —
+ * inbound messages always resolve LID -> phone via `senderPn`, so the stored
+ * identity was unreachable. The members silently stayed gated guests, and one
+ * of them broke a project-membership check months later.
+ *
+ * 13 is the cut because it separates the two populations cleanly in practice:
+ * every real member number observed here is 10-12 digits, while every observed
+ * LID is 14-15 (820 of 850 roster entries). The residual cost is that a genuine
+ * 14-15 digit E.164 number is refused; that is the deliberate trade. Refusing an
+ * ambiguous id LOUDLY, with an actionable message, beats silently minting an
+ * identity that can never be matched or safely messaged — `targetJid` would
+ * route those digits to `<id>@s.whatsapp.net`, i.e. potentially a real but
+ * unrelated person's number.
+ */
+export const MAX_WHATSAPP_ID_DIGITS = 13;
+
+/**
  * Validate and normalize a membership target id for a platform, so a WhatsApp
  * number can't be silently filed as a Discord user (issue #78). Strips a
  * leading '+', requires an all-digit id, and range-checks the length by
@@ -22,10 +47,17 @@ export function normalizeMemberId(platform: Platform, rawId: string): string {
         `If this is a WhatsApp number, pass platform: "whatsapp".`,
     );
   }
-  if (platform === 'whatsapp' && (id.length < 7 || id.length > 15)) {
+  if (platform === 'whatsapp' && (id.length < 7 || id.length > MAX_WHATSAPP_ID_DIGITS)) {
+    // 14+ digits is refused as AMBIGUOUS, not merely malformed: that is the
+    // length band WhatsApp LIDs occupy, and a LID is indistinguishable from an
+    // E.164 number once the `@lid` suffix is stripped. See the constant below.
     throw new Error(
-      `"${rawId}" doesn't look like a WhatsApp number (expected 7-15 digits, E.164 without +). ` +
-        `If this is a Discord id, pass platform: "discord".`,
+      `"${rawId}" doesn't look like a WhatsApp number (expected 7-${MAX_WHATSAPP_ID_DIGITS} digits, ` +
+        `E.164 without +). If this is a Discord id, pass platform: "discord". ` +
+        `If you copied it from the roster or a group listing, it is probably a WhatsApp LID ` +
+        `(a privacy id), NOT a phone number — a member added under a LID can never be matched to ` +
+        `a real sender, because inbound messages always resolve to the phone number. Use the ` +
+        `person's actual phone number in E.164 form.`,
     );
   }
   return id;

--- a/tests/memberId.test.ts
+++ b/tests/memberId.test.ts
@@ -30,3 +30,39 @@ test('rejects non-numeric ids', () => {
   assert.throws(() => normalizeMemberId('whatsapp', 'not-a-number'), /expected digits only/);
   assert.throws(() => normalizeMemberId('discord', '1234abcd'), /expected digits only/);
 });
+
+// --- WhatsApp LID rejection (the 2026-08-01 phantom-member incident) --------
+// A WhatsApp LID (privacy id) is just digits once `@lid` is stripped, so it
+// used to pass as an E.164 number. Four members were created that way and were
+// permanently unmatchable: inbound messages always resolve LID -> phone via
+// `senderPn`, so nothing ever equalled the stored id. One of them (Angela
+// Donald, added 2026-07-21) sat as a gated guest for 11 days; another broke a
+// project-membership check on 2026-08-01.
+
+test('SECURITY: a WhatsApp LID is refused as a member id — it can never match a real sender, and routing it as a phone JID could reach an unrelated number', () => {
+  // The four ids actually created in production by this bug.
+  for (const lid of ['205995875803153', '177983595790491', '132822417318087', '89455629213795']) {
+    assert.throws(
+      () => normalizeMemberId('whatsapp', lid),
+      /probably a WhatsApp LID/,
+      `${lid} (a real LID from the incident) must be refused`,
+    );
+  }
+});
+
+test('the LID rejection message is actionable — it names the cause and what to supply instead', () => {
+  assert.throws(
+    () => normalizeMemberId('whatsapp', '205995875803153'),
+    /roster or a group listing.*actual phone number in E\.164 form/s,
+  );
+});
+
+test('every real member number in production still validates — the LID bound must not cost a legitimate add', () => {
+  // The five genuine WhatsApp members left after the phantom rows were removed.
+  for (const phone of ['64272480362', '64273938855', '6421807830', '642041824635', '64220608616']) {
+    assert.equal(normalizeMemberId('whatsapp', phone), phone);
+  }
+  // Boundary: 13 digits is the last accepted length, 14 is the first refused.
+  assert.equal(normalizeMemberId('whatsapp', '1234567890123'), '1234567890123');
+  assert.throws(() => normalizeMemberId('whatsapp', '12345678901234'), /probably a WhatsApp LID/);
+});

--- a/tests/memberId.test.ts
+++ b/tests/memberId.test.ts
@@ -66,3 +66,31 @@ test('every real member number in production still validates — the LID bound m
   assert.equal(normalizeMemberId('whatsapp', '1234567890123'), '1234567890123');
   assert.throws(() => normalizeMemberId('whatsapp', '12345678901234'), /probably a WhatsApp LID/);
 });
+
+test('a too-SHORT WhatsApp id is diagnosed as a typo, never as a LID (PR #934 review)', () => {
+  // Regression: the too-short and too-long branches were one condition, so a
+  // 5-digit typo was told it was "probably a WhatsApp LID copied from the
+  // roster" — a confident wrong answer during exactly the confusion this
+  // validation exists to reduce. LIDs are long (14-15 digits); a short id
+  // cannot be one.
+  for (const short of ['12345', '123456', '1']) {
+    assert.throws(() => normalizeMemberId('whatsapp', short), /it is too short/);
+    assert.throws(() => normalizeMemberId('whatsapp', short), /missing country code|truncated/);
+    // The LID diagnosis must NOT appear.
+    try {
+      normalizeMemberId('whatsapp', short);
+      assert.fail(`${short} should have been rejected`);
+    } catch (err) {
+      assert.doesNotMatch(
+        (err as Error).message,
+        /LID|roster|group listing/,
+        `a too-short id must not be blamed on a LID (got: ${(err as Error).message})`,
+      );
+    }
+  }
+});
+
+test('the too-LONG branch keeps its LID diagnosis, and the two messages stay distinct', () => {
+  assert.throws(() => normalizeMemberId('whatsapp', '205995875803153'), /it is too long/);
+  assert.throws(() => normalizeMemberId('whatsapp', '205995875803153'), /probably a WhatsApp LID/);
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -102,6 +102,7 @@
   "linkCheck.test.ts": 13,
   "lowRatedCaveatRouter.test.ts": 4,
   "memberDigest.test.ts": 18,
+  "memberId.test.ts": 1,
   "modelAndPlanSelectionSkill.test.ts": 1,
   "modelUsageRouter.test.ts": 2,
   "moderation.test.ts": 15,


### PR DESCRIPTION
## Summary

Chris tested the new `projects` feature over WhatsApp and Dave reported it couldn't see him as a member of a project he'd just been added to — both the add and the bind having reported success.

**Root cause is not in `projects`.** WhatsApp identifies a person two ways: an E.164 **phone number** and a **LID** (`<digits>@lid`, a privacy id). Only the phone number is a usable identity here — `resolveSenderId` resolves LID → phone via `senderPn` on every inbound message, so `community_users`, RBAC and project membership all match on the phone number. A LID matches nothing.

Strip `@lid` and a LID is just digits, so it passed `normalizeMemberId`'s 7–15 digit E.164 check.

## Evidence from production

Four members had been created under LIDs and were **permanently unmatchable** — they appeared in the member list while remaining gated guests:

| id | who | created | consequence |
|---|---|---|---|
| `177983595790491` | Angela Donald | 2026-07-21 | guest for **11 days** while listed as a member |
| `132822417318087` | (unnamed) | 2026-07-27 | inert |
| `89455629213795` | (unnamed) | 2026-07-27 | inert |
| `205995875803153` | Chris Watson | 2026-08-01 | broke the project-membership check |

Confirmed decisively: **no `lid:`-prefixed or bare-LID identity has ever appeared in `interactions`** — every real sender resolves to a phone number. So those rows could never match.

The supply of LIDs is not hypothetical: `server_roster` for WhatsApp is LID-keyed — **820 of 850 entries were 14–15 digits**, because group participant metadata gives LIDs and nothing else — and `list_roster` exposes it to the model. "Add this person" naturally picks one up.

## The fix

`normalizeMemberId` caps a WhatsApp id at **13 digits** (`MAX_WHATSAPP_ID_DIGITS`), below E.164's 15, because that is where the two populations separate in practice: every real member number observed here is 10–12 digits, every observed LID is 14–15. A 14+ digit id is refused as **ambiguous**, with a message naming the likely cause and what to supply instead.

**The deliberate cost:** a genuine 14–15 digit E.164 number is refused too. That is preferred to silently minting an identity that can never be matched — and that could be **messaged**: `targetJid` routes a phone-shaped id to `<id>@s.whatsapp.net`, which for LID digits may be an unrelated real person's number. `targetJid`'s own comment warns about exactly this ("LID digits routed as a phone JID could hit an unrelated real number") while `isPhoneUserId` (`/^\d{5,16}$/`) does not actually catch it.

## Security / privacy impact

Tightens an identity-admission gate; grants nothing new.

- **`isPhoneUserId` deliberately left unchanged.** It gates *live routing* — DM send, moderation actions, revoke authorship — so tightening it could silently stop serving an existing member with a long number. With the add-time gate closed and the phantom rows removed, no LID reaches it: a LID-only sender is already `lid:`-prefixed by `lidFallbackId` and rejected there. Stated explicitly in `docs/SECURITY.md` §6b so the omission reads as a decision, not an oversight.
- New `SECURITY:` test uses **the four real ids from the incident**, plus an assertion that every real production member number still validates, so the new bound cannot silently cost a legitimate add. `tests/security-floor.json` updated (+1).

## Production data already repaired (separately, with Chris's approval)

- Project 1's membership repointed from the LID to `64272480362`.
- All four phantom `community_users` rows deleted — they granted nothing and carried the misdelivery risk above. **Angela keeps her working Discord membership** (`1530057080868835369`, role `member`), which is how she was actually reachable all along.
- The five remaining WhatsApp members are all phone numbers.

## How verified

- Full suite: **3255 tests, 0 failures.**
- `npm run typecheck`, `npm run lint`, `npm run context:check` clean; Prettier clean.
- Tests assert both directions: the four real LIDs are refused with an actionable message, and all five real member numbers still validate, plus the 13/14-digit boundary.

## Not done here

The deeper fix is to stop LIDs entering phone-shaped fields at all — `server_roster` should store them in the existing unambiguous `lid:` form (`lidFallbackId` already establishes that convention, and `resolveSenderId` honours it), and the LID→phone mapping should be **persisted** rather than the current in-memory `lidToPhone` `Map`, which is learned opportunistically, consumed on removal, and lost on restart. That would let a LID be *resolved* rather than refused. It's a larger change touching the adapter and 820 existing roster rows, so it's deliberately out of scope here.
