### PR TITLE
Give access_requests an erasure path and a retention sweep (#939)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,12 @@ INTERACTION_RETENTION_DAYS=
 # (left_at IS NOT NULL). Unset/0 = disabled. Must be 0 or >= 30 if set.
 # Currently-present members are never touched regardless of this setting.
 ROSTER_DEPARTED_RETENTION_DAYS=
+# Age-based purge of PENDING access requests (name + platform user id of
+# non-members who asked for access) once they have gone quiet for this long.
+# Unset/0 = disabled. Must be 0 or >= 30 if set. A guest who is still asking is
+# never purged (the clock runs off their LAST request), and an approved
+# requester's row is already deleted at add_member time.
+ACCESS_REQUEST_RETENTION_DAYS=
 # A platform disconnected continuously past this many minutes triggers one
 # debounced super-admin DM alert (via whichever adapter is still up).
 HEALTH_ALERT_AFTER_MINUTES=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 ## 2026-08-01
 
 ### Changed
+- **If you asked the bot for access and were never added, that record no longer
+  sits there forever.** When someone who isn't a member messages the bot, it
+  keeps their name and platform id so admins can see the request — on WhatsApp
+  that id is their phone number. Until now the only way that record was ever
+  deleted was being approved. Two fixes: asking to be forgotten
+  (`forget_me`, or an admin's `purge_user_data`) now erases a pending request
+  too, and communities can set `ACCESS_REQUEST_RETENTION_DAYS` so requests that
+  have gone quiet are cleared automatically. If you're still asking, your
+  request is never swept — the clock only starts once you stop.
 - **Admins can now archive every WhatsApp group the bot is in, not just named
   ones** (`WHATSAPP_ARCHIVE_ALL_GROUPS`, off by default). Previously each group
   had to be listed individually; this matches how Discord archiving already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 
 ### Changed
 - **If you asked the bot for access and were never added, that record no longer
-  sits there forever.** When someone who isn't a member messages the bot, it
+  sits there forever** (#940). When someone who isn't a member messages the bot, it
   keeps their name and platform id so admins can see the request — on WhatsApp
   that id is their phone number. Until now the only way that record was ever
   deleted was being approved. Two fixes: asking to be forgotten

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -3603,7 +3603,14 @@ often.
   old posture, pinned by test). Two metadata-only exceptions exist
   regardless of either flag: `access_requests` (identity + request count for
   guests who addressed the bot) and `server_roster` (join/leave identity
-  metadata, Discord-only) — neither stores content.
+  metadata, Discord-only) — neither stores content. **Metadata-only is a
+  statement about what these tables hold, never a licence to hold it
+  forever**: both are erasable via `forget_me`/`purge_user_data` and both are
+  age-purgeable (`ACCESS_REQUEST_RETENTION_DAYS` /
+  `ROSTER_DEPARTED_RETENTION_DAYS`). Until issue #939, `access_requests` was
+  neither — the sole delete was on approval, so a non-member who asked and was
+  never added was retained indefinitely with no erasure path. That was a real
+  gap, not an accepted trade-off, and it is now closed on both axes.
 - **The roster narrows the "guests are invisible" spirit, not its letter**:
   `server_roster` deliberately records the *identity* (never content) of every
   guild member — including lurkers who never touched the bot — because the
@@ -3616,11 +3623,30 @@ often.
   default disabled; a 30-day floor when enabled keeps `list_roster`'s
   "left this week" pulse intact). Currently-present rows (`left_at IS NULL`)
   are never purged regardless of this setting.
+- **The pending access-request queue expires too (issue #939)**:
+  `access_requests` holds the display name and platform user id of anyone who
+  addressed the bot in gated mode without being a member — and on WhatsApp the
+  user id *is* the phone number, so this is the single most sensitive
+  non-member record the system keeps. A row leaves the table three ways now:
+  deleted on approval (`add_member` -> `clearAccessRequest`), erased on
+  `forget_me`/`purge_user_data` (delegating to that same single deletion path,
+  inside the purge transaction), or age-purged once the requester has gone
+  quiet for `ACCESS_REQUEST_RETENTION_DAYS` (default disabled; a 30-day floor
+  when enabled). The retention clock runs off `last_requested_at`, not
+  `first_requested_at`, so an open request from someone still asking is never
+  swept — only abandoned ones. Erasing a pending request is safe where erasing
+  a `blocked_users` row would not be: the queue entry grants nothing and gates
+  nothing, and a purged requester who asks again simply reappears as a fresh
+  request (and re-triggers the first-time-only admin alert, by design).
+  Enabling retention does bound `list_access_requests`/the admin digest's
+  oldest-pending age from above — anything older has been deleted — which is
+  why the floor is generous rather than tight.
 - **forget_me/purge scope**: deletes the user's messages, replies to them,
   knowledge entries *sourced from* them, content reports *they submitted
   as reporter*, their response-style preference, their auto-moderation
-  warning history (`member_warnings`), and moderation appeals *they filed*
-  (`moderation_appeals`, issue #554). Membership rows, the
+  warning history (`member_warnings`), moderation appeals *they filed*
+  (`moderation_appeals`, issue #554), and any pending access request in their
+  name (`access_requests`, issue #939). Membership rows, the
   admin audit log, and reports where the user is only the *target* (not the
   reporter) are retained deliberately
   (accountability) — the same precedent already applied to `admin_audit`. If
@@ -3636,7 +3662,10 @@ often.
   so it can never see another member's data. It deliberately does **not**
   count or query `member_notes` (issue #45's members-have-no-self-access
   boundary), `member_warnings` (see `my_warnings` instead), `server_roster`,
-  `admin_digest_sends`, or `answer_feedback` — `forget_me` purges a strict
+  `admin_digest_sends`, `access_requests` (a pending request is guest-tier
+  state; `my_data` is member-tier, and by the time a member can call it their
+  row has already been deleted at approval), or `answer_feedback` —
+  `forget_me` purges a strict
   superset of what `my_data` ever reports, and that asymmetry is intentional,
   not a bug to "reconcile" away.
 - **DM-originated content reports are visible to every admin, not only

--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -23,6 +23,7 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 
 <!-- module-map:begin -->
 
+- `src/accessRequestRetention.ts` — Scheduled purge of pending access requests whose requester has gone quiet, the third retention sweep beside interactions and roster; the clock runs off the LAST request, so an open request is never swept.
 - `src/ackClassifier.ts` — Deterministic "is this just 'thanks'?" classifier; lets the router skip a whole agent turn (and its cost) on a pure acknowledgement.
 - `src/adminDigest.ts` — Builds and sends the periodic admin digest: moderation, engagement, feedback and cost summaries for admins, scoped to their own conversations.
 - `src/adminLeverageAlert.ts` — Weekly super-admin push of `adminActivitySummary`'s actions-per-admin rate, the pull-to-push complement of the on-demand `admin_activity` tool.

--- a/src/accessRequestRetention.ts
+++ b/src/accessRequestRetention.ts
@@ -1,0 +1,38 @@
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { purgeOldAccessRequests } from './storage/repository.js';
+import { startTrackedJob } from './backgroundJobs.js';
+import type { PlatformAdapter } from './platforms/types.js';
+
+const DAY_MS = 24 * 60 * 60_000;
+
+/**
+ * Age-based purge of stale pending `access_requests` rows (issue #939). Off
+ * unless ACCESS_REQUEST_RETENTION_DAYS is set. Runs on its own timer, gated
+ * only on its own config — independent of INTERACTION_RETENTION_DAYS and
+ * ROSTER_DEPARTED_RETENTION_DAYS, so one purge being disabled never suppresses
+ * another. Routed through the shared `startTrackedJob` helper (issue #291) for
+ * consecutive-failure alerting; see src/interactionRetention.ts for the
+ * matching freshness-guard rationale that keeps the actual purge daily even
+ * though `startTrackedJob` itself ticks every 6h.
+ *
+ * This is the third of the three retention sweeps and closes the last PII
+ * store that had no expiry at all: an approved requester's row is deleted by
+ * `clearAccessRequest`, but a NEVER-approved one used to live forever. See
+ * `purgeOldAccessRequests` for why the clock runs off `last_requested_at`.
+ */
+export function startAccessRequestRetentionPurge(
+  adapters: readonly PlatformAdapter[],
+  purge: (days: number) => Promise<number> = purgeOldAccessRequests,
+): ReturnType<typeof setInterval> | null {
+  const days = config.behaviour.accessRequestRetentionDays;
+  let lastRunAt: number | null = null;
+  const runOnce = async () => {
+    const now = Date.now();
+    if (lastRunAt !== null && now - lastRunAt < DAY_MS) return;
+    const count = await purge(days);
+    lastRunAt = now;
+    logger.info({ days, count }, 'Purged stale pending access requests (retention policy)');
+  };
+  return startTrackedJob('access-request-retention-purge', adapters, days > 0, runOnce);
+}

--- a/src/backgroundJobHealth.ts
+++ b/src/backgroundJobHealth.ts
@@ -47,6 +47,7 @@ export type BackgroundJobName =
   | 'knowledge-link-check'
   | 'interaction-retention-purge'
   | 'roster-retention-purge'
+  | 'access-request-retention-purge'
   | 'anthropic-status-check'
   | 'embedding-model'
   | 'admin-digest'

--- a/src/config.ts
+++ b/src/config.ts
@@ -609,6 +609,12 @@ const EnvSchema = z.object({
   // upgrade). Currently-present members (left_at IS NULL) are never touched
   // regardless of this setting — see storage/repository.ts:purgeDepartedRoster.
   ROSTER_DEPARTED_RETENTION_DAYS: z.coerce.number().int().nonnegative().default(0),
+  // Age-based purge of PENDING `access_requests` rows that have gone quiet
+  // (issue #939). Unset/0 = disabled (no behaviour change on upgrade). Clock
+  // runs off last_requested_at, so a guest who is still asking is never
+  // purged; an approved requester's row is already deleted on add_member.
+  // See storage/repository.ts:purgeOldAccessRequests.
+  ACCESS_REQUEST_RETENTION_DAYS: z.coerce.number().int().nonnegative().default(0),
   // Sustained platform disconnect -> one debounced super-admin DM alert.
   HEALTH_ALERT_AFTER_MINUTES: z.coerce.number().positive().default(5),
   // Proactive super-admin alert when rolling-24h outbound reply count
@@ -1138,6 +1144,15 @@ const MIN_INTERACTION_RETENTION_DAYS = 7;
 // floor comfortably preserves that pulse while still bounding retention.
 const MIN_ROSTER_DEPARTED_RETENTION_DAYS = 30;
 
+// A pending access request is a person waiting on a human decision, so the
+// floor is set by how long admins can plausibly take to make one, not by how
+// fast the data could be dropped. 30 days matches the roster floor and keeps
+// this comfortably clear of the admin digest's own nag horizon — enabling
+// retention must never delete a backlog out from under the digest that exists
+// to surface it. It also bounds `oldestAccessRequestAgeDays` from above (see
+// its doc comment), which is only honest if the bound is generous.
+const MIN_ACCESS_REQUEST_RETENTION_DAYS = 30;
+
 // A threshold below a month would flag entries an admin just as plausibly
 // hasn't gotten around to re-checking yet rather than ones that are stale.
 const MIN_KNOWLEDGE_STALE_DAYS = 30;
@@ -1186,6 +1201,15 @@ const EnvSchemaChecked = EnvSchema.refine(
     {
       message: `ROSTER_DEPARTED_RETENTION_DAYS must be 0 (disabled) or at least ${MIN_ROSTER_DEPARTED_RETENTION_DAYS}`,
       path: ['ROSTER_DEPARTED_RETENTION_DAYS'],
+    },
+  )
+  .refine(
+    (e) =>
+      e.ACCESS_REQUEST_RETENTION_DAYS === 0 ||
+      e.ACCESS_REQUEST_RETENTION_DAYS >= MIN_ACCESS_REQUEST_RETENTION_DAYS,
+    {
+      message: `ACCESS_REQUEST_RETENTION_DAYS must be 0 (disabled) or at least ${MIN_ACCESS_REQUEST_RETENTION_DAYS}`,
+      path: ['ACCESS_REQUEST_RETENTION_DAYS'],
     },
   )
   .refine((e) => e.KNOWLEDGE_STALE_DAYS === 0 || e.KNOWLEDGE_STALE_DAYS >= MIN_KNOWLEDGE_STALE_DAYS, {
@@ -1526,6 +1550,7 @@ export const config = {
     maxIncomingMessageChars: env.MAX_INCOMING_MESSAGE_CHARS,
     interactionRetentionDays: env.INTERACTION_RETENTION_DAYS,
     rosterDepartedRetentionDays: env.ROSTER_DEPARTED_RETENTION_DAYS,
+    accessRequestRetentionDays: env.ACCESS_REQUEST_RETENTION_DAYS,
     healthAlertAfterMinutes: env.HEALTH_ALERT_AFTER_MINUTES,
     healthPort: env.HEALTH_PORT,
     healthHost: env.HEALTH_HOST,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { closeDb, healthcheck } from './storage/db.js';
 import { verifyEmbeddingDim } from './storage/repository.js';
 import { startRetentionPurge } from './interactionRetention.js';
 import { startRosterRetentionPurge } from './rosterRetention.js';
+import { startAccessRequestRetentionPurge } from './accessRequestRetention.js';
 import {
   startContextBuilder,
   startKnowledgeRefresh,
@@ -75,6 +76,7 @@ async function main(): Promise<void> {
   //     (issue #291), hence the `adapters` argument.
   const retentionTimer = startRetentionPurge(adapters);
   const rosterRetentionTimer = startRosterRetentionPurge(adapters);
+  const accessRequestRetentionTimer = startAccessRequestRetentionPurge(adapters);
 
   // 4c. Sustained-disconnect super-admin alerting (always on; no user-facing
   //     surface to disable) and the optional /healthz endpoint.
@@ -137,6 +139,7 @@ async function main(): Promise<void> {
     logger.info({ signal }, 'Shutting down');
     if (retentionTimer) clearInterval(retentionTimer);
     if (rosterRetentionTimer) clearInterval(rosterRetentionTimer);
+    if (accessRequestRetentionTimer) clearInterval(accessRequestRetentionTimer);
     clearInterval(disconnectAlertTimer);
     if (embeddingHealthTimer) clearInterval(embeddingHealthTimer);
     if (usageAlertTimer) clearInterval(usageAlertTimer);

--- a/src/storage/repository/accessRequests.ts
+++ b/src/storage/repository/accessRequests.ts
@@ -1,5 +1,6 @@
 import type { Platform } from '../../platforms/types.js';
 import { pool } from '../db.js';
+import type { Queryable } from './shared.js';
 
 /**
  * Gated-mode pending access-request queue: who has asked for access, how long
@@ -74,9 +75,67 @@ export async function listAccessRequests(limit = 50): Promise<AccessRequest[]> {
   }));
 }
 
-/** Clear a resolved access request (e.g. after add_member succeeds for that user). */
-export async function clearAccessRequest(platform: Platform, userId: string): Promise<void> {
-  await pool.query(`DELETE FROM access_requests WHERE platform = $1 AND user_id = $2`, [platform, userId]);
+/**
+ * Clear a resolved access request (e.g. after add_member succeeds for that
+ * user) — and, since issue #939, the ERASURE path for this table too: this is
+ * the single deletion path `purgeSingleIdentity` delegates to for
+ * `forget_me`/`purge_user_data`.
+ *
+ * Takes an optional {@link Queryable} for exactly the reason
+ * `forgetLidMappingsForPhone` does (PR #935 review): the privacy purge must be
+ * able to pass its own transaction `client` so this delete commits or rolls
+ * back atomically with the rest of the erasure, and there must be ONE copy of
+ * the DELETE so a future predicate change can't apply to the add_member path
+ * but not the erasure path — that kind of drift is a PII-retention bug, not a
+ * cosmetic one.
+ *
+ * Returns the row count (0 or 1 — `UNIQUE (platform, user_id)`) so the purge
+ * can include it in its total rather than silently dropping it.
+ */
+export async function clearAccessRequest(
+  platform: Platform,
+  userId: string,
+  db: Queryable = pool,
+): Promise<number> {
+  const { rowCount } = await db.query(`DELETE FROM access_requests WHERE platform = $1 AND user_id = $2`, [
+    platform,
+    userId,
+  ]);
+  return rowCount ?? 0;
+}
+
+/**
+ * Age-based retention: delete pending access requests that have gone quiet for
+ * `days` (issue #939). Until this existed, `access_requests` was the one PII
+ * store in the schema with NO expiry at all — the only delete was
+ * `clearAccessRequest` on approval, so a non-member's name and (on WhatsApp)
+ * phone number sat there indefinitely for anyone who asked and was never
+ * added. That is the population least likely to have any relationship with
+ * this community, so it is the last data that should be kept forever.
+ *
+ * Keyed on `last_requested_at`, NOT `first_requested_at`: the row should
+ * expire once the person STOPS asking, not on a fixed clock from their first
+ * ping. A guest still actively requesting is still an open request and is
+ * never purged, however old their first attempt is.
+ *
+ * Deleting a row is not the same as resolving it — a purged guest who asks
+ * again gets a genuinely fresh row, so `recordAccessRequest` reports
+ * `inserted: true` and the first-time-only admin alert fires again (correct: a
+ * new request months later deserves a new notification), and their
+ * `first_requested_at` wait clock restarts.
+ *
+ * NOTE the interaction with {@link oldestAccessRequestAgeDays}: when this is
+ * enabled, the admin digest's oldest-pending age can never exceed `days`,
+ * because anything older has been deleted. The floor in config.ts
+ * (MIN_ACCESS_REQUEST_RETENTION_DAYS) exists so that ceiling always stays well
+ * above the horizon admins actually triage on.
+ */
+export async function purgeOldAccessRequests(days: number): Promise<number> {
+  const { rowCount } = await pool.query(
+    `DELETE FROM access_requests WHERE last_requested_at < now() - ($1::text || ' days')::interval`,
+    [days],
+  );
+  return rowCount ?? 0;
 }
 
 /**
@@ -99,6 +158,12 @@ export async function countAccessRequests(): Promise<number> {
  * backlog and `MIN` over an empty table is `null`, never `0` — returned
  * as-is rather than coerced, so an admin/digest reader can never mistake
  * "no pending requests" for "a request that just arrived".
+ *
+ * One caveat once ACCESS_REQUEST_RETENTION_DAYS is enabled (issue #939): this
+ * value is then bounded above by that setting, since
+ * {@link purgeOldAccessRequests} has already deleted anything quiet for
+ * longer. "Oldest pending: 29 days" under a 30-day retention means the oldest
+ * SURVIVING request, not necessarily the oldest ever made.
  */
 export async function oldestAccessRequestAgeDays(): Promise<number | null> {
   const { rows } = await pool.query(

--- a/src/storage/repository/budgetsPrivacy.ts
+++ b/src/storage/repository/budgetsPrivacy.ts
@@ -3,6 +3,7 @@ import { pool } from '../db.js';
 import { invalidateDigestsForInteractions } from './shared.js';
 import { resolveLinkedIdentities } from './members.js';
 import { forgetLidMappingsForPhone } from './whatsappLidMap.js';
+import { clearAccessRequest } from './accessRequests.js';
 import { getResponseStyle, type ResponseStyle } from './preferences.js';
 
 /**
@@ -274,6 +275,25 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
     // atomically with the rest of this transaction.
     const lidMappings = platform === 'whatsapp' ? await forgetLidMappingsForPhone(userId, client) : 0;
 
+    // access_requests (issue #939). Previously the ONLY route out of this
+    // table was `clearAccessRequest` on approval, so someone who asked for
+    // access and was never added had their display name — and on WhatsApp
+    // their phone number, since that IS the user id there — retained
+    // indefinitely with no erasure path and no expiry. docs/SECURITY.md named
+    // it a metadata-only exception to guest invisibility, which is true of its
+    // CONTENT but was never a licence to keep the identity forever.
+    //
+    // Delegates to `clearAccessRequest` with this transaction's `client`, for
+    // the same one-deletion-path reason as the LID mapping above rather than
+    // inlining a second DELETE here.
+    //
+    // Deleting a PENDING request cannot be an end-run around moderation, which
+    // is why this is safe where `blocked_users` deliberately is not: an
+    // access_requests row grants nothing and gates nothing — it is a queue
+    // entry. Someone who erases it and asks again simply reappears in the
+    // queue as a fresh request.
+    const accessRequests = await clearAccessRequest(platform, userId, client);
+
     await client.query(`UPDATE projects SET created_by = NULL WHERE created_by = $1`, [userId]);
     await client.query(`UPDATE project_members SET added_by = NULL WHERE added_by = $1`, [userId]);
     await client.query(`UPDATE project_surfaces SET bound_by = NULL WHERE bound_by = $1`, [userId]);
@@ -301,7 +321,8 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
       (knowledgeTips ?? 0) +
       (helperNotifications ?? 0) +
       (projectConnectionRequests ?? 0) +
-      lidMappings
+      lidMappings +
+      accessRequests
     );
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -321,7 +342,8 @@ async function purgeSingleIdentity(platform: Platform, userId: string): Promise<
  * knowledge_candidates drafted from an invalidated digest (issue #102), any
  * moderation appeal(s) *they filed* (issue #554), and any knowledge_candidates
  * row *they themselves suggested* via suggest_knowledge in ANY status (issue
- * #633) — across every identity linked to them via
+ * #633), and any still-pending access request in their name (issue #939) —
+ * across every identity linked to them via
  * `link_member` (SECURITY: this is a deliberate blast-radius expansion —
  * linking two identities means forget_me/purge from *either* now erases
  * *both*, which is why `link_member` is CONFIRM-gated, audited, and

--- a/tests/accessRequestRetention.test.ts
+++ b/tests/accessRequestRetention.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// config.ts validates env at import time — provide a dummy environment before
+// importing anything that (transitively) loads it, matching the convention in
+// tests/rosterRetention.test.ts. ACCESS_REQUEST_RETENTION_DAYS is deliberately
+// left unset so this exercises the disabled-by-default path: enabling a purge
+// that deletes rows is an operator decision, never something an upgrade does
+// silently.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+
+const { startAccessRequestRetentionPurge } = await import('../src/accessRequestRetention.js');
+
+test('startAccessRequestRetentionPurge: ACCESS_REQUEST_RETENTION_DAYS unset (default) creates no timer', () => {
+  const timer = startAccessRequestRetentionPurge([]);
+  assert.equal(timer, null, 'disabled by default — no timer, no deletions, no extra queries');
+});

--- a/tests/accessRequestRetentionIndependence.test.ts
+++ b/tests/accessRequestRetentionIndependence.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// config.ts validates env at import time. This file deliberately sets
+// ACCESS_REQUEST_RETENTION_DAYS while leaving BOTH other retention purges at 0
+// (disabled), pinning the same independence requirement issue #136 established
+// for the roster purge: there are now three retention sweeps, and each must be
+// gated solely on its own env var. A shared "is retention on at all" gate would
+// mean an operator who wants only the PII-sensitive access-request sweep is
+// forced to also age-purge interactions, or gets nothing.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+process.env.INTERACTION_RETENTION_DAYS = '0';
+process.env.ROSTER_DEPARTED_RETENTION_DAYS = '0';
+process.env.ACCESS_REQUEST_RETENTION_DAYS = '30';
+
+const { config } = await import('../src/config.js');
+const { startAccessRequestRetentionPurge } = await import('../src/accessRequestRetention.js');
+
+test(
+  'startAccessRequestRetentionPurge: creates a timer on its OWN gate, with both the interaction and roster ' +
+    'purges disabled (issue #939, following #136)',
+  () => {
+    assert.equal(
+      config.behaviour.interactionRetentionDays,
+      0,
+      'sanity: the interactions purge is disabled in this scenario',
+    );
+    assert.equal(
+      config.behaviour.rosterDepartedRetentionDays,
+      0,
+      'sanity: the roster purge is disabled in this scenario',
+    );
+    assert.equal(config.behaviour.accessRequestRetentionDays, 30);
+
+    // Inject a stub purge, for the same reason tests/rosterRetentionIndependence
+    // does: startTrackedJob fires `void run()` immediately rather than on the
+    // first interval, and the `void` means the clearInterval below cannot
+    // cancel it — so the real purge would run against the shared CI database
+    // and race repository.test.ts's own deliberately-backdated fixtures. This
+    // test asserts only the timer-creation gate, so it needs no real deletion.
+    const timer = startAccessRequestRetentionPurge([], async () => 0);
+    assert.notEqual(
+      timer,
+      null,
+      'the access-request purge must run on its own gate — the other purges being disabled must never suppress it',
+    );
+    if (timer) clearInterval(timer);
+  },
+);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -48,6 +48,46 @@ test('config: ROSTER_DEPARTED_RETENTION_DAYS unset (default) is disabled — zer
   assert.equal(config.behaviour.rosterDepartedRetentionDays, 0);
 });
 
+test('config: ACCESS_REQUEST_RETENTION_DAYS unset (default) is disabled — a purge that deletes rows is never turned on by an upgrade (issue #939)', () => {
+  assert.equal(config.behaviour.accessRequestRetentionDays, 0);
+});
+
+test('config: ACCESS_REQUEST_RETENTION_DAYS is REJECTED at startup below its 30-day floor (issue #939)', () => {
+  // The floor is not cosmetic. A pending access request is a person waiting on
+  // a human decision, so too tight a window deletes open requests before
+  // admins realistically triage them — and it silently caps
+  // oldestAccessRequestAgeDays, the very signal the admin digest uses to nag
+  // about the backlog. Refusing at startup beats discovering it from a queue
+  // that mysteriously never ages past the window.
+  const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+  const runWith = (days: string) =>
+    spawnSync(process.execPath, ['node_modules/tsx/dist/cli.mjs', 'tests/fixtures/loadConfig.ts'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLAUDE_CODE_OAUTH_TOKEN: 'test-token',
+        DISCORD_BOT_TOKEN: 'test-token',
+        DISCORD_GUILD_ID: '1',
+        DATABASE_URL: 'postgres://test:test@127.0.0.1:5432/test',
+        WHATSAPP_PROVIDER: 'disabled',
+        ACCESS_REQUEST_RETENTION_DAYS: days,
+      },
+    });
+
+  const tooLow = runWith('7');
+  assert.notEqual(tooLow.status, 0, 'below the floor must fail startup, not be silently accepted');
+  assert.match(`${tooLow.stderr}${tooLow.stdout}`, /ACCESS_REQUEST_RETENTION_DAYS/);
+
+  const disabled = runWith('0');
+  assert.equal(disabled.status, 0, `0 stays the explicit disabled value; stderr: ${disabled.stderr}`);
+  assert.equal(JSON.parse(disabled.stdout).behaviour.accessRequestRetentionDays, 0);
+
+  const atFloor = runWith('30');
+  assert.equal(atFloor.status, 0, `the floor itself is accepted; stderr: ${atFloor.stderr}`);
+  assert.equal(JSON.parse(atFloor.stdout).behaviour.accessRequestRetentionDays, 30);
+});
+
 test('config: AGENT_TURN_TIMEOUT_MS unset defaults to 300_000 (issue #826)', () => {
   assert.equal(config.behaviour.agentTurnTimeoutMs, 300_000);
 });

--- a/tests/repository.test.ts
+++ b/tests/repository.test.ts
@@ -103,6 +103,7 @@ const {
   countAccessRequests,
   oldestAccessRequestAgeDays,
   clearAccessRequest,
+  purgeOldAccessRequests,
   upsertRosterMember,
   markRosterLeave,
   listRoster,
@@ -14290,5 +14291,118 @@ test(
     );
 
     await pool.query(`DELETE FROM interactions WHERE conversation_id = $1`, [conversationId]);
+  },
+);
+
+test(
+  'repository: purgeOldAccessRequests sweeps a request that has gone QUIET past the window, keeps a recent one, and — the point of the last_requested_at clock — keeps an ancient request the person is STILL making (issue #939)',
+  { skip },
+  async () => {
+    const quiet = `${RUN}-arret-quiet`;
+    const recent = `${RUN}-arret-recent`;
+    const persistent = `${RUN}-arret-persistent`;
+    for (const userId of [quiet, recent, persistent]) {
+      await recordAccessRequest({ platform: 'discord', userId, userName: 'tester' });
+    }
+
+    // `quiet`: asked once, long ago, never again -> abandoned, sweep it.
+    await pool.query(
+      `UPDATE access_requests
+          SET first_requested_at = now() - interval '400 days',
+              last_requested_at  = now() - interval '400 days'
+        WHERE platform = 'discord' AND user_id = $1`,
+      [quiet],
+    );
+    // `persistent`: FIRST asked even longer ago, but asked again an hour ago.
+    // On a first_requested_at clock this row would be swept — deleting an open
+    // request from someone actively still waiting on an answer, which is the
+    // exact failure the last_requested_at choice exists to prevent.
+    await pool.query(
+      `UPDATE access_requests
+          SET first_requested_at = now() - interval '500 days',
+              last_requested_at  = now() - interval '1 hour'
+        WHERE platform = 'discord' AND user_id = $1`,
+      [persistent],
+    );
+
+    const purged = await purgeOldAccessRequests(365);
+    assert.ok(purged >= 1, 'the abandoned request is swept');
+
+    const { rows } = await pool.query(
+      `SELECT user_id FROM access_requests WHERE user_id = ANY($1::text[]) ORDER BY user_id`,
+      [[quiet, recent, persistent]],
+    );
+    const survivors = rows.map((r) => r.user_id).sort();
+    assert.deepEqual(
+      survivors,
+      [persistent, recent].sort(),
+      'only the quiet row is deleted — a still-active requester survives however old their first ask was',
+    );
+
+    await clearAccessRequest('discord', recent);
+    await clearAccessRequest('discord', persistent);
+  },
+);
+
+test(
+  'SECURITY: repository: purgeUserData (forget_me/purge_user_data) erases the caller\u2019s PENDING access request and nobody else\u2019s (issue #939)',
+  { skip },
+  async () => {
+    const victim = `${RUN}-arpurge-victim`;
+    const bystander = `${RUN}-arpurge-bystander`;
+    await recordAccessRequest({ platform: 'discord', userId: victim, userName: 'Victim Name' });
+    await recordAccessRequest({ platform: 'discord', userId: bystander, userName: 'Bystander Name' });
+
+    await purgeUserData('discord', victim);
+
+    const { rows: gone } = await pool.query(
+      `SELECT 1 FROM access_requests WHERE platform = 'discord' AND user_id = $1`,
+      [victim],
+    );
+    assert.equal(gone.length, 0, 'SECURITY: a pending access request must not survive an erasure request');
+    const { rows: kept } = await pool.query(
+      `SELECT 1 FROM access_requests WHERE platform = 'discord' AND user_id = $1`,
+      [bystander],
+    );
+    assert.equal(kept.length, 1, "another pending requester's row is untouched");
+
+    await clearAccessRequest('discord', bystander);
+  },
+);
+
+test(
+  'SECURITY: repository: clearAccessRequest honours a caller-supplied transaction client, so the erasure rolls back with the rest of purgeSingleIdentity instead of committing on its own (issue #939)',
+  { skip },
+  async () => {
+    // The regression this pins is precisely the one PR #935 review caught on
+    // the sibling LID-mapping delete: writing `pool` where `client` belongs.
+    // It typechecks, it passes any test that only asserts the row is gone, and
+    // it silently makes erasure non-atomic — a crash later in the purge would
+    // leave this row deleted while everything else rolled back. Here the
+    // rollback is explicit, so a `pool` regression fails loudly.
+    const userId = `${RUN}-artx`;
+    await recordAccessRequest({ platform: 'discord', userId, userName: 'tester' });
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const deleted = await clearAccessRequest('discord', userId, client);
+      assert.equal(deleted, 1, 'the delete reports the row it removed, so the purge can count it');
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+
+    const { rows } = await pool.query(
+      `SELECT 1 FROM access_requests WHERE platform = 'discord' AND user_id = $1`,
+      [userId],
+    );
+    assert.equal(
+      rows.length,
+      1,
+      'SECURITY: the delete must participate in the caller\u2019s transaction — rolled back, the row is still here',
+    );
+
+    await clearAccessRequest('discord', userId);
   },
 );

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -126,7 +126,7 @@
   "repeatQuestionShortcutRouter.test.ts": 4,
   "replyRetractionDisabled.test.ts": 2,
   "replyRetractionRouter.test.ts": 1,
-  "repository.test.ts": 115,
+  "repository.test.ts": 117,
   "reviewVerdict.test.ts": 5,
   "router.test.ts": 9,
   "secrets.test.ts": 5,


### PR DESCRIPTION
Closes #939.

## The gap

`access_requests` holds the display name and platform user id of every non-member who addressed the bot in gated mode. **On WhatsApp the user id *is* the phone number**, so this is the most sensitive record the system keeps about people who are not members.

It was the one PII store in the schema with **neither an expiry nor an erasure path**. The only `DELETE` was `clearAccessRequest` on approval, so anyone who asked and was never added was retained indefinitely — no `forget_me`, no `purge_user_data`, no sweep. `docs/SECURITY.md` listed it as a metadata-only exception to guest invisibility, which is true of its *content* but was never a licence to keep the identity forever; the `server_roster` bullet immediately below it already documented that table as both deletable and age-purgeable.

## 1. Erasure

`purgeSingleIdentity` now **delegates** to `clearAccessRequest`, passing its transaction `client`.

Both halves of that sentence are load-bearing, and both come straight from PR #935's review of the sibling LID-mapping delete:

- **Delegating** rather than inlining a second `DELETE` keeps one deletion path. Two copies silently drift the day someone adds a predicate to one and not the other, and that drift is a PII-retention bug.
- **Passing `client`, not `pool`**, keeps the erasure atomic. This is the regression that typechecks, passes any test that only asserts the row is gone, and quietly makes erasure non-atomic — so it is pinned by an explicit ROLLBACK test, not just a row-is-gone assertion.

`clearAccessRequest` now returns its row count so the purge total includes it rather than dropping it.

## 2. Retention

New `ACCESS_REQUEST_RETENTION_DAYS` — default `0` (disabled), 30-day floor, **rejected at startup** below it. A third sweep beside the interactions and roster ones, gated solely on its own env var (the independence requirement #136 established).

The clock runs off **`last_requested_at`, not `first_requested_at`**. A guest who is still asking has an *open* request and is never swept, however old their first ask; only abandoned requests expire. There is a test that would fail under the `first_requested_at` reading.

Deleting a pending request cannot route around moderation the way deleting a `blocked_users` row would: the queue entry grants nothing and gates nothing, and a purged requester who asks again simply reappears as a fresh request (and re-triggers the first-time-only admin alert — correct for a new request months later).

## Called out rather than left implicit

Enabling retention **bounds `oldestAccessRequestAgeDays` from above** — the admin digest's oldest-pending signal can never exceed the window, because anything older is deleted. That is why the floor is generous rather than tight, and it is documented on both functions.

## Tests

- `purgeOldAccessRequests` sweeps a quiet request, keeps a recent one, and keeps an ancient request the person is **still making** — the `last_requested_at` semantic.
- SECURITY: `purgeUserData` erases the caller's pending request and nobody else's.
- SECURITY: `clearAccessRequest` honours a caller-supplied transaction client — proven by rolling back and asserting the row survives.
- Timer gate: disabled by default; enabled on its own gate with both sibling purges at `0`.
- Config: floor rejected at startup, `0` and `30` accepted (via the existing `loadConfig.ts` fixture harness).

**Verified locally:** typecheck (src + tests), lint, prettier, and all 4 non-DB tests pass. The 3 DB-backed tests in `repository.test.ts` could **not** be run locally — no Postgres on this machine — so they are unverified until CI runs them.

Default is off, so merging changes no behaviour until `ACCESS_REQUEST_RETENTION_DAYS` is set; the erasure fix applies immediately.
