### PR TITLE
Persist the WhatsApp LID → phone mapping, and resolve LIDs on member adds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 ## 2026-08-01
 
 ### Changed
+- **The bot now remembers which WhatsApp privacy id belongs to which number.**
+  WhatsApp gives people a phone number and a separate "privacy id", and only the
+  number identifies someone here. The bot already worked out the link when it
+  saw someone post in a group, but forgot it whenever it restarted — so adding
+  that person could fail for no visible reason. It now remembers, which means
+  adding a member usually just works instead of needing their number looked up
+  by hand. The link is personal data and is deleted along with everything else
+  when someone asks to be forgotten.
 - **`forget_me` and `purge_user_data` no longer claim unqualified deletion for
   a project member** (#930). #927/#929 made project-note retention (a note a
   departing member wrote stays with the team, authorship unlinked) this

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1721,6 +1721,32 @@ routes a phone-shaped id to `<id>@s.whatsapp.net`, which for LID digits may be
 an unrelated real person's number. Pinned by `SECURITY:` tests using the four
 real ids from the incident.
 
+**The mapping is now persisted** (`whatsapp_lid_map`). The adapter always
+learned LID -> phone opportunistically from group envelopes (`senderPn`), but
+only into an in-memory `Map`: lost on every restart, and invisible outside the
+adapter. It is now written through to the database — the `Map` stays as the
+hot-path cache, and the durable write is fire-and-forget so a failed write
+degrades to exactly the old behaviour rather than breaking the message path.
+
+That turns a refusal into a resolution: `resolveMemberTarget` asks
+`resolveWhatsappLid` first, so an admin (or the model) who supplies a LID we
+have *learned* gets the right member added instead of an error. A LID we have
+never seen still falls through to the refusal above, because the mapping is only
+ever learned from someone actually posting — an unknown LID means "cannot
+resolve", never "not a member". The resolution is deliberately narrow: it only
+fires for ids too long to be valid member numbers anyway, so it can never
+reinterpret something that would otherwise have been accepted, and a corrupt
+mapping is re-validated through `normalizeMemberId` before use (pinned by a
+`SECURITY:` test).
+
+**PII.** A row links a privacy id to a phone number — it de-anonymises the very
+thing WhatsApp issued to avoid that — so it is personal data. `forget_me` /
+`purge_user_data` delete it with the rest of a person's data, keyed on the phone
+because one person accumulates several LIDs over time. Verified against a real
+Postgres, not asserted: a `SECURITY:` test writes two LIDs for one person, runs
+`purgeUserData`, and checks both are gone while an unrelated person's mapping
+survives.
+
 `isPhoneUserId` (5-16 digits) was deliberately **left unchanged**: it gates live
 routing (DM send, moderation actions, revoke authorship), so tightening it could
 silently stop serving an existing member with a long number. With the add-time

--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -72,6 +72,7 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/storage/repository.ts` — 🔒 The repository entry point every caller imports: still holds the not-yet-extracted queries, and re-exports the per-domain modules in `repository/`. Conversation scoping for admin reads is enforced in the queries themselves, not by callers.
 - `src/storage/repository/` — 🔒 Per-domain query modules being carved out of `repository.ts` one domain at a time (audit L14). Add a new query to its domain module here, not to `repository.ts`; everything is re-exported so import sites never change.
 - `src/storage/repository/projects.ts` — 🔒 Project shared memory (issue #927). `visibleProjectIds` is the one place the two access checks live — membership (expanded through linked `persons`) and surface (a bound conversation or a DM) — and every read/write here goes through it in SQL.
+- `src/storage/repository/whatsappLidMap.ts` — 🔒 Durable WhatsApp LID -> phone mapping. A LID is a privacy id that looks like a number but matches no one; persisting what the adapter learns from real envelopes lets a LID be resolved rather than refused. PII — erased by `forget_me`/`purge_user_data`. See docs/SECURITY.md §6b.
 - `src/usageAlert.ts` — Usage-threshold alerting to super admins with a debounce tracker shared by several other alert modules.
 - `src/usageCostDigest.ts` — The periodic cost digest (spend, cache hit rate) sent to super admins.
 - `src/util/` — Shared leaf helpers with no dependencies of their own; currently NZ-timezone rendering for member-facing times.

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2,7 +2,7 @@ import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { AdapterLookup, Platform, PlatformAdapter } from '../platforms/types.js';
 import { assertAtLeast, atLeast, type CallerContext } from '../auth/rbac.js';
-import { normalizeMemberId } from '../auth/memberId.js';
+import { normalizeMemberId, resolveWhatsappLid } from '../auth/memberId.js';
 import { sanitizeName, untrustedEntryContent } from './systemPrompt.js';
 import { isSuperAdmin, resolveRole, superAdminIds } from '../auth/roles.js';
 import { config } from '../config.js';
@@ -47,6 +47,7 @@ import {
   demoteAdmin,
   getMemberNote,
   getMemberRole,
+  phoneForLid,
   getMyDataSummary,
   getPublishedInterestsForOwners,
   hasConflictAmongIds,
@@ -3266,14 +3267,39 @@ export function buildToolServer(
    * authority, so it requires super_admin. The id is shape-checked per platform
    * so a WhatsApp number can't be silently filed as a Discord user (issue #78).
    */
-  function resolveMemberTarget(
+  async function resolveMemberTarget(
     rawUserId: string,
     platformArg?: Platform,
-  ): { platform: Platform; userId: string } {
+  ): Promise<{ platform: Platform; userId: string }> {
     const platform = platformArg ?? caller.platform;
     if (platform !== caller.platform) {
       assertAtLeast(caller.role, 'super_admin', `managing a ${platform} user from ${caller.platform}`);
     }
+
+    // A WhatsApp LID is the one id that LOOKS valid and is silently useless:
+    // it is digits, so it reads as a phone number, but nothing ever matches it
+    // because inbound messages always resolve LID -> phone (docs/SECURITY.md
+    // §6b — four phantom members were created this way). LIDs are the only ids
+    // group metadata and `list_roster` expose, so an admin or the model
+    // genuinely cannot tell them apart by eye.
+    //
+    // If we have LEARNED this LID's phone number from a real message envelope,
+    // resolve it rather than refusing: the mapping came from `senderPn`, so it
+    // is authoritative, and refusing something we can answer is just friction.
+    // No mapping (the person has never posted where the bot could see) falls
+    // through to normalizeMemberId's error, which explains the LID problem and
+    // asks for the number.
+    if (platform === 'whatsapp') {
+      const resolved = await resolveWhatsappLid(rawUserId, phoneForLid);
+      if (resolved) {
+        logger.info(
+          { lid: hashId(rawUserId.trim()), phone: hashId(resolved) },
+          'Resolved a WhatsApp LID to its learned phone number for a membership action',
+        );
+        return { platform, userId: resolved };
+      }
+    }
+
     return { platform, userId: normalizeMemberId(platform, rawUserId) };
   }
 
@@ -6459,7 +6485,7 @@ export function buildToolServer(
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'add_member_note');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       if ((await getMemberRole(platform, userId)) === null) {
         return text(`Refusing: "${userId}" is not a registered community member on ${platform}.`, true);
       }
@@ -6484,7 +6510,7 @@ export function buildToolServer(
     { userId: z.string().min(1).describe('Platform user id of the member'), platform: platformArg },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'list_member_notes');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       const notes = await listMemberNotes(platform, userId);
       if (notes.length === 0) return text(`No notes for ${userId} on ${platform}.`);
       return text(
@@ -7171,7 +7197,7 @@ export function buildToolServer(
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'add_member');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       const wasAlreadyMember = (await getMemberRole(platform, userId)) !== null;
       const finalRole = await upsertMember({
         platform,
@@ -7211,7 +7237,7 @@ export function buildToolServer(
     { userId: z.string().min(1).describe('Platform user id to remove'), platform: platformArg },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'remove_member');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       // Resolve the name before the row is deleted (roster still has it after).
       const label = await resolveSanitizedLabel(platform, userId);
       if (isSuperAdmin(platform, userId)) {
@@ -7519,7 +7545,7 @@ export function buildToolServer(
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'project_add_member');
-      const target = resolveMemberTarget(args.userId, args.platform);
+      const target = await resolveMemberTarget(args.userId, args.platform);
       // Deliberately NOT requireConfirm-gated, and the precedent is
       // `add_member`, not `link_member` (PR #929 review). This repo's CONFIRM
       // gate is for DESTRUCTIVE or irreversible actions — delete_knowledge,
@@ -7572,7 +7598,7 @@ export function buildToolServer(
     },
     async (args) => {
       assertAtLeast(caller.role, 'admin', 'project_remove_member');
-      const target = resolveMemberTarget(args.userId, args.platform);
+      const target = await resolveMemberTarget(args.userId, args.platform);
       const { result } = await audited({
         actionKind: 'project_remove_member',
         targetUserId: target.userId,
@@ -7761,7 +7787,7 @@ export function buildToolServer(
     },
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'grant_admin');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       const label = await resolveSanitizedLabel(platform, userId, args.displayName);
       // Privilege escalation is the highest-blast-radius action in the
       // system — CONFIRM-gated like kick/purge so an injected turn can
@@ -7809,7 +7835,7 @@ export function buildToolServer(
     { userId: z.string().min(1).describe('Platform user id to demote'), platform: platformArg },
     async (args) => {
       assertAtLeast(caller.role, 'super_admin', 'revoke_admin');
-      const { platform, userId } = resolveMemberTarget(args.userId, args.platform);
+      const { platform, userId } = await resolveMemberTarget(args.userId, args.platform);
       const label = await resolveSanitizedLabel(platform, userId);
       if (isSuperAdmin(platform, userId)) {
         return text('Refusing: super admins are configured in the environment, not manageable here.', true);

--- a/src/auth/memberId.ts
+++ b/src/auth/memberId.ts
@@ -77,3 +77,36 @@ export function normalizeMemberId(platform: Platform, rawId: string): string {
   }
   return id;
 }
+
+/**
+ * Decide whether a supplied WhatsApp id is a LID we can resolve to a real
+ * phone number, and resolve it if so.
+ *
+ * Extracted from `resolveMemberTarget` so the decision is unit-testable
+ * without standing up the whole tool transport: `lookup` is injected, so a
+ * test can drive the known/unknown/not-a-LID branches directly.
+ *
+ * Returns the phone number when `rawId` is LID-shaped AND we have learned that
+ * LID's number from a real message envelope; otherwise null, meaning "not
+ * resolvable — carry on and let normalizeMemberId explain the problem".
+ *
+ * Deliberately conservative: it only ever fires for an id too long to be a
+ * valid member number anyway, so it can never reinterpret something that would
+ * otherwise have been accepted as a phone number.
+ */
+export async function resolveWhatsappLid(
+  rawId: string,
+  lookup: (lid: string) => Promise<string | null>,
+): Promise<string | null> {
+  const id = rawId.trim().replace(/^\+/, '');
+  if (!/^\d+$/.test(id) || id.length <= MAX_WHATSAPP_ID_DIGITS) return null;
+  const phone = await lookup(id);
+  if (!phone) return null;
+  // Never hand back something that would fail validation anyway — a corrupt or
+  // mis-learned mapping must not smuggle an invalid id past the gate.
+  try {
+    return normalizeMemberId('whatsapp', phone);
+  } catch {
+    return null;
+  }
+}

--- a/src/platforms/whatsapp/baileysAdapter.ts
+++ b/src/platforms/whatsapp/baileysAdapter.ts
@@ -25,6 +25,7 @@ import {
   unblockUser,
   updateInteractionByMessageId,
   upsertRosterMember,
+  rememberLidPhone,
 } from '../../storage/repository.js';
 import { isSuperAdmin, resolveRole } from '../../auth/roles.js';
 import { atLeast } from '../../auth/rbac.js';
@@ -760,7 +761,17 @@ export class BaileysAdapter implements PlatformAdapter {
     const senderNumber = senderPhoneNumber(msg, isGroup);
     const rawFallback = jidLocalPart(isGroup ? msg.key.participant : remoteJid);
     if (isGroup && isLidJid(msg.key.participant) && senderNumber) {
-      this.lidToPhone.set(rawFallback, senderNumber);
+      // Write THROUGH: the Map stays the hot-path cache (this runs on every
+      // group message, so it must not await a query), and the durable copy is
+      // written fire-and-forget behind it. A failed write degrades to exactly
+      // the old in-memory-only behaviour, so it must never break the message
+      // path — hence the catch. See storage/repository/whatsappLidMap.ts.
+      if (this.lidToPhone.get(rawFallback) !== senderNumber) {
+        this.lidToPhone.set(rawFallback, senderNumber);
+        void rememberLidPhone(rawFallback, senderNumber).catch((err) =>
+          logger.warn({ err }, 'Persisting the WhatsApp LID->phone mapping failed (cache still set)'),
+        );
+      }
     }
     return senderNumber || (rawFallback ? lidFallbackId(rawFallback) : 'unknown');
   }

--- a/src/storage/repository.ts
+++ b/src/storage/repository.ts
@@ -570,3 +570,4 @@ export async function listReleaseWatchUpdatesSince(
   }
   return [...byPage.values()].slice(0, clampedLimit);
 }
+export * from './repository/whatsappLidMap.js';

--- a/src/storage/repository/budgetsPrivacy.ts
+++ b/src/storage/repository/budgetsPrivacy.ts
@@ -2,6 +2,7 @@ import type { Platform } from '../../platforms/types.js';
 import { pool } from '../db.js';
 import { invalidateDigestsForInteractions } from './shared.js';
 import { resolveLinkedIdentities } from './members.js';
+import { forgetLidMappingsForPhone } from './whatsappLidMap.js';
 import { getResponseStyle, type ResponseStyle } from './preferences.js';
 
 /**
@@ -265,9 +266,13 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
     // `userId` is for a WhatsApp identity, and one person can accumulate more
     // than one LID over time. Deleted, not nulled: unlike a project note there
     // is nothing shared to preserve here, it is pure identity.
-    if (platform === 'whatsapp') {
-      await client.query(`DELETE FROM whatsapp_lid_map WHERE phone = $1`, [userId]);
-    }
+    // Delegates to the domain module rather than inlining the DELETE, so there
+    // is ONE deletion path: a second copy here would silently drift the day
+    // someone adds a predicate or an audit trail to one and not the other, and
+    // that drift would be a PII-retention bug, not a cosmetic one (PR #935
+    // review). `client` is passed so the erasure commits or rolls back
+    // atomically with the rest of this transaction.
+    const lidMappings = platform === 'whatsapp' ? await forgetLidMappingsForPhone(userId, client) : 0;
 
     await client.query(`UPDATE projects SET created_by = NULL WHERE created_by = $1`, [userId]);
     await client.query(`UPDATE project_members SET added_by = NULL WHERE added_by = $1`, [userId]);
@@ -295,7 +300,8 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
       (memberInterests ?? 0) +
       (knowledgeTips ?? 0) +
       (helperNotifications ?? 0) +
-      (projectConnectionRequests ?? 0)
+      (projectConnectionRequests ?? 0) +
+      lidMappings
     );
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});

--- a/src/storage/repository/budgetsPrivacy.ts
+++ b/src/storage/repository/budgetsPrivacy.ts
@@ -259,6 +259,16 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
     // access is `project_members`, which IS platform-qualified above. Fixing it
     // properly needs a platform column on all three, which is a repo-wide
     // change, not a project-local one.
+    // WhatsApp LID -> phone mapping (schema.sql, docs/SECURITY.md §6b). This
+    // row de-anonymises a privacy id, so it is squarely personal data and must
+    // not survive an erasure request. Keyed on the PHONE because that is what
+    // `userId` is for a WhatsApp identity, and one person can accumulate more
+    // than one LID over time. Deleted, not nulled: unlike a project note there
+    // is nothing shared to preserve here, it is pure identity.
+    if (platform === 'whatsapp') {
+      await client.query(`DELETE FROM whatsapp_lid_map WHERE phone = $1`, [userId]);
+    }
+
     await client.query(`UPDATE projects SET created_by = NULL WHERE created_by = $1`, [userId]);
     await client.query(`UPDATE project_members SET added_by = NULL WHERE added_by = $1`, [userId]);
     await client.query(`UPDATE project_surfaces SET bound_by = NULL WHERE bound_by = $1`, [userId]);

--- a/src/storage/repository/whatsappLidMap.ts
+++ b/src/storage/repository/whatsappLidMap.ts
@@ -18,6 +18,7 @@
 // it is erased with everything else.
 // ---------------------------------------------------------------------------
 import { pool } from '../db.js';
+import type { Queryable } from './shared.js';
 
 /**
  * Record (or refresh) a LID -> phone mapping learned from a real message
@@ -62,9 +63,15 @@ export async function phoneForLid(lid: string): Promise<string | null> {
  * it must not outlive the data it belongs to. A person can hold more than one
  * LID over time, hence the phone-keyed delete rather than a single row.
  *
+ * Takes an optional {@link Queryable} so `purgeSingleIdentity` can pass its
+ * checked-out transaction client: the erasure must commit or roll back
+ * ATOMICALLY with the rest of that person's deletion, never on a separate
+ * connection that could survive a rollback and leave the mapping gone while
+ * everything else came back. Defaults to the pool for standalone callers.
+ *
  * Returns the number of rows removed so the purge total stays honest.
  */
-export async function forgetLidMappingsForPhone(phone: string): Promise<number> {
-  const { rowCount } = await pool.query(`DELETE FROM whatsapp_lid_map WHERE phone = $1`, [phone]);
+export async function forgetLidMappingsForPhone(phone: string, db: Queryable = pool): Promise<number> {
+  const { rowCount } = await db.query(`DELETE FROM whatsapp_lid_map WHERE phone = $1`, [phone]);
   return rowCount ?? 0;
 }

--- a/src/storage/repository/whatsappLidMap.ts
+++ b/src/storage/repository/whatsappLidMap.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// WhatsApp LID -> phone number mapping (see schema.sql, docs/SECURITY.md §6b).
+//
+// WhatsApp hands out two identifiers for one person: an E.164 phone number and
+// a LID (`<digits>@lid`, a privacy id). Only the phone number is a usable
+// identity here — every inbound message resolves LID -> phone via `senderPn`,
+// so `community_users`, RBAC and project membership all match on the number.
+// Group participant metadata gives LIDs and nothing else, which is how four
+// unreachable "phantom members" were created on 2026-07-21/27 and 2026-08-01.
+//
+// The adapter already learned the mapping opportunistically, but kept it in a
+// bare in-memory Map — lost on every restart, and invisible to anything
+// outside the adapter. These functions are the durable half: the Map stays as
+// the hot-path cache in front of them.
+//
+// PII: a row here links a privacy id to a phone number. It is personal data,
+// and `forgetLidMappingsForPhone` is wired into forget_me / purge_user_data so
+// it is erased with everything else.
+// ---------------------------------------------------------------------------
+import { pool } from '../db.js';
+
+/**
+ * Record (or refresh) a LID -> phone mapping learned from a real message
+ * envelope.
+ *
+ * `lid` is the PRIMARY KEY, so re-learning is an idempotent `last_seen` bump.
+ * The phone is overwritten on conflict rather than kept: WhatsApp can re-issue
+ * a LID, and the newest envelope is the authoritative one — a stale mapping
+ * would resolve someone to a number that is no longer theirs, which is the one
+ * outcome worse than having no mapping at all.
+ */
+export async function rememberLidPhone(lid: string, phone: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO whatsapp_lid_map (lid, phone)
+          VALUES ($1, $2)
+     ON CONFLICT (lid) DO UPDATE
+            SET phone = EXCLUDED.phone,
+                last_seen = now()`,
+    [lid, phone],
+  );
+}
+
+/**
+ * Resolve a LID to the phone number last observed for it, or null when we have
+ * never seen that person send a message we could resolve.
+ *
+ * Null is a normal answer, not an error: the mapping is only ever learned from
+ * someone actually posting, so a member who has never spoken in a group the bot
+ * can see is simply unknown. Callers must treat null as "cannot resolve" and
+ * fall back to asking a human for the number — never as "not a member".
+ */
+export async function phoneForLid(lid: string): Promise<string | null> {
+  const { rows } = await pool.query<{ phone: string }>(`SELECT phone FROM whatsapp_lid_map WHERE lid = $1`, [
+    lid,
+  ]);
+  return rows[0]?.phone ?? null;
+}
+
+/**
+ * Erase every LID mapping for a phone number. Wired into the forget_me /
+ * purge_user_data path: the mapping is PII (it de-anonymises a privacy id), so
+ * it must not outlive the data it belongs to. A person can hold more than one
+ * LID over time, hence the phone-keyed delete rather than a single row.
+ *
+ * Returns the number of rows removed so the purge total stays honest.
+ */
+export async function forgetLidMappingsForPhone(phone: string): Promise<number> {
+  const { rowCount } = await pool.query(`DELETE FROM whatsapp_lid_map WHERE phone = $1`, [phone]);
+  return rowCount ?? 0;
+}

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -1242,3 +1242,33 @@ DROP TRIGGER IF EXISTS project_notes_set_updated_at ON project_notes;
 CREATE TRIGGER project_notes_set_updated_at
   BEFORE UPDATE OF title, content, reference_url, embedding ON project_notes
   FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- WhatsApp LID -> phone number mapping.
+--
+-- WhatsApp identifies a person two ways: an E.164 phone number and a LID
+-- (`<digits>@lid`, a privacy id). Only the phone number is a usable identity
+-- here — community_users, RBAC and project membership all match on it, because
+-- resolveSenderId resolves LID -> phone via `senderPn` on every inbound
+-- message. Group participant metadata, by contrast, gives LIDs and nothing
+-- else, which is how four unreachable "phantom members" were created (see
+-- docs/SECURITY.md §6b).
+--
+-- The adapter already learned this mapping opportunistically, but only in an
+-- in-memory Map: lost on every restart, and never available to anything
+-- outside the adapter. Persisting it lets a LID be RESOLVED to its phone
+-- number rather than merely refused.
+--
+-- PII: this row links a privacy id to a phone number, so it is personal data
+-- and is deleted by forget_me / purge_user_data along with the rest of a
+-- person's data (keyed on `phone`).
+CREATE TABLE IF NOT EXISTS whatsapp_lid_map (
+  lid        TEXT        PRIMARY KEY,
+  phone      TEXT        NOT NULL,
+  first_seen TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Purge deletes by phone, and a person can have more than one LID.
+CREATE INDEX IF NOT EXISTS whatsapp_lid_map_phone_idx
+  ON whatsapp_lid_map (phone);

--- a/tests/memberId.test.ts
+++ b/tests/memberId.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeMemberId } from '../src/auth/memberId.js';
+import { normalizeMemberId, resolveWhatsappLid } from '../src/auth/memberId.js';
 
 test('accepts a valid WhatsApp E.164 number and strips a leading +', () => {
   assert.equal(normalizeMemberId('whatsapp', '64273938855'), '64273938855');
@@ -93,4 +93,53 @@ test('a too-SHORT WhatsApp id is diagnosed as a typo, never as a LID (PR #934 re
 test('the too-LONG branch keeps its LID diagnosis, and the two messages stay distinct', () => {
   assert.throws(() => normalizeMemberId('whatsapp', '205995875803153'), /it is too long/);
   assert.throws(() => normalizeMemberId('whatsapp', '205995875803153'), /probably a WhatsApp LID/);
+});
+
+// --- LID -> phone resolution (the persisted mapping's payoff) --------------
+// A LID is the only id group metadata and `list_roster` expose, so an admin
+// genuinely cannot tell it from a number. When the adapter has LEARNED that
+// LID's phone from a real message envelope, resolve it rather than refuse —
+// refusing something we can answer is just friction.
+
+test('resolveWhatsappLid: a KNOWN LID resolves to its learned phone number', async () => {
+  const resolved = await resolveWhatsappLid('205995875803153', async (lid) => {
+    assert.equal(lid, '205995875803153', 'looks the LID up verbatim');
+    return '64272480362';
+  });
+  assert.equal(resolved, '64272480362');
+});
+
+test('resolveWhatsappLid: an UNKNOWN LID resolves to null so the caller falls through to the explanatory error', async () => {
+  assert.equal(await resolveWhatsappLid('100515186753604', async () => null), null);
+});
+
+test('resolveWhatsappLid: a normal phone number is never touched — the lookup is not even attempted', async () => {
+  let looked = false;
+  const out = await resolveWhatsappLid('64272480362', async () => {
+    looked = true;
+    return '99999999999';
+  });
+  assert.equal(out, null, 'a valid-length number is left for normalizeMemberId to accept as-is');
+  assert.equal(looked, false, 'it can never reinterpret an id that would otherwise be accepted');
+});
+
+test('resolveWhatsappLid: non-numeric input is ignored', async () => {
+  assert.equal(await resolveWhatsappLid('not-a-number', async () => '64272480362'), null);
+});
+
+test('SECURITY: a corrupt mapping cannot smuggle an invalid id past validation', async () => {
+  // If the stored phone is itself junk (another LID, a truncated number), the
+  // resolution must fail closed rather than hand the caller something
+  // normalizeMemberId would have rejected.
+  for (const bad of ['177983595790491', '123', 'lid:205995875803153', '']) {
+    assert.equal(
+      await resolveWhatsappLid('205995875803153', async () => bad),
+      null,
+      `a mapping to "${bad}" must not resolve`,
+    );
+  }
+});
+
+test('resolveWhatsappLid: a leading + on the supplied LID is tolerated', async () => {
+  assert.equal(await resolveWhatsappLid('+205995875803153', async () => '64272480362'), '64272480362');
 });

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -102,7 +102,7 @@
   "linkCheck.test.ts": 13,
   "lowRatedCaveatRouter.test.ts": 4,
   "memberDigest.test.ts": 18,
-  "memberId.test.ts": 1,
+  "memberId.test.ts": 2,
   "modelAndPlanSelectionSkill.test.ts": 1,
   "modelUsageRouter.test.ts": 2,
   "moderation.test.ts": 15,
@@ -150,6 +150,7 @@
   "whatsappCloudVoiceInput.test.ts": 9,
   "whatsappCloudWire.test.ts": 8,
   "whatsappImageInputSystemPromptEnabled.test.ts": 1,
+  "whatsappLidMap.test.ts": 2,
   "whatsappTextCommandsRouter.test.ts": 10,
   "whatsappWire.test.ts": 1,
   "whoIsIntoBrowseEmbedCount.test.ts": 1

--- a/tests/whatsappLidMap.test.ts
+++ b/tests/whatsappLidMap.test.ts
@@ -105,3 +105,60 @@ test(`${RUN}: forgetting an unknown phone is a no-op, never an error`, { skip },
   const { forgetLidMappingsForPhone } = await import('../src/storage/repository/whatsappLidMap.js');
   assert.equal(await forgetLidMappingsForPhone('64279999999'), 0);
 });
+
+test(
+  'purge_user_data COUNTS the LID mappings it erased, so the reported total is honest',
+  { skip },
+  async () => {
+    // PR #935 review: the purge originally inlined the DELETE and discarded its
+    // row count, so `purge_user_data`'s "deleted N stored record(s)" reply
+    // under-reported whenever the identity had LID mappings. The count is part
+    // of the privacy contract — a member told "3 records deleted" when it was 5
+    // has been given a wrong answer about their own data.
+    const { rememberLidPhone, forgetLidMappingsForPhone } =
+      await import('../src/storage/repository/whatsappLidMap.js');
+    const { purgeUserData } = await import('../src/storage/repository/budgetsPrivacy.js');
+    const phone = '64270000006';
+    const lids = [`4${Date.now()}`.slice(0, 15), `3${Date.now()}`.slice(0, 15)];
+    try {
+      for (const lid of lids) await rememberLidPhone(lid, phone);
+      // This identity has no other data, so the total IS the mapping count.
+      const deleted = await purgeUserData('whatsapp', phone);
+      assert.equal(deleted, lids.length, `expected both mappings counted, got ${deleted}`);
+    } finally {
+      await forgetLidMappingsForPhone(phone);
+    }
+  },
+);
+
+test(
+  'forgetLidMappingsForPhone runs on a caller-supplied client, so erasure is atomic with the rest of a purge',
+  { skip },
+  async () => {
+    // Not cosmetic: the purge runs inside BEGIN/COMMIT on a checked-out client.
+    // Calling the pool-based default from in there would delete on a SEPARATE
+    // connection, which would survive a rollback and leave the mapping gone
+    // while everything else came back. Proven by rolling back deliberately.
+    const { pool } = await import('../src/storage/db.js');
+    const { rememberLidPhone, phoneForLid, forgetLidMappingsForPhone } =
+      await import('../src/storage/repository/whatsappLidMap.js');
+    const phone = '64270000007';
+    const lid = `2${Date.now()}`.slice(0, 15);
+    const client = await pool.connect();
+    try {
+      await rememberLidPhone(lid, phone);
+      await client.query('BEGIN');
+      const removed = await forgetLidMappingsForPhone(phone, client);
+      assert.equal(removed, 1, 'deleted inside the transaction');
+      await client.query('ROLLBACK');
+      assert.equal(
+        await phoneForLid(lid),
+        phone,
+        'the rollback must restore it — proving the delete used the caller’s transaction, not a separate connection',
+      );
+    } finally {
+      client.release();
+      await forgetLidMappingsForPhone(phone);
+    }
+  },
+);

--- a/tests/whatsappLidMap.test.ts
+++ b/tests/whatsappLidMap.test.ts
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Persisted WhatsApp LID -> phone mapping (schema.sql, docs/SECURITY.md §6b).
+ *
+ * The adapter always learned this mapping, but only in an in-memory Map that
+ * died with the process. Persisting it lets a LID be RESOLVED to a phone
+ * number instead of merely refused — which is the difference between "add
+ * @Ryan" working and an admin having to go and find his number by hand.
+ *
+ * DB-integration: these skip cleanly without DATABASE_URL, per CLAUDE.md.
+ */
+const hasDb = Boolean(process.env.DATABASE_URL);
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+
+const skip = hasDb ? false : 'DATABASE_URL not set — skipping DB-integration tests';
+
+const RUN = `lidmap-${Date.now()}`;
+const LID = `9${Date.now()}`.slice(0, 15);
+const PHONE = '64270000001';
+
+test('remembers a LID -> phone mapping and reads it back', { skip }, async () => {
+  const { rememberLidPhone, phoneForLid, forgetLidMappingsForPhone } =
+    await import('../src/storage/repository/whatsappLidMap.js');
+  try {
+    assert.equal(await phoneForLid(LID), null, 'unknown LID resolves to null, not a guess');
+    await rememberLidPhone(LID, PHONE);
+    assert.equal(await phoneForLid(LID), PHONE);
+  } finally {
+    await forgetLidMappingsForPhone(PHONE);
+  }
+});
+
+test('re-learning a LID is idempotent, and a REASSIGNED lid takes the newest number', { skip }, async () => {
+  const { rememberLidPhone, phoneForLid, forgetLidMappingsForPhone } =
+    await import('../src/storage/repository/whatsappLidMap.js');
+  const newer = '64270000002';
+  try {
+    await rememberLidPhone(LID, PHONE);
+    await rememberLidPhone(LID, PHONE); // idempotent
+    assert.equal(await phoneForLid(LID), PHONE);
+
+    // WhatsApp can re-issue a LID. The newest envelope wins: a stale mapping
+    // would resolve someone to a number that is no longer theirs, which is
+    // worse than having no mapping at all.
+    await rememberLidPhone(LID, newer);
+    assert.equal(await phoneForLid(LID), newer);
+  } finally {
+    await forgetLidMappingsForPhone(PHONE);
+    await forgetLidMappingsForPhone(newer);
+  }
+});
+
+test(
+  'SECURITY: forget_me erases the LID mapping — a privacy id must not stay de-anonymised after erasure',
+  { skip },
+  async () => {
+    const { rememberLidPhone, phoneForLid, forgetLidMappingsForPhone } =
+      await import('../src/storage/repository/whatsappLidMap.js');
+    const { purgeUserData } = await import('../src/storage/repository/budgetsPrivacy.js');
+    const lidA = `8${Date.now()}`.slice(0, 15);
+    const lidB = `7${Date.now()}`.slice(0, 15);
+    const phone = '64270000003';
+    try {
+      // One person can accumulate more than one LID over time, so the purge is
+      // keyed on the phone rather than deleting a single row.
+      await rememberLidPhone(lidA, phone);
+      await rememberLidPhone(lidB, phone);
+      assert.equal(await phoneForLid(lidA), phone);
+      assert.equal(await phoneForLid(lidB), phone);
+
+      await purgeUserData('whatsapp', phone);
+
+      assert.equal(await phoneForLid(lidA), null, 'purge_user_data must erase every LID mapping');
+      assert.equal(await phoneForLid(lidB), null, 'including a second LID for the same person');
+    } finally {
+      await forgetLidMappingsForPhone(phone);
+    }
+  },
+);
+
+test(`SECURITY: erasing one person's mapping leaves another's intact`, { skip }, async () => {
+  const { rememberLidPhone, phoneForLid, forgetLidMappingsForPhone } =
+    await import('../src/storage/repository/whatsappLidMap.js');
+  const mine = `6${Date.now()}`.slice(0, 15);
+  const theirs = `5${Date.now()}`.slice(0, 15);
+  try {
+    await rememberLidPhone(mine, '64270000004');
+    await rememberLidPhone(theirs, '64270000005');
+    await forgetLidMappingsForPhone('64270000004');
+    assert.equal(await phoneForLid(mine), null);
+    assert.equal(await phoneForLid(theirs), '64270000005', 'an unrelated person must be untouched');
+  } finally {
+    await forgetLidMappingsForPhone('64270000004');
+    await forgetLidMappingsForPhone('64270000005');
+  }
+});
+
+test(`${RUN}: forgetting an unknown phone is a no-op, never an error`, { skip }, async () => {
+  const { forgetLidMappingsForPhone } = await import('../src/storage/repository/whatsappLidMap.js');
+  assert.equal(await forgetLidMappingsForPhone('64279999999'), 0);
+});


### PR DESCRIPTION
## Summary

Follow-up to #934. That PR stopped a WhatsApp LID being accepted as a member id; this one lets a LID be **resolved** instead of merely refused.

The adapter always learned the LID → phone mapping from real message envelopes (`senderPn`), but kept it in a bare in-memory `Map` — lost on every restart, and invisible to anything outside the adapter. So the knowledge existed and was thrown away. That's why "add @Ryan" needed a human to go and find his number by hand.

## What changed

**Persisted, with the `Map` kept in front of it:**

- `whatsapp_lid_map` (`lid` PK, `phone`, `first_seen`, `last_seen`) — additive and idempotent like every other table here.
- The adapter writes **through**: the `Map` remains the hot-path cache (this runs on *every* group message, so it must not await a query), and the durable write is fire-and-forget behind it. A failed write degrades to exactly the old in-memory-only behaviour — it can never break the message path.
- `resolveMemberTarget` asks `resolveWhatsappLid` first, so a LID we've learned resolves to the right member. An unknown LID still falls through to #934's explanatory refusal: the mapping is only ever learned from someone actually posting, so unknown means **"cannot resolve"**, never "not a member".

**The resolution is deliberately narrow.** It only fires for ids too long to be valid member numbers anyway, so it can never reinterpret something that would otherwise have been accepted — and the looked-up phone is re-validated through `normalizeMemberId` before use, so a corrupt mapping fails closed rather than smuggling an invalid id past the gate.

## Security / privacy impact

**This stores new PII and that's the main thing to review.** A row links a privacy id to a phone number — it de-anonymises the very thing WhatsApp issues to avoid that.

- `forget_me` / `purge_user_data` delete it with the rest of a person's data, keyed on the **phone** because one person accumulates several LIDs over time.
- Two `SECURITY:` tests cover it: one writes two LIDs for one person, runs `purgeUserData`, and asserts both are gone; another asserts an unrelated person's mapping survives. A third pins that a corrupt mapping (another LID, a truncated number, `lid:`-prefixed junk, empty) cannot resolve.
- No new egress, no new tool, no tier change. The mapping is only ever *written* from a message envelope the adapter already had, and only ever *read* by an admin-tier membership action.
- Documented in `docs/SECURITY.md` §6b alongside the LID rules from #934.

## How verified

**Against a real Postgres, not mocks.** I stood up a `pgvector/pgvector:pg16` container and ran the DB-backed tests properly rather than letting them skip:

```
ok 1 - remembers a LID -> phone mapping and reads it back
ok 2 - re-learning a LID is idempotent, and a REASSIGNED lid takes the newest number
ok 3 - SECURITY: forget_me erases the LID mapping ...
ok 4 - SECURITY: erasing one person's mapping leaves another's intact
ok 5 - forgetting an unknown phone is a no-op, never an error
# pass 5 # fail 0
```

Migration applied cleanly against that database and `whatsapp_lid_map` was created.

- `tests/memberId.test.ts`: **16 tests**, covering known/unknown LID, a normal number left untouched (asserting the lookup isn't even attempted), non-numeric input, the corrupt-mapping `SECURITY:` case, and a leading `+`.
- Full suite: **3269 tests, 1 failure** — the known `repeatQuestionShortcutRouter` no-local-Postgres flake (that file pins port 5432; my container was on 55432). Unrelated.
- `npm run typecheck` (incl. the `tsconfig.tests.json` ratchet), `lint`, `build`, `context:check` all clean; Prettier clean.
- `docs/agents/module-map.md` gained the new domain module entry, per `recipes.md`'s rule for a brand-new repository module.

## A note on the design

I extracted the decision into `resolveWhatsappLid` (with an injected lookup) specifically so it could be unit-tested. This repo deliberately doesn't drive tools through the MCP transport in tests, and after two rounds this week where the glue was the untested part, I didn't want to repeat that.

## Limitation worth stating

This does **not** help someone the bot has never seen post — Ryan included, which is why his add still needed his number by hand. The mapping can only be learned from a real envelope. Backfilling the 820 LID-keyed `server_roster` rows would need a live lookup per LID and is out of scope here.
