### PR TITLE
Agent-base Phase 1: one notification service for super-admin alerts and alert-slot windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
 Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 #775 #784 #804 #807 #809 #810 #812 #814 #816 #817 #818 #819 #821 #824 #825
-#868 #896 #899 #904 #949 #950
+#868 #896 #899 #904 #949 #950 #951
 -->
 
 

--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -60,6 +60,7 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/memberDigest.ts` — The member-facing digest of recent community activity, built from PII-scrubbed aggregates rather than raw messages.
 - `src/moderation/` — Two-stage moderation: a zero-cost wordlist pass, then a model pass, with admins and super admins exempt. The enforcer is injected so the platform side stays swappable.
 - `src/mutedRoleAlertNotice.ts` — Pure debounce for the super-admin alert raised when Discord muted-role permission overwrites exhaust their retries.
+- `src/notifications.ts` — The shared super-admin DM fan-out every alert producer delegates to (connected-adapters-only, window-reopen queueing, optional queue-on-outage), plus the rolling-hour alert-slot reserver factory behind the router's and moderator's guild-wide alert caps.
 - `src/pauseNotice.ts` — Pure debounce for the "the bot is paused" reply, on a longer window than the rate-limit notice because a pause is longer-lived.
 - `src/pendingAlertQueue.ts` — Best-effort queue for super-admin alerts raised while every adapter was disconnected, so an alert during an outage is not simply lost.
 - `src/platforms/` — 🔒 The platform abstraction plus the Discord and WhatsApp (Baileys and Cloud API) adapters. Adapters own the send path, so outbound filtering and chunking live at their edges.

--- a/src/backgroundJobCostAlert.ts
+++ b/src/backgroundJobCostAlert.ts
@@ -1,9 +1,8 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { superAdminIds } from './auth/roles.js';
 import { startTrackedJob } from './backgroundJobs.js';
 import { sumBackgroundJobCosts, type BackgroundJob } from './storage/repository.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 /** The three background jobs that write `background_job_costs` rows (issue #401) — a fixed enum, never derived from anything dynamic. */
@@ -139,21 +138,13 @@ export function startBackgroundJobCostAlert(
   );
 }
 
+// `queueWhenDisconnected: false` — a fully-disconnected outage drops this
+// alert rather than queueing it: the next 6h tick re-derives today's spend
+// from `background_job_costs` and re-alerts if still over threshold, so a
+// queued copy would only deliver stale numbers on reconnect.
 async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  for (const adapter of adapters) {
-    if (!adapter.isConnected()) continue; // can't send through a dead connection
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Cost-spike alert: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Cost-spike alert DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, {
+    label: 'Cost-spike alert',
+    queueWhenDisconnected: false,
+  });
 }

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -1,6 +1,5 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { superAdminIds } from './auth/roles.js';
 import { embed } from './storage/embeddings.js';
 import { latestContextDigestAt } from './storage/repository.js';
 import { runContextBuilder, shouldRunContextBuilder, type ClusterSummarizer } from './context/builder.js';
@@ -40,8 +39,7 @@ import {
   type BackgroundJobName,
   type JobFailureTracker,
 } from './backgroundJobHealth.js';
-import { queuePendingAlert } from './pendingAlertQueue.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 const TICK_INTERVAL_MS = 6 * 3_600_000;
@@ -63,8 +61,8 @@ export const BACKGROUND_JOB_FAILURE_ALERT_THRESHOLD = 3;
  * `tracker` variable). `runOnce` resolving (including a no-op "not due
  * yet" skip) counts as success and silently resets the tracker; throwing
  * counts as a failure and steps it, DMing super admins via the same
- * `sendDirectMessage` + `superAdminIds` path `usageAlert.ts`/`health.ts`
- * already use once the threshold is reached.
+ * `notifications.ts` fan-out `usageAlert.ts`/`health.ts` already use once
+ * the threshold is reached.
  *
  * Exported (issue #291) so the two retention purges (src/interactionRetention.ts,
  * src/rosterRetention.ts) can wire through the same tracker/alert plumbing
@@ -124,30 +122,10 @@ export function startTrackedJob(
 // silently dropped, and flushed through the first adapter to reconnect via
 // health.ts's existing flushPendingAlerts (issue #545).
 async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  if (!adapters.some((adapter) => adapter.isConnected())) {
-    logger.warn(
-      { message },
-      'Background job failure alert could not be delivered live — no connected adapter; queued for flush on reconnect',
-    );
-    queuePendingAlert(message, 'system'); // job-failure alert — never evicted by a member-reachable alert (#545)
-    return;
-  }
-  for (const adapter of adapters) {
-    if (!adapter.isConnected()) continue; // can't send through a dead connection
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Background job failure alert: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Background job failure alert DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, {
+    label: 'Background job failure alert',
+    queueWhenDisconnected: true,
+  });
 }
 
 /**

--- a/src/departedAdminAlert.ts
+++ b/src/departedAdminAlert.ts
@@ -1,11 +1,9 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { superAdminIds } from './auth/roles.js';
 import { listAdminRoster, type AdminRosterEntry } from './storage/repository.js';
 import { startTrackedJob } from './backgroundJobs.js';
 import { initialUsageAlertTracker, stepUsageAlertTracker } from './usageAlert.js';
-import { queuePendingAlert } from './pendingAlertQueue.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 /**
@@ -73,36 +71,18 @@ export function startDepartedAdminAlert(
 }
 
 /**
- * Exported (issue #568) so `engagementAlert.ts` can reuse this exact
- * super-admin-only, connected-adapters-only fan-out by import rather than a
- * second copy — the adversarial-review note on #568 pins this as the single
- * source of truth for "super admins only" DM delivery across both jobs. That
- * makes this function's disconnect-handling (issue #593) apply to both
- * producers by construction, not by duplicating the fix.
+ * Exported (issue #568) so `engagementAlert.ts`/`adminLeverageAlert.ts` can
+ * reuse this exact super-admin-only, connected-adapters-only fan-out by
+ * import rather than a second copy — the adversarial-review note on #568 pins
+ * this as those jobs' shared entry point for "super admins only" DM delivery.
+ * The delivery mechanics themselves now live in `notifications.ts`'s
+ * `alertSuperAdmins` (the codebase-wide single source of truth), so a
+ * delivery fix like #593's disconnect handling reaches every producer by
+ * construction, not by duplicating the fix.
  */
 export async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  const connected = adapters.filter((adapter) => adapter.isConnected());
-  if (connected.length === 0) {
-    logger.warn(
-      { message },
-      'Departed-admin alert could not be delivered live — no connected adapter; queued for flush on reconnect',
-    );
-    queuePendingAlert(message, 'system'); // super-admin-only alert — never evicted by a member-reachable alert (#545)
-    return;
-  }
-  for (const adapter of connected) {
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Departed-admin alert: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Departed-admin alert DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, {
+    label: 'Departed-admin alert',
+    queueWhenDisconnected: true,
+  });
 }

--- a/src/health.ts
+++ b/src/health.ts
@@ -13,11 +13,10 @@ import {
 } from './healthState.js';
 import {
   drainPendingAlerts,
-  queuePendingAlert,
   getPendingAlertsForTests,
   resetPendingAlertsForTests,
 } from './pendingAlertQueue.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 const CHECK_INTERVAL_MS = 30_000;
@@ -72,30 +71,7 @@ export function startDisconnectAlerts(adapters: readonly PlatformAdapter[]): Ret
 // drive queuing/overflow behaviour directly, without waiting out the
 // once-per-outage debounce in stepDisconnectTracker.
 export async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  const connected = adapters.filter((adapter) => adapter.isConnected());
-  if (connected.length === 0) {
-    logger.warn(
-      { message },
-      'Health alert could not be delivered live — no connected adapter; queued for flush on reconnect',
-    );
-    queuePendingAlert(message, 'system'); // disconnect alert — never evicted by a member-reachable alert (#545)
-    return;
-  }
-  for (const adapter of connected) {
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Health alert: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Health alert DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, { label: 'Health alert', queueWhenDisconnected: true });
 }
 
 // Sends every queued message through the just-reconnected adapter, then

--- a/src/moderation/moderator.ts
+++ b/src/moderation/moderator.ts
@@ -1,6 +1,7 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
+import { makeAlertSlotReserver } from '../notifications.js';
 import type { Platform } from '../platforms/types.js';
 import {
   recordBackgroundJobCost,
@@ -228,8 +229,6 @@ const MODERATION_ALERT_SUMMARY_DEBOUNCE_MS = 10_000;
 export class Moderator {
   constructor(private readonly deps: ModeratorDeps) {}
 
-  /** Timestamps of posted admin alerts, for the guild-wide rolling-hour cap (issue #517). */
-  private readonly alertTimestamps: number[] = [];
   /** Alerts suppressed since the last summary flush, in the current debounce cycle. */
   private suppressedAlerts = 0;
   private summaryFlushTimer: NodeJS.Timeout | null = null;
@@ -331,21 +330,19 @@ export class Moderator {
     }
   }
 
+  /** The rolling-hour window behind `reserveAlertSlot` — the shared `makeAlertSlotReserver` shape from notifications.ts, same as router.ts's alert slots. */
+  private readonly reserveAlertSlotWindow = makeAlertSlotReserver();
+
   /**
-   * Rolling-hour cap on admin alerts (issue #517), mirroring
-   * `reserveEscalationSlot` in router.ts exactly: filter timestamps older
-   * than an hour, push the new one, compare against the limit. Guild-wide
-   * (not per-user/per-channel) — a multi-account raid can't buy extra slots
-   * by spreading hits across identities.
+   * Rolling-hour cap on admin alerts (issue #517), the same guild-wide
+   * sliding window as `reserveEscalationSlot` in router.ts — guild-wide
+   * (not per-user/per-channel) so a multi-account raid can't buy extra
+   * slots by spreading hits across identities. Reads the limit from
+   * `deps` at call time, which is why this stays a method over the window
+   * rather than binding the limit at construction.
    */
   private reserveAlertSlot(): boolean {
-    const now = Date.now();
-    const recent = this.alertTimestamps.filter((t) => now - t < 3_600_000);
-    this.alertTimestamps.length = 0;
-    this.alertTimestamps.push(...recent);
-    if (this.alertTimestamps.length >= this.deps.alertRateLimitPerHour) return false;
-    this.alertTimestamps.push(now);
-    return true;
+    return this.reserveAlertSlotWindow(this.deps.alertRateLimitPerHour);
   }
 
   /**

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,106 @@
+import { logger } from './logger.js';
+import { superAdminIds } from './auth/roles.js';
+import { queuePendingAlert } from './pendingAlertQueue.js';
+import { WindowClosedError } from './platforms/types.js';
+import type { PlatformAdapter } from './platforms/types.js';
+
+/**
+ * Per-producer options for `alertSuperAdmins`. The two fields are exactly the
+ * two axes the six pre-consolidation copies had drifted on — everything else
+ * (recipient set, per-recipient fire-and-forget sends, WindowClosedError →
+ * queueForWindowReopen handling) was already identical across all of them.
+ */
+export interface SuperAdminAlertOptions {
+  /**
+   * Log label, e.g. 'Usage alert' — appears verbatim in every log line this
+   * fan-out emits, so operators can attribute a failed or queued DM to its
+   * producer without a stack trace.
+   */
+  label: string;
+  /**
+   * What to do when EVERY adapter is disconnected: `true` queues the message
+   * via `queuePendingAlert` for flush on reconnect (reactive alerts that fire
+   * once per condition — a missed one is gone for good); `false` drops it
+   * silently (periodic digests/cost alerts whose next scheduled run
+   * re-reports from source data anyway, so queueing would deliver stale
+   * numbers after an outage).
+   */
+  queueWhenDisconnected: boolean;
+}
+
+/**
+ * The one super-admin DM fan-out — the single source of truth for "super
+ * admins only" alert delivery, replacing six per-module copies (health,
+ * backgroundJobs, usageAlert, departedAdminAlert, usageCostDigest,
+ * backgroundJobCostAlert) that had drifted on the two axes captured in
+ * `SuperAdminAlertOptions`. Producers keep a thin, purpose-named wrapper
+ * binding their label and disconnect policy, so their call sites and tests
+ * are unchanged and a future delivery fix (like #593's disconnect handling
+ * or #888's window-reopen queueing) lands here once, for every producer.
+ *
+ * SECURITY: the recipient set is `superAdminIds` — derived from env config,
+ * never from message content or the DB — and a queued message goes in at
+ * 'system' priority, which `pendingAlertQueue` never evicts for a
+ * member-reachable alert (#545). Sends are fire-and-forget per recipient: one
+ * closed WhatsApp window (queued for reopen via `queueForWindowReopen`) or
+ * one failed DM (logged) never blocks delivery to the rest.
+ */
+export async function alertSuperAdmins(
+  adapters: readonly PlatformAdapter[],
+  message: string,
+  opts: SuperAdminAlertOptions,
+): Promise<void> {
+  const connected = adapters.filter((adapter) => adapter.isConnected());
+  if (connected.length === 0) {
+    if (opts.queueWhenDisconnected) {
+      logger.warn(
+        { message },
+        `${opts.label} could not be delivered live — no connected adapter; queued for flush on reconnect`,
+      );
+      queuePendingAlert(message, 'system'); // super-admin-only alert — never evicted by a member-reachable alert (#545)
+    }
+    return;
+  }
+  for (const adapter of connected) {
+    for (const id of superAdminIds(adapter.platform)) {
+      adapter.sendDirectMessage(id, message).catch((err) => {
+        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
+          adapter.queueForWindowReopen(id, message, 'system');
+          logger.warn(
+            { platform: adapter.platform, id },
+            `${opts.label}: recipient window closed, queued for reopen`,
+          );
+          return;
+        }
+        logger.warn({ err, platform: adapter.platform, id }, `${opts.label} DM failed`);
+      });
+    }
+  }
+}
+
+/**
+ * Factory for the guild-wide rolling-hour alert-slot reserver — the one
+ * sliding window behind every keyless admin-alert rate cap, replacing five
+ * identical private copies in `router.ts` (access-request, knowledge-gap,
+ * stale-knowledge, repeat-question, escalation) and the mirror copy in
+ * `moderation/moderator.ts`. Each call returns an independent window with its
+ * own private timestamp state, so distinct alert categories can never consume
+ * each other's slots. The returned reserver prunes entries older than an hour
+ * on every call (no external sweep needed), returns false without reserving
+ * once `limit` is reached inside the window, and is deliberately keyless —
+ * guild-wide, matching the guild-wide admin audience of every caller; the
+ * per-conversation-keyed reservers in `agent/tools.ts` are a different shape
+ * and stay put.
+ */
+export function makeAlertSlotReserver(): (limit: number) => boolean {
+  const timestamps: number[] = [];
+  return (limit: number): boolean => {
+    const now = Date.now();
+    const recent = timestamps.filter((t) => now - t < 3_600_000);
+    timestamps.length = 0;
+    timestamps.push(...recent);
+    if (recent.length >= limit) return false;
+    timestamps.push(now);
+    return true;
+  };
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -84,6 +84,7 @@ import {
   DAILY_REPLY_BUDGET_WARNING_TEXT_PLAIN,
 } from './dailyReplyBudgetWarning.js';
 import { shouldNotifyBudgetCheckFailed } from './budgetCheckFailureNotice.js';
+import { makeAlertSlotReserver } from './notifications.js';
 import {
   appendWaitClause,
   appendWaitClauseMi,
@@ -428,8 +429,6 @@ export class Router {
    * map here.
    */
   private readonly pendingEscalations = new Map<string, { query: string; at: number }>();
-  /** Timestamps of confirmed escalation notifications, for the guild-wide rolling-hour cap (ESCALATION_RATE_LIMIT_PER_HOUR). */
-  private readonly escalationTimestamps: number[] = [];
   /**
    * Auto-answer thread id -> parent channel id (+ creation time), issue #477.
    * A CONFIRM/CANCEL or escalation-confirmation the member types INSIDE an
@@ -580,72 +579,39 @@ export class Router {
     setInterval(() => this.sweep(), this.RATE_WINDOW_MS * 5).unref();
   }
 
-  /** Rolling-hour timestamps for `ACCESS_REQUEST_ALERT_RATE_LIMIT_PER_HOUR` (issue #480) — guild-wide, not per-conversation, since the alert audience (`listAdmins()`) is guild-wide too. */
-  private readonly accessRequestAlertTimestamps: number[] = [];
-
   /**
-   * Reserve one access-request-alert slot against a rolling hourly cap, same
-   * sliding-window shape as `tools.ts`'s `reserveAnnounceSlot`/
-   * `reservePollSlot` — but keyless/guild-wide rather than per-conversation,
-   * matching this alert's guild-wide `listAdmins()` audience. Returns false
-   * without reserving if the guild already hit `limit` within the last hour;
-   * the request is still recorded by the caller either way (issue #480).
+   * Reserve one access-request-alert slot against the rolling hourly cap
+   * (`ACCESS_REQUEST_ALERT_RATE_LIMIT_PER_HOUR`, issue #480) — the shared
+   * `makeAlertSlotReserver` window from `notifications.ts`: keyless/
+   * guild-wide rather than per-conversation, matching this alert's
+   * guild-wide `listAdmins()` audience. Returns false without reserving if
+   * the guild already hit `limit` within the last hour; the request is
+   * still recorded by the caller either way (issue #480).
    */
-  private reserveAccessRequestAlertSlot(limit: number): boolean {
-    const now = Date.now();
-    const windowMs = 60 * 60 * 1000;
-    const recent = this.accessRequestAlertTimestamps.filter((t) => now - t < windowMs);
-    this.accessRequestAlertTimestamps.length = 0;
-    this.accessRequestAlertTimestamps.push(...recent);
-    if (recent.length >= limit) return false;
-    this.accessRequestAlertTimestamps.push(now);
-    return true;
-  }
-
-  /** Rolling-hour timestamps for `KNOWLEDGE_GAP_ALERT_RATE_LIMIT_PER_HOUR` (issue #650) — guild-wide, same reasoning as `accessRequestAlertTimestamps` above (the `listAdmins()` audience is guild-wide too). */
-  private readonly knowledgeGapAlertTimestamps: number[] = [];
+  private readonly reserveAccessRequestAlertSlot = makeAlertSlotReserver();
 
   /**
-   * Reserve one knowledge-gap-cluster-alert slot against a rolling hourly
-   * cap, identical sliding-window shape as `reserveAccessRequestAlertSlot`.
-   * Returns false without reserving if the guild already hit `limit` within
-   * the last hour — the caller (below) leaves the crossed cluster's rows
-   * unalerted in that case, so a later gap in the same cluster can retry the
-   * alert once the window frees (issue #650 acceptance criterion 6).
+   * Reserve one knowledge-gap-cluster-alert slot against the rolling hourly
+   * cap (`KNOWLEDGE_GAP_ALERT_RATE_LIMIT_PER_HOUR`, issue #650), its own
+   * `makeAlertSlotReserver` window. Returns false without reserving if the
+   * guild already hit `limit` within the last hour — the caller (below)
+   * leaves the crossed cluster's rows unalerted in that case, so a later gap
+   * in the same cluster can retry the alert once the window frees (issue
+   * #650 acceptance criterion 6).
    */
-  private reserveKnowledgeGapAlertSlot(limit: number): boolean {
-    const now = Date.now();
-    const windowMs = 60 * 60 * 1000;
-    const recent = this.knowledgeGapAlertTimestamps.filter((t) => now - t < windowMs);
-    this.knowledgeGapAlertTimestamps.length = 0;
-    this.knowledgeGapAlertTimestamps.push(...recent);
-    if (recent.length >= limit) return false;
-    this.knowledgeGapAlertTimestamps.push(now);
-    return true;
-  }
-
-  /** Rolling-hour timestamps for `KNOWLEDGE_STALE_ALERT_RATE_LIMIT_PER_HOUR` (issue #701) — guild-wide, same reasoning as `knowledgeGapAlertTimestamps` above (the `listAdmins()` audience is guild-wide too). */
-  private readonly staleKnowledgeAlertTimestamps: number[] = [];
+  private readonly reserveKnowledgeGapAlertSlot = makeAlertSlotReserver();
 
   /**
-   * Reserve one stale-knowledge-alert slot against a rolling hourly cap,
-   * identical sliding-window shape as `reserveKnowledgeGapAlertSlot`. Unlike
-   * that sibling, a miss here does NOT leave the underlying row unstamped —
+   * Reserve one stale-knowledge-alert slot against the rolling hourly cap
+   * (`KNOWLEDGE_STALE_ALERT_RATE_LIMIT_PER_HOUR`, issue #701), its own
+   * `makeAlertSlotReserver` window. Unlike its knowledge-gap sibling, a miss
+   * here does NOT leave the underlying row unstamped —
    * `maybeAlertStaleKnowledge` below always stamps `stale_alerted_at` via
    * `markStaleKnowledgeAlertedFn` before even checking this slot, so a
    * rate-limited entry doesn't retry-storm (acceptance criterion 5c). This
    * only gates whether the `notifyAdmins` DM itself goes out.
    */
-  private reserveStaleKnowledgeAlertSlot(limit: number): boolean {
-    const now = Date.now();
-    const windowMs = 60 * 60 * 1000;
-    const recent = this.staleKnowledgeAlertTimestamps.filter((t) => now - t < windowMs);
-    this.staleKnowledgeAlertTimestamps.length = 0;
-    this.staleKnowledgeAlertTimestamps.push(...recent);
-    if (recent.length >= limit) return false;
-    this.staleKnowledgeAlertTimestamps.push(now);
-    return true;
-  }
+  private readonly reserveStaleKnowledgeAlertSlot = makeAlertSlotReserver();
 
   /**
    * Real-time admin nudge for a served, stale knowledge entry (issue #701) —
@@ -678,27 +644,16 @@ export class Router {
     ).catch((err) => logger.warn({ err, id }, 'Stale-knowledge admin notification failed'));
   }
 
-  /** Rolling-hour timestamps for `REPEAT_QUESTION_ALERT_RATE_LIMIT_PER_HOUR` (issue #887) — guild-wide, same reasoning as `knowledgeGapAlertTimestamps` above (the `listAdmins()` audience is guild-wide too). */
-  private readonly repeatQuestionAlertTimestamps: number[] = [];
-
   /**
-   * Reserve one repeat-question-cluster-alert slot against a rolling hourly
-   * cap, identical sliding-window shape as `reserveKnowledgeGapAlertSlot`.
-   * Returns false without reserving if the guild already hit `limit` within
-   * the last hour — the caller (below) simply drops the DM in that case; the
-   * underlying cluster is unaffected and still visible via the weekly digest
-   * / `question_digest` (acceptance criterion 4).
+   * Reserve one repeat-question-cluster-alert slot against the rolling
+   * hourly cap (`REPEAT_QUESTION_ALERT_RATE_LIMIT_PER_HOUR`, issue #887),
+   * its own `makeAlertSlotReserver` window. Returns false without reserving
+   * if the guild already hit `limit` within the last hour — the caller
+   * (below) simply drops the DM in that case; the underlying cluster is
+   * unaffected and still visible via the weekly digest / `question_digest`
+   * (acceptance criterion 4).
    */
-  private reserveRepeatQuestionAlertSlot(limit: number): boolean {
-    const now = Date.now();
-    const windowMs = 60 * 60 * 1000;
-    const recent = this.repeatQuestionAlertTimestamps.filter((t) => now - t < windowMs);
-    this.repeatQuestionAlertTimestamps.length = 0;
-    this.repeatQuestionAlertTimestamps.push(...recent);
-    if (recent.length >= limit) return false;
-    this.repeatQuestionAlertTimestamps.push(now);
-    return true;
-  }
+  private readonly reserveRepeatQuestionAlertSlot = makeAlertSlotReserver();
 
   /**
    * Per-conversation cooldown gate for the repeat-question-cluster alert
@@ -901,21 +856,13 @@ export class Router {
 
   /**
    * Reserve one guild-wide escalation-notification slot against the rolling
-   * hourly cap (issue #479 acceptance criterion 6) — same sliding-window
-   * shape as `reserveAnnounceSlot`/`reservePollSlot` in `agent/tools.ts`, but
-   * a single shared window (not per-conversation): the cap bounds total
-   * admin-notification volume regardless of which conversation or caller
-   * tier triggers it.
+   * hourly cap (issue #479 acceptance criterion 6, backed by
+   * `ESCALATION_RATE_LIMIT_PER_HOUR`) — the shared `makeAlertSlotReserver`
+   * window from `notifications.ts`, single and shared (not
+   * per-conversation): the cap bounds total admin-notification volume
+   * regardless of which conversation or caller tier triggers it.
    */
-  private reserveEscalationSlot(limit: number): boolean {
-    const now = Date.now();
-    const recent = this.escalationTimestamps.filter((t) => now - t < 3_600_000);
-    this.escalationTimestamps.length = 0;
-    this.escalationTimestamps.push(...recent);
-    if (this.escalationTimestamps.length >= limit) return false;
-    this.escalationTimestamps.push(now);
-    return true;
-  }
+  private readonly reserveEscalationSlot = makeAlertSlotReserver();
 
   /**
    * Creates the Discord thread an auto-answer reply is contained in (issue

--- a/src/usageAlert.ts
+++ b/src/usageAlert.ts
@@ -1,6 +1,5 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { superAdminIds } from './auth/roles.js';
 import { usageStats } from './storage/repository.js';
 import { BACKGROUND_JOB_FAILURE_ALERT_THRESHOLD } from './backgroundJobs.js';
 import {
@@ -10,8 +9,7 @@ import {
   stepJobFailureTracker,
   type JobFailureTracker,
 } from './backgroundJobHealth.js';
-import { queuePendingAlert } from './pendingAlertQueue.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 type UsageAlertStats = Awaited<ReturnType<typeof usageStats>>;
@@ -123,28 +121,5 @@ export function startUsageAlert(adapters: readonly PlatformAdapter[]): ReturnTyp
 }
 
 async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  const connected = adapters.filter((adapter) => adapter.isConnected());
-  if (connected.length === 0) {
-    logger.warn(
-      { message },
-      'Usage alert could not be delivered live — no connected adapter; queued for flush on reconnect',
-    );
-    queuePendingAlert(message, 'system'); // super-admin-only alert — never evicted by a member-reachable alert (#545)
-    return;
-  }
-  for (const adapter of connected) {
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Usage alert: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Usage alert DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, { label: 'Usage alert', queueWhenDisconnected: true });
 }

--- a/src/usageCostDigest.ts
+++ b/src/usageCostDigest.ts
@@ -1,6 +1,5 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { superAdminIds } from './auth/roles.js';
 import { startTrackedJob } from './backgroundJobs.js';
 import {
   getLastUsageCostDigestCacheHitRate,
@@ -9,7 +8,7 @@ import {
   usageStats,
   wasUsageCostDigestSentRecently,
 } from './storage/repository.js';
-import { WindowClosedError } from './platforms/types.js';
+import { alertSuperAdmins as sendSuperAdminAlert } from './notifications.js';
 import type { PlatformAdapter } from './platforms/types.js';
 
 /** Same weekly window as `adminDigest.ts`'s `FRESHNESS_DAYS` — this signal targets the same ~7-day cadence. */
@@ -165,21 +164,13 @@ export function startUsageCostDigest(
   return startTrackedJob('usage-cost-digest', adapters, config.usageCostDigest.enabled, runOnce);
 }
 
+// `queueWhenDisconnected: false` — a fully-disconnected outage drops this
+// digest rather than queueing it: the weekly cadence re-reports current
+// numbers on the next due tick, so a queued copy would only deliver a stale
+// week-over-week comparison on reconnect.
 async function alertSuperAdmins(adapters: readonly PlatformAdapter[], message: string): Promise<void> {
-  for (const adapter of adapters) {
-    if (!adapter.isConnected()) continue; // can't send through a dead connection
-    for (const id of superAdminIds(adapter.platform)) {
-      adapter.sendDirectMessage(id, message).catch((err) => {
-        if (err instanceof WindowClosedError && adapter.queueForWindowReopen) {
-          adapter.queueForWindowReopen(id, message, 'system');
-          logger.warn(
-            { platform: adapter.platform, id },
-            'Cost-trend digest: recipient window closed, queued for reopen',
-          );
-          return;
-        }
-        logger.warn({ err, platform: adapter.platform, id }, 'Cost-trend digest DM failed');
-      });
-    }
-  }
+  await sendSuperAdminAlert(adapters, message, {
+    label: 'Cost-trend digest',
+    queueWhenDisconnected: false,
+  });
 }

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,171 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { OutgoingMessage, PlatformAdapter } from '../src/platforms/types.js';
+
+// config.ts validates env at import time — provide a dummy environment
+// before importing anything that (transitively) loads it, matching the
+// convention in tests/backgroundJobCostAlert.test.ts.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+process.env.SUPER_ADMIN_WHATSAPP_NUMBERS = 'super-1';
+
+const { alertSuperAdmins, makeAlertSlotReserver } = await import('../src/notifications.js');
+const { getPendingAlertEntriesForTests, resetPendingAlertsForTests } =
+  await import('../src/pendingAlertQueue.js');
+const { WindowClosedError } = await import('../src/platforms/types.js');
+
+/**
+ * A fake Cloud-like adapter (mirrors `tests/backgroundJobCostAlert.test.ts`'s
+ * shape): `sendDirectMessage` rejects with whatever `rejections[userId]`
+ * names, and `queueForWindowReopen` records what was queued, per-recipient,
+ * for assertion.
+ */
+function makeAdapter(opts: { connected: boolean; rejections?: Record<string, Error> }): {
+  adapter: PlatformAdapter;
+  dms: Array<{ userId: string; text: string }>;
+  queued: Array<{ userId: string; message: string; priority: 'system' | 'low' }>;
+} {
+  const dms: Array<{ userId: string; text: string }> = [];
+  const queued: Array<{ userId: string; message: string; priority: 'system' | 'low' }> = [];
+  const adapter: PlatformAdapter = {
+    platform: 'whatsapp',
+    adminCapabilities: new Set(),
+    async start() {},
+    async stop() {},
+    isConnected: () => opts.connected,
+    onMessage() {},
+    async sendMessage(_out: OutgoingMessage) {},
+    async sendDirectMessage(userId: string, text: string) {
+      const rejection = opts.rejections?.[userId];
+      if (rejection !== undefined) throw rejection;
+      dms.push({ userId, text });
+    },
+    async conversationsForUser() {
+      return [];
+    },
+    async performAdminAction() {
+      return '';
+    },
+    queueForWindowReopen(userId: string, message: string, priority: 'system' | 'low') {
+      queued.push({ userId, message, priority });
+    },
+  };
+  return { adapter, dms, queued };
+}
+
+// alertSuperAdmins sends fire-and-forget per recipient, so give the
+// microtask queue a turn before asserting — same technique as
+// tests/usageCostDigest.test.ts.
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('alertSuperAdmins: delivers to super admins through connected adapters only', async () => {
+  resetPendingAlertsForTests();
+  const live = makeAdapter({ connected: true });
+  const dead = makeAdapter({ connected: false });
+
+  await alertSuperAdmins([live.adapter, dead.adapter], 'hello', {
+    label: 'Test alert',
+    queueWhenDisconnected: true,
+  });
+  await flush();
+
+  assert.deepEqual(live.dms, [{ userId: 'super-1', text: 'hello' }]);
+  assert.equal(dead.dms.length, 0, 'nothing is sent through a disconnected adapter');
+  assert.equal(getPendingAlertEntriesForTests().length, 0, 'nothing is queued while an adapter is live');
+});
+
+test("alertSuperAdmins: queueWhenDisconnected=true queues at 'system' priority when every adapter is down", async () => {
+  resetPendingAlertsForTests();
+  const dead = makeAdapter({ connected: false });
+
+  await alertSuperAdmins([dead.adapter], 'outage alert', {
+    label: 'Test alert',
+    queueWhenDisconnected: true,
+  });
+  await flush();
+
+  assert.equal(dead.dms.length, 0);
+  const pending = getPendingAlertEntriesForTests();
+  assert.equal(pending.length, 1, 'the alert is queued for flush on reconnect');
+  assert.equal(pending[0].message, 'outage alert');
+  assert.equal(pending[0].priority, 'system', "super-admin alerts queue at 'system' priority (#545)");
+  resetPendingAlertsForTests();
+});
+
+test('alertSuperAdmins: queueWhenDisconnected=false drops silently when every adapter is down', async () => {
+  resetPendingAlertsForTests();
+  const dead = makeAdapter({ connected: false });
+
+  await alertSuperAdmins([dead.adapter], 'stale digest', {
+    label: 'Test digest',
+    queueWhenDisconnected: false,
+  });
+  await flush();
+
+  assert.equal(dead.dms.length, 0);
+  assert.equal(getPendingAlertEntriesForTests().length, 0, 'a periodic digest is dropped, never queued');
+});
+
+test('alertSuperAdmins: a WindowClosedError rejection queues that recipient for reopen instead of dropping', async () => {
+  resetPendingAlertsForTests();
+  const { adapter, queued } = makeAdapter({
+    connected: true,
+    rejections: { 'super-1': new WindowClosedError('super-1') },
+  });
+
+  await alertSuperAdmins([adapter], 'window test', {
+    label: 'Test alert',
+    queueWhenDisconnected: true,
+  });
+  await flush();
+
+  assert.deepEqual(queued, [{ userId: 'super-1', message: 'window test', priority: 'system' }]);
+  assert.equal(
+    getPendingAlertEntriesForTests().length,
+    0,
+    'reopen queueing is per-recipient, not the outage queue',
+  );
+});
+
+test('alertSuperAdmins: a non-window send failure is swallowed (logged), never thrown', async () => {
+  resetPendingAlertsForTests();
+  const { adapter, queued } = makeAdapter({
+    connected: true,
+    rejections: { 'super-1': new Error('boom') },
+  });
+
+  await alertSuperAdmins([adapter], 'failure test', {
+    label: 'Test alert',
+    queueWhenDisconnected: true,
+  });
+  await flush();
+
+  assert.equal(queued.length, 0, 'a generic failure does not use the reopen queue');
+});
+
+test('makeAlertSlotReserver: enforces the limit inside a rolling hour', () => {
+  const reserve = makeAlertSlotReserver();
+  assert.equal(reserve(2), true);
+  assert.equal(reserve(2), true);
+  assert.equal(reserve(2), false, 'the third reservation inside the hour is refused');
+});
+
+test('makeAlertSlotReserver: each factory call is an independent window', () => {
+  const a = makeAlertSlotReserver();
+  const b = makeAlertSlotReserver();
+  assert.equal(a(1), true);
+  assert.equal(a(1), false, 'window a is exhausted');
+  assert.equal(b(1), true, "window b is unaffected by window a's reservations");
+});
+
+test('makeAlertSlotReserver: a refused reservation does not consume a slot', () => {
+  const reserve = makeAlertSlotReserver();
+  assert.equal(reserve(1), true);
+  assert.equal(reserve(1), false);
+  assert.equal(reserve(2), true, 'the refused attempt left only one timestamp in the window');
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -29,6 +29,7 @@
     "tests/backgroundJobCostAlert.test.ts",
     "tests/memberDigest.test.ts",
     "tests/noticeDebounce.test.ts",
+    "tests/notifications.test.ts",
     "tests/projectScope.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
     "tests/usageCostDigest.test.ts",


### PR DESCRIPTION
## Summary

Third Phase 1 leaf cleanup from `docs/AGENT-BASE-PLAN.md` (the "one `alertSuperAdmins`/notification service" item, including the parenthetical "collapse the router's `reserve*Slot` copies onto it").

**Super-admin DM fan-out.** Six modules (`health.ts`, `backgroundJobs.ts`, `usageAlert.ts`, `departedAdminAlert.ts`, `usageCostDigest.ts`, `backgroundJobCostAlert.ts` — the plan said four; two more had accrued) each carried a near-identical `alertSuperAdmins`, drifted on exactly two axes: the log label, and whether an alert raised while every adapter is disconnected queues via `pendingAlertQueue` (the four reactive alerts) or drops silently (the two periodic cost signals, whose next scheduled run re-reports from source data). The new `src/notifications.ts` owns the one fan-out, parameterised on precisely those two axes via `SuperAdminAlertOptions`. Each producer keeps a thin purpose-named wrapper binding its label and disconnect policy, so every call site and every existing test import is unchanged, and per-producer behaviour (including log text) is preserved: queue-on-outage producers still queue at `'system'` priority, the two cost signals still drop, and `engagementAlert.ts`/`adminLeverageAlert.ts` keep sharing `departedAdminAlert.ts`'s exported wrapper as before.

**Alert-slot windows.** The same module exports `makeAlertSlotReserver()` — the keyless, guild-wide rolling-hour sliding window — replacing five identical private copies in `router.ts` (access-request, knowledge-gap, stale-knowledge, repeat-question, escalation) plus the copy in `moderation/moderator.ts` that was already documented as "mirroring `reserveEscalationSlot` exactly". Each router reserver becomes an instance property holding its own independent window, so all call sites are untouched; the moderator keeps its `reserveAlertSlot()` method (it reads its limit from `deps` at call time) delegating to a shared window. The per-conversation-keyed reservers in `agent/tools.ts` are a different shape and are deliberately out of scope (they're their own plan item).

New `tests/notifications.test.ts` (8 tests, added to the `tsconfig.tests.json` ratchet) covers connected-adapters-only delivery, `'system'`-priority outage queueing vs silent drop per policy, `WindowClosedError` → `queueForWindowReopen` per-recipient handling, swallowed generic send failures, and the reserver's limit enforcement, window independence, and no-slot-consumed-on-refusal. The `src/notifications.ts` module-map entry is added in the same diff.

## Security / privacy impact

None by design, and the consolidation strengthens two invariants by construction: the recipient set for every producer remains `superAdminIds` (env-derived, never from message content or the DB), and a queued outage alert always goes in at `'system'` priority, which `pendingAlertQueue` never evicts for a member-reachable alert (#545) — both now enforced in one place instead of six. The rate-cap semantics of all six collapsed slot windows are byte-equivalent (filter &lt; 1h, refuse at limit without reserving), and each category keeps its own independent window, so no alert category can consume another's slots. No change to auth, tool gating, outbound filtering, data access scope, or stored data.

## How verified

`npm run typecheck` clean (including `typecheck:tests` with the new test file ratcheted in). `npm test` — 3293 tests, 2440 pass, 0 fail (853 skipped: DB-backed tests without a local `DATABASE_URL`, which skip cleanly by design; 8 tests are new). The pre-existing behavioural tests for all six producers (window-reopen queueing, outage queueing, cross-producer queue caps, shared-function inheritance in `engagementAlert`/`adminLeverageAlert`) and for every router alert cap pass unchanged — they now exercise the shared implementation through the wrappers. `npm run test:security` — 1233 SECURITY tests ran, exact manifest match across 156 files (none added/removed). `npm run context:check`, `npm run format:check`, `npm run build`, and eslint on the changed files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_