### PR TITLE
Derive the Agent Skills feature_flags label from ENABLED_SKILLS (#941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 ## 2026-08-01
 
 ### Changed
-- **Asking the bot which Agent Skills are on now lists all of them** (#943).
+- **Asking the bot which Agent Skills are on now lists all of them** (#942).
   It was naming two (`prompt-review`, `claude-code-setup`) while six were
   actually loaded — the label was written when only those two existed and was
   never updated as more were added. It's now generated from the real list, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 ## 2026-08-01
 
 ### Changed
+- **Asking the bot which Agent Skills are on now lists all of them** (#943).
+  It was naming two (`prompt-review`, `claude-code-setup`) while six were
+  actually loaded — the label was written when only those two existed and was
+  never updated as more were added. It's now generated from the real list, so
+  it can't fall behind again.
 - **Admins can now archive every WhatsApp group the bot is in, not just named
   ones** (`WHATSAPP_ARCHIVE_ALL_GROUPS`, off by default). Previously each group
   had to be listed individually; this matches how Discord archiving already

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -41,6 +41,7 @@ import {
   withWebSearchDedupLock,
   type ToolServerTurnState,
 } from './tools.js';
+import { ENABLED_SKILLS } from './enabledSkills.js';
 import {
   initialUsageLimitTracker,
   isUsageLimitFailure,
@@ -330,21 +331,6 @@ function filterFeatureFlaggedTools(tools: string[]): string[] {
  */
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_DIR = join(__dirname, 'skills');
-
-/**
- * The explicit, hand-written skill allowlist (issue #741) — never 'all', so a
- * future skill file added to SKILLS_DIR needs a deliberate second edit here
- * to activate, matching this repo's existing convention of hand-written,
- * non-reflective tool/skill allowlists elsewhere.
- */
-const ENABLED_SKILLS = [
-  'prompt-review',
-  'model-and-plan-selection',
-  'agent-architecture-review',
-  'project-showcase',
-  'claude-code-setup',
-  'getting-started',
-] as const;
 
 /**
  * Build the SDK query options for one turn. Extracted (and exported) so the

--- a/src/agent/enabledSkills.ts
+++ b/src/agent/enabledSkills.ts
@@ -1,0 +1,28 @@
+/**
+ * The explicit, hand-written Agent Skills allowlist (issue #741) — never
+ * `'all'`, so a future skill file added to the skills directory needs a
+ * deliberate second edit here to activate, matching this repo's existing
+ * convention of hand-written, non-reflective tool/skill allowlists elsewhere.
+ *
+ * This lives in its own leaf module, rather than in `agent/core.ts` where it
+ * started, for one reason: `feature_flags` (agent/tools.ts) must be able to
+ * NAME the skills it reports as enabled, and `core.ts` already imports
+ * `tools.js`, so importing back the other way would be a cycle.
+ *
+ * That indirection exists because the alternative silently failed. The
+ * `feature_flags` label was written once (#742) naming the two skills that
+ * existed then, and was never touched again while four more were added
+ * (#755, #757, #758, #759, plus getting-started) — so an admin asking the bot
+ * what was enabled was told "prompt-review, claude-code-setup" long after six
+ * were live. A hand-maintained list in one place and a hand-maintained
+ * sentence about it in another WILL drift; deriving the sentence from the list
+ * is what makes that impossible rather than merely unlikely.
+ */
+export const ENABLED_SKILLS = [
+  'prompt-review',
+  'model-and-plan-selection',
+  'agent-architecture-review',
+  'project-showcase',
+  'claude-code-setup',
+  'getting-started',
+] as const;

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,4 +1,5 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { ENABLED_SKILLS } from './enabledSkills.js';
 import { z } from 'zod';
 import type { AdapterLookup, Platform, PlatformAdapter } from '../platforms/types.js';
 import { assertAtLeast, atLeast, type CallerContext } from '../auth/rbac.js';
@@ -1509,7 +1510,11 @@ export const FEATURE_FLAG_MAP: readonly FeatureFlagEntry[] = [
   {
     envVar: 'AGENT_SKILLS_ENABLED',
     configPath: 'agentSkills.enabled',
-    label: 'Agent Skills (prompt-review, claude-code-setup)',
+    // DERIVED from the allowlist, never a second hand-written copy of it: the
+    // literal this replaced named two skills and stayed that way through four
+    // more being added, so admins were told less was enabled than actually
+    // was. See agent/enabledSkills.ts.
+    label: `Agent Skills (${ENABLED_SKILLS.join(', ')})`,
     category: 'Integrations',
   },
 ] as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,8 +99,10 @@ const EnvSchema = z.object({
   AGENT_WEB_SEARCH_DEDUP_SIMILARITY_THRESHOLD: z.coerce.number().min(0).max(1).default(0.9),
   // Wires the SDK's Agent Skills mechanism (issue #741): when on,
   // buildQueryOptions (agent/core.ts) adds 'Skill' to the base tools array
-  // and loads the repo-bundled agent/skills/ plugin directory (skills:
-  // ['prompt-review', 'claude-code-setup'], never 'all'), and the #635
+  // and loads the repo-bundled agent/skills/ plugin directory (the skills
+  // named in agent/enabledSkills.ts, never 'all' — six of them as of
+  // #755/#757/#758/#759; that list is the single source, so do not restate it
+  // here, which is exactly how the feature_flags label went stale), and the #635
   // prompt-review checklist moves out of the always-on GUIDELINES
   // system-prompt block into skills/prompt-review/SKILL.md — a lower
   // per-turn cached-prefix token count for the overwhelming majority of

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,5 +1,6 @@
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { ENABLED_SKILLS } from '../src/agent/enabledSkills.js';
 import { readFileSync } from 'node:fs';
 import type { AdapterLookup, Platform, PlatformAdapter, UpcomingEvent } from '../src/platforms/types.js';
 import { formatNzEventTime } from '../src/util/nzTime.js';
@@ -8874,6 +8875,28 @@ test('SECURITY: engagement_stats handler refuses a forged direct call from a non
 });
 
 // --- issue #559: feature_flags ---------------------------------------------
+
+test('feature_flags: the Agent Skills label names EVERY enabled skill — it is derived from ENABLED_SKILLS, not a second hand-written copy that can go stale (issue #941)', () => {
+  // This is a regression test for a real, live mis-report, not a hypothetical.
+  // The label was written once in #742 naming the two skills that existed
+  // then, and was never updated while four more were added (#755/#757/#758/
+  // #759 + getting-started). An admin who asked the bot which skills were on
+  // was told "prompt-review, claude-code-setup" while six were actually
+  // loaded — the bot confidently under-reporting its own configuration, which
+  // is worse than saying nothing, because it reads as a config error and
+  // invites someone to go "fix" a system that was already correct.
+  const rendered = formatFeatureFlags({ agentSkills: { enabled: true } });
+  const skillsLine = rendered.split('\n').find((l) => l.startsWith('- Agent Skills'));
+  assert.ok(skillsLine, 'the Agent Skills flag renders a line');
+  for (const skill of ENABLED_SKILLS) {
+    assert.ok(
+      skillsLine.includes(skill),
+      `the label must name '${skill}' — it is loaded, so reporting anything less misleads the admin who asked. ` +
+        `Rendered: ${skillsLine}`,
+    );
+  }
+  assert.match(skillsLine, /: On$/, 'and it still reports the flag state itself');
+});
 
 function featureFlagsHandler(role: 'member' | 'admin' | 'guest' | 'super_admin') {
   const server = buildToolServer(


### PR DESCRIPTION
Closes #941.

An admin asked the bot which Agent Skills were enabled and was told **two** — `prompt-review` and `claude-code-setup` — while **six** were loaded.

## Cause

`feature_flags` rendered a hardcoded label written in #742, when exactly those two skills existed. It was never touched again while #755, #757, #758, #759 and `getting-started` added four more. The allowlist and the sentence describing it were two hand-maintained copies of the same fact, and they drifted. `config.ts`'s comment on `AGENT_SKILLS_ENABLED` named the same stale pair.

## Why it's worth a fix rather than a string edit

The bot is what admins use to *check* configuration. Under-reporting its own state **confidently** reads as a config error and invites someone to go "fix" a system that was already correct — which is exactly what happened. Editing the literal to name six would just reset the same clock.

## Change

`ENABLED_SKILLS` moves into `src/agent/enabledSkills.ts`, a leaf module. It has to move: `agent/core.ts` already imports `agent/tools.js`, so importing back the other way would be a cycle. The label is then built with `.join(', ')`, and `config.ts`'s comment now points at the single source instead of restating it.

## Test

`tests/tools.test.ts` asserts the rendered label names **every** `ENABLED_SKILLS` entry. I confirmed it is not vacuous: reverted to the old literal, it fails reproducing the exact string the admin was shown —

```
the label must name 'model-and-plan-selection' — it is loaded, so reporting anything less
misleads the admin who asked. Rendered: - Agent Skills (prompt-review, claude-code-setup): On
```

— and passes with the fix.

**Verified locally:** typecheck (src + tests), lint, prettier, `context:check`, and 42/42 tests across the four skills/agent-options test files.

No behaviour change to which skills load — only to what the bot *reports*. The six were correct all along.