### PR TITLE
Agent-base Phase 1: consolidate five identical notice debounces onto one shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
 Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 #775 #784 #804 #807 #809 #810 #812 #814 #816 #817 #818 #819 #821 #824 #825
-#868 #896 #899 #904 #949
+#868 #896 #899 #904 #949 #950
 -->
 
 

--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -76,7 +76,7 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/storage/repository/whatsappLidMap.ts` — 🔒 Durable WhatsApp LID -> phone mapping. A LID is a privacy id that looks like a number but matches no one; persisting what the adapter learns from real envelopes lets a LID be resolved rather than refused. PII — erased by `forget_me`/`purge_user_data`. See docs/SECURITY.md §6b.
 - `src/usageAlert.ts` — Usage-threshold alerting to super admins with a debounce tracker shared by several other alert modules.
 - `src/usageCostDigest.ts` — The periodic cost digest (spend, cache hit rate) sent to super admins.
-- `src/util/` — Shared leaf helpers with no dependencies of their own; currently NZ-timezone rendering for member-facing times.
+- `src/util/` — Shared leaf helpers with no dependencies of their own; currently NZ-timezone rendering for member-facing times and the `shouldNotifyAfterWindow` notice debounce every debounced notice module re-exports.
 - `src/voiceLanguageCaveatNotice.ts` — Fixed caveat DM for a te reo Māori speaker sending a voice note, because the transcription model is English-only and would otherwise fail silently.
 
 <!-- module-map:end -->

--- a/src/budgetCheckFailureNotice.ts
+++ b/src/budgetCheckFailureNotice.ts
@@ -1,15 +1,9 @@
 /**
- * Pure debounce for the daily-reply-budget check-failure alert. Mirrors
- * rateLimitNotice.ts's shouldNotifyRateLimited exactly, but this one gates a
- * single process-wide super-admin DM rather than a per-user member notice —
- * a countRepliesToUser failure is a systemic DB/infra condition, not a
- * per-user event (issue #203).
+ * Daily-reply-budget check-failure alert: the shared
+ * `shouldNotifyAfterWindow` debounce (util/noticeDebounce.ts) under a domain
+ * name. Unlike the rate-limit/pause notices this gates a single process-wide
+ * super-admin DM rather than a per-user member notice — a countRepliesToUser
+ * failure is a systemic DB/infra condition, not a per-user event (issue #203).
  */
 
-export function shouldNotifyBudgetCheckFailed(
-  lastNotifiedAt: number | undefined,
-  now: number,
-  windowMs: number,
-): boolean {
-  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
-}
+export { shouldNotifyAfterWindow as shouldNotifyBudgetCheckFailed } from './util/noticeDebounce.js';

--- a/src/mutedRoleAlertNotice.ts
+++ b/src/mutedRoleAlertNotice.ts
@@ -1,16 +1,9 @@
 /**
- * Pure debounce for the muted-role permission-overwrite retry-exhaustion
- * alert. Mirrors budgetCheckFailureNotice.ts's shouldNotifyBudgetCheckFailed
- * exactly, but this one gates a single process-wide super-admin DM for the
- * Discord adapter's `applyMutedRoleOverwrite` retry-exhaustion path — a
- * transient-Discord-API failure is a systemic condition, not a per-channel
- * event (issue #276).
+ * Muted-role permission-overwrite retry-exhaustion alert: the shared
+ * `shouldNotifyAfterWindow` debounce (util/noticeDebounce.ts) under a domain
+ * name, gating a single process-wide super-admin DM for the Discord adapter's
+ * `applyMutedRoleOverwrite` retry-exhaustion path — a transient-Discord-API
+ * failure is a systemic condition, not a per-channel event (issue #276).
  */
 
-export function shouldNotifyMutedRoleOverwriteFailed(
-  lastNotifiedAt: number | undefined,
-  now: number,
-  windowMs: number,
-): boolean {
-  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
-}
+export { shouldNotifyAfterWindow as shouldNotifyMutedRoleOverwriteFailed } from './util/noticeDebounce.js';

--- a/src/pauseNotice.ts
+++ b/src/pauseNotice.ts
@@ -1,6 +1,7 @@
 /**
- * Pure debounce for the pause notice (issue #128). Mirrors
- * rateLimitNotice.ts's shape exactly, but debounced against a longer window:
+ * Pause notice (issue #128): text constants plus the shared
+ * `shouldNotifyAfterWindow` debounce (util/noticeDebounce.ts) under a domain
+ * name, debounced against a longer window than the rate-limit notice:
  * a pause_bot is typically longer-lived than a rate-limit burst, so
  * re-notifying on every addressed message would be noisy — once per window
  * is enough to reassure a member the bot isn't broken.
@@ -23,10 +24,4 @@ export const PAUSE_NOTICE_TEXT_MI =
 // surface.
 export const PAUSE_NOTICE_TEXT_PLAIN = 'The assistant is paused right now. Please try again later.';
 
-export function shouldNotifyPaused(
-  lastNotifiedAt: number | undefined,
-  now: number,
-  windowMs: number,
-): boolean {
-  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
-}
+export { shouldNotifyAfterWindow as shouldNotifyPaused } from './util/noticeDebounce.js';

--- a/src/rateLimitNotice.ts
+++ b/src/rateLimitNotice.ts
@@ -1,7 +1,7 @@
 /**
- * Pure debounce for the per-user rate-limit notice. Mirrors router.ts's
- * inline budgetNotified check (router.ts:180-181), but debounced against
- * the rate-limit window instead of the 24h budget window, so a burst of
+ * Per-user rate-limit notice: text constants plus the shared
+ * `shouldNotifyAfterWindow` debounce (util/noticeDebounce.ts) under a
+ * domain name, debounced against the rate-limit window so a burst of
  * over-limit messages produces exactly one notice per episode.
  */
 
@@ -24,10 +24,4 @@ export const RATE_LIMIT_NOTICE_TEXT_MI =
 export const RATE_LIMIT_NOTICE_TEXT_PLAIN =
   "You're sending messages too fast. Please wait a bit, then try again.";
 
-export function shouldNotifyRateLimited(
-  lastNotifiedAt: number | undefined,
-  now: number,
-  windowMs: number,
-): boolean {
-  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
-}
+export { shouldNotifyAfterWindow as shouldNotifyRateLimited } from './util/noticeDebounce.js';

--- a/src/util/noticeDebounce.ts
+++ b/src/util/noticeDebounce.ts
@@ -1,0 +1,18 @@
+/**
+ * The one shared "at most once per rolling window" notice debounce: notify
+ * when there is no prior notice, or when the window has fully elapsed since
+ * the last one. Every debounced notice in this codebase (per-user rate-limit
+ * and pause notices, the process-wide budget-check-failure and muted-role
+ * alerts, the WhatsApp/Discord voice-language caveat) re-exports this under
+ * its own domain name — the caller keeps a readable, purpose-named predicate
+ * while the semantics live in exactly one place. Callers own their timestamp
+ * state and pass `now` in, so the predicate stays pure and clock-injectable
+ * for tests.
+ */
+export function shouldNotifyAfterWindow(
+  lastNotifiedAt: number | undefined,
+  now: number,
+  windowMs: number,
+): boolean {
+  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
+}

--- a/src/voiceLanguageCaveatNotice.ts
+++ b/src/voiceLanguageCaveatNotice.ts
@@ -19,6 +19,4 @@ export const VOICE_LANGUAGE_CAVEAT_TEXT =
 export const VOICE_LANGUAGE_CAVEAT_TEXT_MI =
   'He mihi whakamōhio: ko te reo Ingarihi anake e whakamāoritia ana ngā karere reo i tēnei wā, nā reira tērā pea kāore te kupu i mahia e au e rite tonu ana ki tāu i kī ai.';
 
-export function shouldNotify(lastNotifiedAt: number | undefined, now: number, windowMs: number): boolean {
-  return lastNotifiedAt === undefined || now - lastNotifiedAt > windowMs;
-}
+export { shouldNotifyAfterWindow as shouldNotify } from './util/noticeDebounce.js';

--- a/tests/noticeDebounce.test.ts
+++ b/tests/noticeDebounce.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldNotifyAfterWindow } from '../src/util/noticeDebounce.js';
+import { shouldNotifyRateLimited } from '../src/rateLimitNotice.js';
+import { shouldNotifyPaused } from '../src/pauseNotice.js';
+import { shouldNotifyBudgetCheckFailed } from '../src/budgetCheckFailureNotice.js';
+import { shouldNotifyMutedRoleOverwriteFailed } from '../src/mutedRoleAlertNotice.js';
+import { shouldNotify as shouldNotifyVoiceLanguageCaveat } from '../src/voiceLanguageCaveatNotice.js';
+
+const WINDOW_MS = 60_000;
+
+test('shouldNotifyAfterWindow: no prior notice always notifies', () => {
+  assert.equal(shouldNotifyAfterWindow(undefined, 0, WINDOW_MS), true);
+});
+
+test('shouldNotifyAfterWindow: within the window does not re-notify, including at the exact boundary', () => {
+  const notifiedAt = 1_000;
+  assert.equal(shouldNotifyAfterWindow(notifiedAt, notifiedAt + WINDOW_MS - 1, WINDOW_MS), false);
+  assert.equal(shouldNotifyAfterWindow(notifiedAt, notifiedAt + WINDOW_MS, WINDOW_MS), false);
+});
+
+test('shouldNotifyAfterWindow: re-arms once the window elapses', () => {
+  const notifiedAt = 1_000;
+  assert.equal(shouldNotifyAfterWindow(notifiedAt, notifiedAt + WINDOW_MS + 1, WINDOW_MS), true);
+});
+
+test('every notice module re-exports the one shared debounce, not a drifted copy', () => {
+  for (const alias of [
+    shouldNotifyRateLimited,
+    shouldNotifyPaused,
+    shouldNotifyBudgetCheckFailed,
+    shouldNotifyMutedRoleOverwriteFailed,
+    shouldNotifyVoiceLanguageCaveat,
+  ]) {
+    assert.equal(alias, shouldNotifyAfterWindow);
+  }
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -28,6 +28,7 @@
     "src/**/*.ts",
     "tests/backgroundJobCostAlert.test.ts",
     "tests/memberDigest.test.ts",
+    "tests/noticeDebounce.test.ts",
     "tests/projectScope.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
     "tests/usageCostDigest.test.ts",


### PR DESCRIPTION
## Summary

Second Phase 1 leaf cleanup from `docs/AGENT-BASE-PLAN.md` (the "one `shouldNotifyAfterWindow` debounce" item): `rateLimitNotice.ts`, `pauseNotice.ts`, `budgetCheckFailureNotice.ts`, `mutedRoleAlertNotice.ts` and `voiceLanguageCaveatNotice.ts` each carried a byte-identical `(lastNotifiedAt, now, windowMs)` debounce predicate — the plan said four copies; a fifth (`mutedRoleAlertNotice`) had accrued since. The implementation now lives once, in `src/util/noticeDebounce.ts` as `shouldNotifyAfterWindow`; each notice module re-exports it under its existing domain name (same zero-churn re-export pattern as #949's `WindowClosedError` move), so every call site — `router.ts`, all three platform adapters, and every existing test import — is unchanged. No behaviour change: the predicate body is byte-identical to all five originals.

A new `tests/noticeDebounce.test.ts` covers the shared predicate (including the exact-boundary case: `now - lastNotifiedAt === windowMs` does NOT re-notify) and pins all five aliases to reference-equality with the shared function, so a drifted copy can't silently reappear. The `src/util/` module-map entry is updated in the same diff.

## Security / privacy impact

None. No change to auth, tool gating, outbound filtering, data access scope, or stored data. The debounce gates only *whether a static notice/alert is re-sent within a window*; all five aliases resolve to the same function object, so every existing debounce window behaves identically. The five modules' text constants are untouched.

## How verified

`npm run typecheck` clean (including `typecheck:tests`; the new test file is added to the `tsconfig.tests.json` ratchet). `npm test` — 3285 tests, 2432 pass, 0 fail (853 skipped: DB-backed tests without a local `DATABASE_URL`, which skip cleanly by design; 4 tests are new). `npm run test:security` — 1233 SECURITY tests ran, exact manifest match across 156 files (no `SECURITY:` tests added or removed, so `tests/security-floor.json` is unchanged). `npm run context:check`, `npm run format:check`, `npm run build`, and eslint on the changed files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_