### PR TITLE
Add WHATSAPP_ARCHIVE_ALL_GROUPS: blanket group archiving, Discord parity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,16 @@ WHATSAPP_WELCOME_COOLDOWN_MINUTES=180
 # WhatsApp community notice from docs/SECURITY.md in a group BEFORE adding
 # its JID here — this changes the gated-mode privacy posture for that group.
 WHATSAPP_ARCHIVE_GROUP_JIDS=
+
+# Archive EVERY group the bot is in, present and future — the WhatsApp
+# counterpart to DISCORD_ARCHIVE_ALL_MESSAGES. Off by default.
+#
+# This deliberately removes the per-group checkpoint above: with the allowlist,
+# adding a JID by hand IS your assertion that the group's notice has been
+# posted. With this on, that obligation moves entirely onto you, including for
+# groups the bot is added to later. Prefer the allowlist if you want the pause.
+# It does NOT archive 1:1 DMs — group messages only, under either setting.
+WHATSAPP_ARCHIVE_ALL_GROUPS=false
 # Voice-note transcription (Baileys only), OFF by default. When on, an
 # eligible caller's voice note is transcribed locally (transformers.js
 # Whisper — no external API, no extra key, audio never leaves the host) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 ## 2026-08-01
 
 ### Changed
+- **Admins can now archive every WhatsApp group the bot is in, not just named
+  ones** (`WHATSAPP_ARCHIVE_ALL_GROUPS`, off by default). Previously each group
+  had to be listed individually; this matches how Discord archiving already
+  works. Private 1:1 chats with the bot are still never archived, and deleting
+  your message still deletes the stored copy. If your community turns this on,
+  every group the bot is in should be told — see docs/SECURITY.md.
 - **The bot now remembers which WhatsApp privacy id belongs to which number.**
   WhatsApp gives people a phone number and a separate "privacy id", and only the
   number identifies someone here. The bot already worked out the link when it

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -362,7 +362,20 @@ A normal user tries to get the agent to moderate, announce, or reveal secrets.
   allowlist**, not a single all-channels flag. WhatsApp groups have no
   "public channel" convention, so each group's archiving is opted into
   individually — the act of adding a JID to the list **is** the operator's
-  assertion that the group's notice has been posted. Guest 1:1 DMs to the
+  assertion that the group's notice has been posted.
+
+  **`WHATSAPP_ARCHIVE_ALL_GROUPS` (off by default) deliberately reverses that
+  for operators who want Discord parity.** With it on, every group the bot is
+  in — including ones it is added to later — is archived with no per-group
+  step. That removes the checkpoint described above, so the notice obligation
+  moves *entirely* onto the operator: turning it on is an assertion that every
+  group the bot is in has been told, and that any group it is added to in
+  future will be. Prefer the JID allowlist if you want the per-group pause;
+  choose the blanket flag knowingly, not for convenience. What it does **not**
+  do is widen archiving beyond groups — `!msg.isDirect` still gates the write
+  in both the router and `inArchiveScope`, so a guest's 1:1 DM is never stored
+  under either setting (pinned by a `SECURITY:` test that runs with the blanket
+  flag on and the allowlist empty). Guest 1:1 DMs to the
   bot are never archived, regardless of config. Edit-tracking is
   best-effort (Baileys' protocol fidelity for edits is less reliable than
   for revokes); delete-honouring is the load-bearing privacy promise and

--- a/src/config.ts
+++ b/src/config.ts
@@ -335,6 +335,22 @@ const EnvSchema = z.object({
   // added here (see SECURITY.md). Unset/empty = feature fully off, zero
   // behaviour change. 1:1 DMs are never archived for gated guests regardless.
   WHATSAPP_ARCHIVE_GROUP_JIDS: z.string().optional(),
+  // Blanket ambient archiving for EVERY group Dave is in, present and future —
+  // the WhatsApp counterpart to DISCORD_ARCHIVE_ALL_MESSAGES, and a deliberate
+  // reversal of the per-group allowlist's original rationale (issue #103,
+  // docs/SECURITY.md): that allowlist existed because adding a JID by hand WAS
+  // the operator's assertion that the group's notice had been posted. A blanket
+  // flag removes that per-group step, so the notice obligation moves entirely
+  // onto the operator — turning this on is an assertion that every group the
+  // bot is in has been told, including groups it is added to later.
+  //
+  // Off by default, and it does NOT widen what is archived beyond groups:
+  // `!msg.isDirect` still gates the write, so a guest's 1:1 DM is never stored
+  // regardless of this flag (pinned by a SECURITY: test).
+  WHATSAPP_ARCHIVE_ALL_GROUPS: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
   // Voice-note transcription (Baileys only). A super admin's voice message is
   // transcribed locally (transformers.js Whisper, no external API/key — same
   // model-download pattern as embeddings) and the transcript is actioned as if
@@ -1352,6 +1368,7 @@ export const config = {
       cooldownMinutes: env.WHATSAPP_WELCOME_COOLDOWN_MINUTES,
     },
     archiveGroupJids: csv(env.WHATSAPP_ARCHIVE_GROUP_JIDS),
+    archiveAllGroups: env.WHATSAPP_ARCHIVE_ALL_GROUPS ?? false,
     voice: {
       enabled: env.WHATSAPP_VOICE_ENABLED ?? false,
       model: env.WHATSAPP_VOICE_MODEL,

--- a/src/platforms/whatsapp/baileysAdapter.ts
+++ b/src/platforms/whatsapp/baileysAdapter.ts
@@ -666,9 +666,14 @@ export class BaileysAdapter implements PlatformAdapter {
     }
   }
 
-  /** True for a group JID that's opted into ambient archiving (`WHATSAPP_ARCHIVE_GROUP_JIDS`, issue #103). */
+  /** True for a group opted into ambient archiving — either blanket
+   * (`WHATSAPP_ARCHIVE_ALL_GROUPS`) or by JID (`WHATSAPP_ARCHIVE_GROUP_JIDS`, issue #103). */
   private inArchiveScope(remoteJid: string, isGroup: boolean): boolean {
-    return isGroup && config.whatsapp.archiveGroupJids.includes(remoteJid);
+    // `isGroup` stays the outer condition, not an afterthought: the blanket
+    // flag widens WHICH groups are archived, never whether 1:1 DMs are. A
+    // guest's DM to the bot is unstored regardless of either setting.
+    if (!isGroup) return false;
+    return config.whatsapp.archiveAllGroups || config.whatsapp.archiveGroupJids.includes(remoteJid);
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -1069,15 +1069,17 @@ export class Router {
     // and record the request (identity + count only) so admins have a queue.
     if (gated && role === 'guest') {
       // Ambient archiving (issue #48; WhatsApp parity issue #103): with
-      // DISCORD_ARCHIVE_ALL_MESSAGES on, or the WhatsApp conversation JID in
-      // WHATSAPP_ARCHIVE_GROUP_JIDS, guest messages in group/guild channels
+      // DISCORD_ARCHIVE_ALL_MESSAGES on, or WHATSAPP_ARCHIVE_ALL_GROUPS on, or
+      // the WhatsApp JID in WHATSAPP_ARCHIVE_GROUP_JIDS, guest messages in groups
       // ARE stored — a deliberate, documented posture change requiring
       // community notice (SECURITY.md). Guest DMs to the bot stay unstored
       // either way. Storage only: the addressed-check below still solely
       // decides whether the agent runs.
       const archiveAmbient =
         (msg.platform === 'discord' && config.discord.archiveAllMessages) ||
-        (msg.platform === 'whatsapp' && config.whatsapp.archiveGroupJids.includes(msg.conversationId));
+        (msg.platform === 'whatsapp' &&
+          (config.whatsapp.archiveAllGroups ||
+            config.whatsapp.archiveGroupJids.includes(msg.conversationId)));
       if (archiveAmbient && !msg.isDirect && msg.text.trim()) {
         recordInteraction({
           platform: msg.platform,

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -142,6 +142,7 @@
   "usageCostDigest.test.ts": 4,
   "voiceTranscribeModelRouting.test.ts": 2,
   "whatsappAmbientArchiving.test.ts": 3,
+  "whatsappArchiveAllGroups.test.ts": 1,
   "whatsappBlockRouter.test.ts": 1,
   "whatsappBlockRouterOpen.test.ts": 1,
   "whatsappCloudAdapter.test.ts": 21,

--- a/tests/whatsappArchiveAllGroups.test.ts
+++ b/tests/whatsappArchiveAllGroups.test.ts
@@ -1,0 +1,165 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AgentReply } from '../src/agent/core.js';
+import type { IncomingMessage, OutgoingMessage, PlatformAdapter } from '../src/platforms/types.js';
+
+// Blanket WhatsApp group archiving (`WHATSAPP_ARCHIVE_ALL_GROUPS`) — the
+// counterpart to DISCORD_ARCHIVE_ALL_MESSAGES, so every group the bot is in is
+// archived without a per-group JID.
+//
+// Its own file, and deliberately with NO allowlist set: config.ts parses env
+// once at import, and the point of these tests is that the blanket flag works
+// ALONE. If the allowlist were also set, a passing test would prove nothing
+// about which setting did the work. The Node test runner gives each file its
+// own process, which is what makes that isolation possible.
+//
+// DB-backed: these assert what actually lands in (or stays out of) the
+// interactions table, so they skip without DATABASE_URL.
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+const ANY_GROUP = 'wa-blanket-group@g.us';
+
+process.env.WHATSAPP_ARCHIVE_ALL_GROUPS = 'true';
+delete process.env.WHATSAPP_ARCHIVE_GROUP_JIDS; // prove the blanket flag alone does it
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+
+const skip = hasDb
+  ? false
+  : 'DATABASE_URL not set — skipping DB-integration tests (CLAUDE.md: exercise against a local Postgres 16 + pgvector)';
+
+const { Router } = await import('../src/router.js');
+const { pool, closeDb } = await import('../src/storage/db.js');
+const { config } = await import('../src/config.js');
+
+const RUN = `wall${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+
+after(async () => {
+  if (hasDb) {
+    await pool.query(`DELETE FROM interactions WHERE user_id LIKE $1 OR conversation_id LIKE $2`, [
+      `${RUN}%`,
+      `${RUN}%`,
+    ]);
+  }
+  await closeDb();
+});
+
+function makeAdapter(): {
+  adapter: PlatformAdapter;
+  sent: OutgoingMessage[];
+  trigger: (msg: IncomingMessage) => Promise<void>;
+} {
+  let handler: ((msg: IncomingMessage) => Promise<void> | void) | null = null;
+  const sent: OutgoingMessage[] = [];
+  const adapter: PlatformAdapter = {
+    platform: 'whatsapp',
+    adminCapabilities: new Set(),
+    async start() {},
+    async stop() {},
+    isConnected: () => true,
+    onMessage(h) {
+      handler = h;
+    },
+    async sendMessage(out) {
+      sent.push(out);
+    },
+    async sendDirectMessage() {},
+    async conversationsForUser() {
+      return [];
+    },
+    async performAdminAction() {
+      return '';
+    },
+  };
+  return {
+    adapter,
+    sent,
+    trigger: async (msg) => {
+      if (!handler) throw new Error('router.register() was never called');
+      await handler(msg);
+    },
+  };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForRows(userId: string, timeoutMs = 30_000): Promise<Array<Record<string, unknown>>> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { rows } = await pool.query(
+      `SELECT content, kind, role, direction, addressed_to_bot FROM interactions WHERE user_id = $1`,
+      [userId],
+    );
+    if (rows.length > 0 || Date.now() > deadline) return rows;
+    await sleep(100);
+  }
+}
+
+test('WHATSAPP_ARCHIVE_ALL_GROUPS archives a group that is on NO allowlist', { skip }, async () => {
+  assert.equal(config.whatsapp.archiveAllGroups, true, 'precondition: blanket flag on');
+  assert.deepEqual(config.whatsapp.archiveGroupJids, [], 'precondition: allowlist deliberately empty');
+
+  let turnCalls = 0;
+  const router = new Router(async (): Promise<AgentReply> => {
+    turnCalls += 1;
+    return { text: 'should never happen' };
+  }, 1_000_000);
+  const { adapter, sent, trigger } = makeAdapter();
+  router.register(adapter);
+
+  const userId = `${RUN}-guest`;
+  await trigger({
+    platform: 'whatsapp',
+    conversationId: ANY_GROUP,
+    userId,
+    userName: 'Someone',
+    text: 'ambient chatter in a group nobody allowlisted',
+    isDirect: false,
+    addressedToBot: false,
+    timestamp: Date.now(),
+    messageId: `${RUN}-m1`,
+  });
+
+  const rows = await waitForRows(userId);
+  assert.equal(rows.length, 1, 'the group message is archived on the blanket flag alone');
+  assert.equal(rows[0].kind, 'ambient');
+  assert.equal(rows[0].role, 'guest');
+  assert.equal(rows[0].direction, 'inbound');
+  // The posture change is storage ONLY — it must not make the bot start
+  // answering ambient chatter.
+  assert.equal(turnCalls, 0, 'an ambient message still never invokes the agent');
+  assert.equal(sent.length, 0, 'the bot still does not reply to ambient chatter');
+});
+
+test(
+  'SECURITY: a guest 1:1 DM is STILL never stored, even with blanket group archiving on',
+  { skip },
+  async () => {
+    // The invariant the blanket flag must not erode. It widens WHICH GROUPS are
+    // archived, never whether private 1:1 conversations are — `!msg.isDirect`
+    // remains the outer gate in both the router and `inArchiveScope`.
+    const router = new Router(async (): Promise<AgentReply> => ({ text: 'nope' }), 1_000_000);
+    const { adapter, trigger } = makeAdapter();
+    router.register(adapter);
+
+    const userId = `${RUN}-dm-guest`;
+    await trigger({
+      platform: 'whatsapp',
+      conversationId: `${RUN}-dm`,
+      userId,
+      userName: 'Guest',
+      text: 'a private message to the bot',
+      isDirect: true,
+      addressedToBot: true,
+      timestamp: Date.now(),
+      messageId: `${RUN}-m2`,
+    });
+
+    await sleep(1_500); // give any (incorrect) fire-and-forget insert time to land
+    const { rows } = await pool.query(`SELECT 1 FROM interactions WHERE user_id = $1`, [userId]);
+    assert.equal(rows.length, 0, 'SECURITY: a guest DM must never be archived, blanket flag or not');
+  },
+);


### PR DESCRIPTION
## Summary

WhatsApp archiving was a **per-group JID allowlist** while Discord had a single all-channels flag, so every group the bot joined needed a config edit before its messages were stored. This adds the blanket counterpart, `WHATSAPP_ARCHIVE_ALL_GROUPS`, **off by default**.

## This deliberately reverses a documented decision, and says so

`docs/SECURITY.md` argued the per-group list *was* the consent checkpoint:

> *"the act of adding a JID to the list **is** the operator's assertion that the group's notice has been posted"*

A blanket flag removes that step. Rather than leave the docs quietly contradicting the code, §6's archiving section now states both options, which to prefer, and that the notice obligation moves **entirely onto the operator** — including for groups the bot is added to later. The operator asked for Discord parity with that trade-off explained up front; this records it rather than hiding it.

## Security / privacy impact

**The change widens *which groups* are archived — never *whether private conversations* are.**

- `!msg.isDirect` remains the outer gate in the router.
- `inArchiveScope` now checks `isGroup` **first and returns early**, so the blanket flag is structurally incapable of reaching a 1:1 DM.
- A `SECURITY:` test pins exactly that, running with the blanket flag **on** and the allowlist **empty**: a guest DM is still not stored.

Also unchanged: ambient storage is decoupled from response (an archived message still never invokes the agent — asserted), delete/edit honouring, retention purge, `forget_me`/`purge_user_data`, and conversation-scoped recall.

It is off by default, so merging changes nothing until an operator sets it.

## Your second ask needed no code

Dave's replies are **already stored**. `recordInteraction({ userId: 'bot', direction: 'outbound' })` runs whenever he responds, independent of archiving config — **211 Discord and 210 WhatsApp replies with full content since 2026-07-03**. So the full transcript for later review already exists for every conversation he takes part in; this PR adds the inbound group side that was missing.

## How verified

**Against a real Postgres** (a `pgvector` container), since these assert what actually lands in the `interactions` table:

- New tests **2/2** — a group on *no* allowlist is archived on the blanket flag alone (and still never invokes the agent), and the guest-DM invariant holds.
- **No regressions** in the existing archiving suites: `whatsappAmbientArchiving` 4/4, `ambientArchivingOff` 2/2, `baileysArchiving` 5/5.
- Full suite: **3273 tests, 0 failures.**
- `typecheck` (incl. the tests ratchet), `lint`, `build`, `context:check` clean; Prettier clean; `security-floor.json` updated (+1).

The new tests are in their own file with `WHATSAPP_ARCHIVE_GROUP_JIDS` explicitly **deleted** from the env, because `config.ts` parses env once at import — had both been set, a passing test would have proved nothing about which setting did the work.

## Before turning it on

Post the ready-to-pin notice from `docs/SECURITY.md` in each group. With the allowlist that step was forced by the config edit; with this flag it isn't, which is the whole trade-off.
