### PR TITLE
Agent-base Phase 1: WebSearch guard + rate-reservation primitives out of tools.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
 Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 #775 #784 #804 #807 #809 #810 #812 #814 #816 #817 #818 #819 #821 #824 #825
-#868 #896 #899 #904 #949 #950 #951 #952
+#868 #896 #899 #904 #949 #950 #951 #952 #953
 -->
 
 

--- a/docs/agents/module-map.md
+++ b/docs/agents/module-map.md
@@ -36,6 +36,7 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/agent/skills/` — 🔒 One `SKILL.md` per Agent Skill, plus the plugin manifest. Loaded only when `AGENT_SKILLS_ENABLED`, and only the hand-written `ENABLED_SKILLS` allowlist in `core.ts` — never derived from request content.
 - `src/agent/systemPrompt.ts` — 🔒 Assembles the system prompt: security guidelines, persona voice rules, and the NZ-date grounding. Voice rules never override the security section above them.
 - `src/agent/tools.ts` — 🔒 Every tool implementation plus its tier requirement. By far the largest file in the repo; find your tool by name before reading anything else.
+- `src/agent/webSearchGuard.ts` — 🔒 The WebSearch PreToolUse guard: per-conversation hourly volume cap, exact-then-embedding query dedup, and the per-conversation lock keeping check-then-record atomic. Fail-closed by contract — a thrown `embed()` denies the call.
 - `src/auth/` — 🔒 Identity and role resolution: tiers come from env plus the `community_users` table, never from message content. Three files, all small and worth reading in full.
 - `src/backgroundJobCostAlert.ts` — Alerts super admins when background-job spend crosses a configured threshold, so an expensive job cannot run up cost unnoticed.
 - `src/backgroundJobHealth.ts` — Pure consecutive-failure debounce tracker for scheduled jobs, so one outage produces one alert rather than an alert per tick.
@@ -77,7 +78,8 @@ is marked **🔒**. Changes there need a `SECURITY:` test (see
 - `src/storage/repository/whatsappLidMap.ts` — 🔒 Durable WhatsApp LID -> phone mapping. A LID is a privacy id that looks like a number but matches no one; persisting what the adapter learns from real envelopes lets a LID be resolved rather than refused. PII — erased by `forget_me`/`purge_user_data`. See docs/SECURITY.md §6b.
 - `src/usageAlert.ts` — Usage-threshold alerting to super admins with a debounce tracker shared by several other alert modules.
 - `src/usageCostDigest.ts` — The periodic cost digest (spend, cache hit rate) sent to super admins.
-- `src/util/` — Shared leaf helpers with no dependencies of their own: NZ-timezone rendering for member-facing times, the `shouldNotifyAfterWindow` notice debounce every debounced notice module re-exports, and the display-name sanitiser below.
+- `src/util/` — Shared leaf helpers with no dependencies of their own: NZ-timezone rendering, the `shouldNotifyAfterWindow` notice debounce, the rate-reservation primitives, and the display-name sanitiser (see entries below).
+- `src/util/rateReservation.ts` — 🔒 The three in-memory rate-cap primitives (sliding window, UTC calendar day, per-key cooldown) behind every tool/adapter reservation cap. Reservations are never refunded on failure, so induced-failure retries can't bypass a cap.
 - `src/util/sanitizeName.ts` — 🔒 Neutralises attacker-controlled display names (bracket stripping, whitespace/NEL collapse, hard truncation) before they are interpolated anywhere the model or another member reads them. Every rendered name goes through here.
 - `src/voiceLanguageCaveatNotice.ts` — Fixed caveat DM for a te reo Māori speaker sending a voice note, because the transcription model is English-only and would otherwise fail silently.
 

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -33,14 +33,13 @@ import {
   renderRequesterTag,
 } from './systemPrompt.js';
 import { selectPersona } from './personas.js';
+import { buildToolServer, type ToolServerTurnState } from './tools.js';
 import {
-  buildToolServer,
   isDuplicateWebSearchQuery,
   recordWebSearchQuery,
   reserveWebSearchSlot,
   withWebSearchDedupLock,
-  type ToolServerTurnState,
-} from './tools.js';
+} from './webSearchGuard.js';
 import { ENABLED_SKILLS } from './enabledSkills.js';
 import {
   initialUsageLimitTracker,
@@ -373,7 +372,7 @@ const SKILLS_DIR = join(__dirname, 'skills');
  *    WebSearch for those tiers.
  *  - the same hook additionally denies an exact-normalized repeat of a
  *    recent query in the same conversation (issue #589,
- *    `isDuplicateWebSearchQuery`/`recordWebSearchQuery` in `tools.ts`) — the
+ *    `isDuplicateWebSearchQuery`/`recordWebSearchQuery` in `webSearchGuard.ts`) — the
  *    volume cap above bounds call count but never inspected the query, so an
  *    agentic turn could reformulate and re-fire the same search for no new
  *    information. The dedup CHECK runs BEFORE the volume-cap check and, on a

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -6,6 +6,11 @@ import { assertAtLeast, atLeast, type CallerContext } from '../auth/rbac.js';
 import { normalizeMemberId, resolveWhatsappLid } from '../auth/memberId.js';
 import { untrustedEntryContent } from './systemPrompt.js';
 import { sanitizeName } from '../util/sanitizeName.js';
+import {
+  makeCalendarDayReserver,
+  makeCooldownReserver,
+  makeSlidingWindowReserver,
+} from '../util/rateReservation.js';
 import { isSuperAdmin, resolveRole, superAdminIds } from '../auth/roles.js';
 import { config } from '../config.js';
 import { logger, hashId } from '../logger.js';
@@ -195,7 +200,6 @@ import {
   WHO_IS_INTO_LIMIT,
 } from '../storage/repository.js';
 import { getCommunityGuidelines, getCommunityGuidelinesMi, updatePolicy } from '../storage/policies.js';
-import { embed } from '../storage/embeddings.js';
 import { registerPendingAction } from './pendingActions.js';
 import { recentChanges } from './changelog.js';
 import { generateImage } from '../media/grokImage.js';
@@ -2396,46 +2400,20 @@ async function resetSessionsForRoleChange(platform: Platform, userId: string, ac
  */
 /** Users with an image generation currently in flight — blocks overlapping spawns per user. */
 const imageGenInFlight = new Set<string>();
-/** Per-user image-generation tally for the current UTC day (abuse cap; see config.imageGen.dailyLimit). */
-const imageGenDaily = new Map<string, { day: string; count: number }>();
-
 /**
- * Reserve one image-generation slot for `key` against today's per-user cap.
- * Returns false (and does not increment) if the cap is already reached.
- * A limit of 0 means unlimited.
+ * Reserve one image-generation slot for `key` against today's per-user cap
+ * (`config.imageGen.dailyLimit`; a limit of 0 means unlimited). Returns
+ * false (and does not increment) if the cap is already reached.
  *
  * A reservation is deliberately NOT refunded if the generation later fails: the
  * cap bounds heavyweight `grok` subprocess spawns, and a failed attempt still
  * spawned (and paid for) one — so a timeout/crash counts, and induced-failure
  * retry spam can't bypass the cap.
  */
-function reserveImageGenDaily(key: string, limit: number): boolean {
-  if (limit <= 0) return true;
-  const today = new Date().toISOString().slice(0, 10);
-  const entry = imageGenDaily.get(key);
-  if (!entry || entry.day !== today) {
-    imageGenDaily.set(key, { day: today, count: 1 });
-    return true;
-  }
-  if (entry.count >= limit) return false;
-  entry.count += 1;
-  return true;
-}
+const reserveImageGenDaily = makeCalendarDayReserver();
 
 /** suggest_issue filings per super admin, for the rolling calendar-day cap. */
-const issueFileDaily = new Map<string, { day: string; count: number }>();
-function reserveIssueDaily(key: string, limit: number): boolean {
-  if (limit <= 0) return true;
-  const today = new Date().toISOString().slice(0, 10);
-  const entry = issueFileDaily.get(key);
-  if (!entry || entry.day !== today) {
-    issueFileDaily.set(key, { day: today, count: 1 });
-    return true;
-  }
-  if (entry.count >= limit) return false;
-  entry.count += 1;
-  return true;
-}
+const reserveIssueDaily = makeCalendarDayReserver();
 
 /**
  * dev_team_dispatch calls per super admin, for the rolling calendar-day cap
@@ -2448,19 +2426,7 @@ function reserveIssueDaily(key: string, limit: number): boolean {
  * a failed POST still probed the service, and refunds would let induced
  * failures bypass the cap (same rationale as reserveImageGenDaily).
  */
-const devTeamDispatchDaily = new Map<string, { day: string; count: number }>();
-export function reserveDevTeamDispatchDaily(key: string, limit: number): boolean {
-  if (limit <= 0) return true;
-  const today = new Date().toISOString().slice(0, 10);
-  const entry = devTeamDispatchDaily.get(key);
-  if (!entry || entry.day !== today) {
-    devTeamDispatchDaily.set(key, { day: today, count: 1 });
-    return true;
-  }
-  if (entry.count >= limit) return false;
-  entry.count += 1;
-  return true;
-}
+export const reserveDevTeamDispatchDaily = makeCalendarDayReserver();
 
 /**
  * Discord image-attachment fetches per platform-qualified sender, for the
@@ -2473,337 +2439,72 @@ export function reserveDevTeamDispatchDaily(key: string, limit: number): boolean
  * even though only Discord implements image input today, matching the
  * defensive convention `reserveVoiceTranscriptionSlot` already established.
  */
-const imageInputDaily = new Map<string, { day: string; count: number }>();
-export function reserveImageInputDaily(key: string, limit: number): boolean {
-  if (limit <= 0) return true;
-  const today = new Date().toISOString().slice(0, 10);
-  const entry = imageInputDaily.get(key);
-  if (!entry || entry.day !== today) {
-    imageInputDaily.set(key, { day: today, count: 1 });
-    return true;
-  }
-  if (entry.count >= limit) return false;
-  entry.count += 1;
-  return true;
-}
-
-/** create_poll timestamps per conversation, for the rolling-hour cap (POLL_RATE_LIMIT_PER_HOUR). */
-const pollTimestampsByConversation = new Map<string, number[]>();
+export const reserveImageInputDaily = makeCalendarDayReserver();
 
 /**
  * Reserve one create_poll slot for `conversationId` against a rolling
- * hourly cap (sliding window, unlike reserveImageGenDaily's calendar-day
- * bucket — a 1-hour cap doesn't align to midnight). Returns false without
- * reserving if the conversation already hit `limit` within the last hour.
+ * hourly cap (POLL_RATE_LIMIT_PER_HOUR; sliding window, unlike
+ * reserveImageGenDaily's calendar-day bucket — a 1-hour cap doesn't align
+ * to midnight). Returns false without reserving if the conversation already
+ * hit `limit` within the last hour.
  */
-function reservePollSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (pollTimestampsByConversation.get(conversationId) ?? []).filter((t) => now - t < windowMs);
-  if (recent.length >= limit) {
-    pollTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  pollTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
-
-/** end_poll timestamps per conversation, for its own rolling-hour cap (POLL_END_RATE_LIMIT_PER_HOUR). */
-const pollEndTimestampsByConversation = new Map<string, number[]>();
+const reservePollSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
- * Reserve one `end_poll` slot for `conversationId` — same sliding-hour shape as
- * `reservePollSlot`, but a SEPARATE bucket so ending polls neither consumes nor
- * is blocked by the create_poll budget (PR #272 review).
+ * Reserve one `end_poll` slot for `conversationId`
+ * (POLL_END_RATE_LIMIT_PER_HOUR) — same sliding-hour shape as
+ * `reservePollSlot`, but a SEPARATE window so ending polls neither consumes
+ * nor is blocked by the create_poll budget (PR #272 review).
  */
-function reservePollEndSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (pollEndTimestampsByConversation.get(conversationId) ?? []).filter(
-    (t) => now - t < windowMs,
-  );
-  if (recent.length >= limit) {
-    pollEndTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  pollEndTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
-
-/** create_thread timestamps per parent channel, for the rolling-hour cap (THREAD_CREATE_RATE_LIMIT_PER_HOUR). */
-const threadTimestampsByConversation = new Map<string, number[]>();
+const reservePollEndSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
- * Reserve one create_thread slot for `conversationId` against a rolling
- * hourly cap, same sliding-window shape as `reservePollSlot`. Returns false
- * without reserving if the channel already hit `limit` within the last hour.
+ * Reserve one create_thread slot for the parent channel against a rolling
+ * hourly cap (THREAD_CREATE_RATE_LIMIT_PER_HOUR), same sliding-window shape
+ * as `reservePollSlot`. Returns false without reserving if the channel
+ * already hit `limit` within the last hour.
  */
-function reserveThreadSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (threadTimestampsByConversation.get(conversationId) ?? []).filter((t) => now - t < windowMs);
-  if (recent.length >= limit) {
-    threadTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  threadTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
+const reserveThreadSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
- * WebSearch invocation timestamps per conversation, for its rolling-hour cap
- * (`config.llm.webSearchRateLimitPerHour`, issue #412). Same sliding-window
- * shape as `reservePollSlot`/`reserveThreadSlot`/`reserveWarnSlot` — WebSearch
- * is a built-in SDK tool rather than one of this file's own MCP tools, so it
- * is gated via a `PreToolUse` hook in `core.ts` instead of inline in a tool
- * handler, but reuses the identical per-conversation cap primitive.
+ * The WebSearch guard itself (volume cap, query dedup, per-conversation
+ * lock) lives in `webSearchGuard.ts` — WebSearch is a built-in SDK tool
+ * gated by `core.ts`'s PreToolUse hook, not one of this file's MCP tools.
+ * Re-exported here so existing import sites (tests especially) keep
+ * working unchanged.
  */
-const webSearchTimestampsByConversation = new Map<string, number[]>();
-
-/**
- * Reserve one WebSearch slot for `conversationId` against a rolling hourly
- * cap, same sliding-window shape as `reservePollSlot`. Returns false without
- * reserving if the conversation already hit `limit` within the last hour.
- * Exported so `core.ts`'s `buildQueryOptions` PreToolUse hook can call it.
- */
-export function reserveWebSearchSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (webSearchTimestampsByConversation.get(conversationId) ?? []).filter(
-    (t) => now - t < windowMs,
-  );
-  if (recent.length >= limit) {
-    webSearchTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  webSearchTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
-
-/** Trim, collapse internal whitespace, and casefold a WebSearch query for exact-match dedup comparison. */
-function normalizeWebSearchQuery(query: string): string {
-  return query.trim().replace(/\s+/g, ' ').toLowerCase();
-}
-
-/** Cosine similarity of two `embed()`-produced (already L2-normalized) vectors — dot product suffices. Local per-file copy, same duplicated-not-shared convention as repository.ts/context/builder.ts's own `cosineSim`. */
-function cosineSim(a: number[], b: number[]): number {
-  let dot = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) dot += a[i] * b[i];
-  return dot;
-}
-
-/**
- * Recent (normalized query, timestamp, embedding) triples per conversation,
- * for WebSearch query-level dedup (issue #589, embedding-similarity upgrade
- * #706). In-memory only — same durability class as
- * `webSearchTimestampsByConversation` right above: a restart just forgets
- * recent queries, harmless. Deliberately holds nothing but the normalized
- * query text, its timestamp, and its embedding vector; never written to
- * `interactions`/`admin_audit` or logged (this module has no DB handle in
- * scope, and the caller in `core.ts` only ever logs `{ err, conversationId }`
- * on failure, never the query or its embedding).
- */
-const webSearchQueryHistoryByConversation = new Map<
-  string,
-  Array<{ query: string; ts: number; embedding: number[] }>
->();
-
-/**
- * Per-conversation serialization queue for the dedup check-then-record
- * critical section (adversarial review on issue #706). Before that PR, the
- * whole `PreToolUse` hook body ran with no `await` at all, so JS
- * run-to-completion semantics meant two "parallel" tool-use invocations for
- * the same turn could never interleave — one hook call always finished
- * (check AND record) before the next began. Adding `await embed()` inside
- * `isDuplicateWebSearchQuery` introduced a genuine yield point: without this
- * lock, two near-simultaneous WebSearch calls in one turn could both read
- * `recent` before either recorded, both compute embeddings concurrently, and
- * neither would see the other as a duplicate — defeating even the
- * exact-match short-circuit for the race window. `withWebSearchDedupLock`
- * restores the pre-#706 atomicity: the caller in `core.ts` wraps the entire
- * check -> volume-reserve -> record sequence in this lock, so a second
- * invocation for the same `conversationId` cannot start its own check until
- * the first has fully finished (recorded or not). Chained via a promise
- * queue rather than a real mutex library since Node has no built-in one;
- * the stored continuation always resolves (never rejects) so one failed
- * turn's error can't wedge the queue for the rest of the conversation, while
- * the promise returned to the caller still propagates `fn`'s own
- * rejection/return value untouched. Never cleared, same as every other
- * per-conversation map in this file — a restart just forgets, harmless.
- */
-const webSearchDedupLocks = new Map<string, Promise<void>>();
-
-export function withWebSearchDedupLock<T>(conversationId: string, fn: () => Promise<T>): Promise<T> {
-  const prior = webSearchDedupLocks.get(conversationId) ?? Promise.resolve();
-  const settled = prior.catch(() => {});
-  const result = settled.then(fn);
-  webSearchDedupLocks.set(
-    conversationId,
-    result.then(
-      () => {},
-      () => {},
-    ),
-  );
-  return result;
-}
-
-/**
- * Returns `{ duplicate: true }` if `query` either (a) once normalized,
- * exactly matches one of the queries recorded for `conversationId` within
- * `windowMs`, or (b) embeds above `similarityThreshold` cosine similarity
- * against one of those queries' stored embeddings — the "search, get an
- * unsatisfying result, reformulate almost identically (or exactly),
- * search again" agentic-loop failure mode (issue #589; embedding upgrade
- * #706, the growth path #589 itself named).
- *
- * The exact-match check runs FIRST and short-circuits before any `embed()`
- * call — same true-short-circuit discipline already proven for
- * `candidateTopicAlreadyReviewed` (`repository.ts`, issue #503 AC1): a
- * verbatim repeat never pays for an embedding. Only when no exact match is
- * found does this embed the (normalized) query and compare it against the
- * window's stored embeddings. The returned `embedding` is the vector this
- * call computed (or `null` when the exact-match path short-circuited, or
- * the query normalized to empty) — callers reuse it for `recordWebSearchQuery`
- * instead of embedding a second time, same reuse-not-recompute discipline as
- * `candidateTopicAlreadyReviewed`/`insertKnowledgeCandidate` (issue #503).
- *
- * Pure check otherwise: it prunes window-expired entries (so the stored
- * history doesn't grow unboundedly across calls that never record) but
- * never itself records `query` — a genuine repeat is therefore also never
- * re-recorded, so its timestamp keeps anchoring the original window instead
- * of extending it. An empty/non-string query (normalizes to `''`) never
- * matches, so a missing `tool_input.query` can't wedge the guard.
- *
- * A thrown/rejected `embed()` call is deliberately NOT caught here — it
- * propagates to the caller's own fail-closed try/catch (`core.ts`'s
- * `PreToolUse` hook, issue #412 AC-5 / #589 review), denying the call rather
- * than silently falling back to exact-match-only (issue #706 SECURITY
- * criterion).
- *
- * Recording is a SEPARATE step (`recordWebSearchQuery`) that callers must
- * invoke only once the call is actually going to proceed — i.e. AFTER
- * `reserveWebSearchSlot` also confirms it, not just after this check passes.
- * Recording here unconditionally (as an earlier version of this guard did)
- * let a query that was later denied by the volume cap poison the dedup
- * history: a retry of that exact query would then be wrongly denied as
- * "already searched" even though no search ever ran (issue #589 review).
- */
-export async function isDuplicateWebSearchQuery(
-  conversationId: string,
-  query: string,
-  windowMs: number,
-  similarityThreshold: number,
-): Promise<{ duplicate: boolean; embedding: number[] | null }> {
-  const normalized = normalizeWebSearchQuery(query);
-  const now = Date.now();
-  const recent = (webSearchQueryHistoryByConversation.get(conversationId) ?? []).filter(
-    (entry) => now - entry.ts < windowMs,
-  );
-  webSearchQueryHistoryByConversation.set(conversationId, recent);
-  if (normalized.length === 0) return { duplicate: false, embedding: null };
-  if (recent.some((entry) => entry.query === normalized)) {
-    return { duplicate: true, embedding: null };
-  }
-
-  const embedding = await embed(normalized);
-  const duplicate = recent.some((entry) => cosineSim(embedding, entry.embedding) >= similarityThreshold);
-  return { duplicate, embedding };
-}
-
-/**
- * Record `query` as seen for `conversationId`, trimmed to the last
- * `historySize` entries (oldest evicted first). `embedding` must be the
- * SAME vector `isDuplicateWebSearchQuery` already computed for this exact
- * call — passed through rather than re-embedded (issue #706, mirroring
- * `candidateTopicAlreadyReviewed`/`insertKnowledgeCandidate`'s reuse
- * discipline, issue #503). Callers must only call this once a WebSearch
- * call is confirmed to actually proceed (after BOTH `isDuplicateWebSearchQuery`
- * returns `duplicate: false` AND `reserveWebSearchSlot` returns true) — see
- * the ordering note on `isDuplicateWebSearchQuery`. An empty/non-string query
- * (normalizes to `''`) is never recorded, so a missing `tool_input.query`
- * can't wedge the guard.
- */
-export function recordWebSearchQuery(
-  conversationId: string,
-  query: string,
-  windowMs: number,
-  historySize: number,
-  embedding: number[] | null,
-): void {
-  const normalized = normalizeWebSearchQuery(query);
-  if (normalized.length === 0) return;
-  const now = Date.now();
-  const recent = (webSearchQueryHistoryByConversation.get(conversationId) ?? []).filter(
-    (entry) => now - entry.ts < windowMs,
-  );
-  // `embedding` is only ever `null` from `isDuplicateWebSearchQuery` when `normalized` was
-  // already empty (this function's own early return above already excludes that) or on an
-  // exact-match duplicate (which the caller never proceeds to record) — so this `?? []` is
-  // defensive against the parameter's type, not a reachable runtime path.
-  recent.push({ query: normalized, ts: now, embedding: embedding ?? [] });
-  while (recent.length > historySize) recent.shift();
-  webSearchQueryHistoryByConversation.set(conversationId, recent);
-}
-
-/**
- * Voice-transcription timestamps per platform-qualified SENDER (issue #507;
- * platform-qualified in issue #732), for `config.whatsapp.voice.rateLimitPerHour`
- * / `config.discord.voice.rateLimitPerHour`. Per-sender rather than
- * per-conversation (unlike `reserveWebSearchSlot`) since this bounds one
- * person's own audio volume, not a shared conversation. Same sliding-window
- * shape as `reserveWebSearchSlot`.
- */
-const voiceTranscriptionTimestampsBySender = new Map<string, number[]>();
+export {
+  reserveWebSearchSlot,
+  withWebSearchDedupLock,
+  isDuplicateWebSearchQuery,
+  recordWebSearchQuery,
+} from './webSearchGuard.js';
 
 /**
  * Reserve one voice-transcription slot for `key` against a rolling hourly
- * cap. Returns false without reserving if the sender already hit `limit`
- * within the last hour. Called from `BaileysAdapter`/`DiscordAdapter` BEFORE
- * any media download, so a refused slot never triggers a download/decode/model
- * run. Callers must skip this entirely when `limit` is 0 (unlimited) so the
- * default configuration does no bookkeeping. `key` MUST be platform-qualified
+ * cap (issue #507; platform-qualified in issue #732 —
+ * `config.whatsapp.voice.rateLimitPerHour` /
+ * `config.discord.voice.rateLimitPerHour`). Per-sender rather than
+ * per-conversation (unlike `reserveWebSearchSlot`) since this bounds one
+ * person's own audio volume, not a shared conversation. Returns false
+ * without reserving if the sender already hit `limit` within the last hour.
+ * Called from `BaileysAdapter`/`DiscordAdapter` BEFORE any media download,
+ * so a refused slot never triggers a download/decode/model run. Callers must
+ * skip this entirely when `limit` is 0 (unlimited) so the default
+ * configuration does no bookkeeping. `key` MUST be platform-qualified
  * (e.g. `` `whatsapp:${senderId}` ``/`` `discord:${senderId}` ``) — a bare
  * sender id would let a WhatsApp phone number and a Discord snowflake that
  * happen to collide share one quota bucket across platforms (issue #732).
  */
-export function reserveVoiceTranscriptionSlot(key: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (voiceTranscriptionTimestampsBySender.get(key) ?? []).filter((t) => now - t < windowMs);
-  if (recent.length >= limit) {
-    voiceTranscriptionTimestampsBySender.set(key, recent);
-    return false;
-  }
-  recent.push(now);
-  voiceTranscriptionTimestampsBySender.set(key, recent);
-  return true;
-}
-
-/** warn_user timestamps per conversation, for the rolling-hour cap (WARN_USER_RATE_LIMIT_PER_HOUR). */
-const warnTimestampsByConversation = new Map<string, number[]>();
+export const reserveVoiceTranscriptionSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
  * Reserve one warn_user slot for `conversationId` against a rolling hourly
- * cap, same sliding-window shape as `reservePollSlot`. Returns false without
- * reserving if the conversation already hit `limit` within the last hour.
+ * cap (WARN_USER_RATE_LIMIT_PER_HOUR), same sliding-window shape as
+ * `reservePollSlot`. Returns false without reserving if the conversation
+ * already hit `limit` within the last hour.
  */
-function reserveWarnSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (warnTimestampsByConversation.get(conversationId) ?? []).filter((t) => now - t < windowMs);
-  if (recent.length >= limit) {
-    warnTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  warnTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
+const reserveWarnSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
  * Wires a manual `warn_user` into the same strike system `Moderator.scan`
@@ -2864,8 +2565,6 @@ async function applyManualWarnStrike(opts: {
  * tool could alone exhaust that hourly cap and starve every other member's
  * max-turns/thumbs-down escalations for the rest of the hour.
  */
-const humanHelpRequestTimestamps = new Map<string, number[]>();
-
 export const HUMAN_HELP_REQUEST_DAILY_LIMIT_PER_USER = 3;
 
 /**
@@ -2875,41 +2574,15 @@ export const HUMAN_HELP_REQUEST_DAILY_LIMIT_PER_USER = 3;
  * Returns false without reserving if `key` already hit `limit` within the
  * last 24h.
  */
-function reserveHumanHelpRequestSlot(key: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 24 * 60 * 60 * 1000;
-  const recent = (humanHelpRequestTimestamps.get(key) ?? []).filter((t) => now - t < windowMs);
-  if (recent.length >= limit) {
-    humanHelpRequestTimestamps.set(key, recent);
-    return false;
-  }
-  recent.push(now);
-  humanHelpRequestTimestamps.set(key, recent);
-  return true;
-}
-
-/** announce timestamps per conversation, for the rolling-hour cap (ANNOUNCE_RATE_LIMIT_PER_HOUR). */
-const announceTimestampsByConversation = new Map<string, number[]>();
+const reserveHumanHelpRequestSlot = makeSlidingWindowReserver(24 * 60 * 60 * 1000);
 
 /**
  * Reserve one announce slot for `conversationId` against a rolling hourly
- * cap, same sliding-window shape as `reservePollSlot`. Returns false without
- * reserving if the conversation already hit `limit` within the last hour.
+ * cap (ANNOUNCE_RATE_LIMIT_PER_HOUR), same sliding-window shape as
+ * `reservePollSlot`. Returns false without reserving if the conversation
+ * already hit `limit` within the last hour.
  */
-function reserveAnnounceSlot(conversationId: string, limit: number): boolean {
-  const now = Date.now();
-  const windowMs = 60 * 60 * 1000;
-  const recent = (announceTimestampsByConversation.get(conversationId) ?? []).filter(
-    (t) => now - t < windowMs,
-  );
-  if (recent.length >= limit) {
-    announceTimestampsByConversation.set(conversationId, recent);
-    return false;
-  }
-  recent.push(now);
-  announceTimestampsByConversation.set(conversationId, recent);
-  return true;
-}
+const reserveAnnounceSlot = makeSlidingWindowReserver(60 * 60 * 1000);
 
 /**
  * appeal_moderation last-fired timestamp per CALLER (`platform:userId`), for
@@ -2920,7 +2593,7 @@ function reserveAnnounceSlot(conversationId: string, limit: number): boolean {
  * restart merely permits one extra appeal DM, harmless for a non-destructive
  * notification.
  */
-const appealModerationLastAt = new Map<string, number>();
+const appealModerationCooldown = makeCooldownReserver();
 
 /**
  * Reserve one appeal_moderation slot for `key` against a rolling per-caller
@@ -2928,12 +2601,7 @@ const appealModerationLastAt = new Map<string, number>();
  * `cooldownHours`.
  */
 function reserveAppealSlot(key: string, cooldownHours: number): boolean {
-  const now = Date.now();
-  const windowMs = cooldownHours * 60 * 60 * 1000;
-  const last = appealModerationLastAt.get(key);
-  if (last !== undefined && now - last < windowMs) return false;
-  appealModerationLastAt.set(key, now);
-  return true;
+  return appealModerationCooldown(key, cooldownHours * 60 * 60 * 1000);
 }
 
 /**
@@ -2948,7 +2616,7 @@ export const ALLOWED_REACTION_EMOJI = ['✅', '👍', '👀', '🎉'] as const;
 
 /** Per-user reaction tally for the current UTC day (anti-spam on the bot's own identity; issue #231). */
 export const REACTION_RATE_LIMIT_PER_DAY = 20;
-const reactionDaily = new Map<string, { day: string; count: number }>();
+const reactionDaily = makeCalendarDayReserver();
 
 /**
  * Reserve one reaction slot for `key` against today's per-user cap, same
@@ -2957,15 +2625,7 @@ const reactionDaily = new Map<string, { day: string; count: number }>();
  * spawn, so an in-memory (not DB) cap is proportionate and needs no migration.
  */
 function reserveReactionDaily(key: string): boolean {
-  const today = new Date().toISOString().slice(0, 10);
-  const entry = reactionDaily.get(key);
-  if (!entry || entry.day !== today) {
-    reactionDaily.set(key, { day: today, count: 1 });
-    return true;
-  }
-  if (entry.count >= REACTION_RATE_LIMIT_PER_DAY) return false;
-  entry.count += 1;
-  return true;
+  return reactionDaily(key, REACTION_RATE_LIMIT_PER_DAY);
 }
 
 /**

--- a/src/agent/webSearchGuard.ts
+++ b/src/agent/webSearchGuard.ts
@@ -1,0 +1,188 @@
+import { embed } from '../storage/embeddings.js';
+import { makeSlidingWindowReserver } from '../util/rateReservation.js';
+
+/**
+ * The WebSearch guard (issues #412, #589, #706), extracted from `tools.ts`:
+ * WebSearch is a built-in SDK tool rather than one of the MCP tools
+ * `tools.ts` hosts, so it is gated via a `PreToolUse` hook in `core.ts`
+ * instead of inline in a tool handler. This module owns everything that hook
+ * needs — the per-conversation volume cap, the query-level dedup (exact
+ * match, then embedding similarity), and the per-conversation lock that
+ * keeps the check-then-record critical section atomic.
+ */
+
+/**
+ * Reserve one WebSearch slot for `conversationId` against a rolling hourly
+ * cap (`config.llm.webSearchRateLimitPerHour`, issue #412) — the shared
+ * `makeSlidingWindowReserver` primitive, per-conversation-keyed like the
+ * tool caps in `tools.ts`. Returns false without reserving if the
+ * conversation already hit `limit` within the last hour. Called by
+ * `core.ts`'s `buildQueryOptions` PreToolUse hook.
+ */
+export const reserveWebSearchSlot = makeSlidingWindowReserver(60 * 60 * 1000);
+
+/** Trim, collapse internal whitespace, and casefold a WebSearch query for exact-match dedup comparison. */
+function normalizeWebSearchQuery(query: string): string {
+  return query.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/** Cosine similarity of two `embed()`-produced (already L2-normalized) vectors — dot product suffices. Local per-file copy, same duplicated-not-shared convention as repository.ts/context/builder.ts's own `cosineSim`. */
+function cosineSim(a: number[], b: number[]): number {
+  let dot = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+/**
+ * Recent (normalized query, timestamp, embedding) triples per conversation,
+ * for WebSearch query-level dedup (issue #589, embedding-similarity upgrade
+ * #706). In-memory only — same durability class as the volume cap right
+ * above: a restart just forgets recent queries, harmless. Deliberately holds
+ * nothing but the normalized query text, its timestamp, and its embedding
+ * vector; never written to `interactions`/`admin_audit` or logged (this
+ * module has no DB handle in scope, and the caller in `core.ts` only ever
+ * logs `{ err, conversationId }` on failure, never the query or its
+ * embedding).
+ */
+const webSearchQueryHistoryByConversation = new Map<
+  string,
+  Array<{ query: string; ts: number; embedding: number[] }>
+>();
+
+/**
+ * Per-conversation serialization queue for the dedup check-then-record
+ * critical section (adversarial review on issue #706). Before that PR, the
+ * whole `PreToolUse` hook body ran with no `await` at all, so JS
+ * run-to-completion semantics meant two "parallel" tool-use invocations for
+ * the same turn could never interleave — one hook call always finished
+ * (check AND record) before the next began. Adding `await embed()` inside
+ * `isDuplicateWebSearchQuery` introduced a genuine yield point: without this
+ * lock, two near-simultaneous WebSearch calls in one turn could both read
+ * `recent` before either recorded, both compute embeddings concurrently, and
+ * neither would see the other as a duplicate — defeating even the
+ * exact-match short-circuit for the race window. `withWebSearchDedupLock`
+ * restores the pre-#706 atomicity: the caller in `core.ts` wraps the entire
+ * check -> volume-reserve -> record sequence in this lock, so a second
+ * invocation for the same `conversationId` cannot start its own check until
+ * the first has fully finished (recorded or not). Chained via a promise
+ * queue rather than a real mutex library since Node has no built-in one;
+ * the stored continuation always resolves (never rejects) so one failed
+ * turn's error can't wedge the queue for the rest of the conversation, while
+ * the promise returned to the caller still propagates `fn`'s own
+ * rejection/return value untouched. Never cleared, same as every other
+ * per-conversation map in this module — a restart just forgets, harmless.
+ */
+const webSearchDedupLocks = new Map<string, Promise<void>>();
+
+export function withWebSearchDedupLock<T>(conversationId: string, fn: () => Promise<T>): Promise<T> {
+  const prior = webSearchDedupLocks.get(conversationId) ?? Promise.resolve();
+  const settled = prior.catch(() => {});
+  const result = settled.then(fn);
+  webSearchDedupLocks.set(
+    conversationId,
+    result.then(
+      () => {},
+      () => {},
+    ),
+  );
+  return result;
+}
+
+/**
+ * Returns `{ duplicate: true }` if `query` either (a) once normalized,
+ * exactly matches one of the queries recorded for `conversationId` within
+ * `windowMs`, or (b) embeds above `similarityThreshold` cosine similarity
+ * against one of those queries' stored embeddings — the "search, get an
+ * unsatisfying result, reformulate almost identically (or exactly),
+ * search again" agentic-loop failure mode (issue #589; embedding upgrade
+ * #706, the growth path #589 itself named).
+ *
+ * The exact-match check runs FIRST and short-circuits before any `embed()`
+ * call — same true-short-circuit discipline already proven for
+ * `candidateTopicAlreadyReviewed` (`repository.ts`, issue #503 AC1): a
+ * verbatim repeat never pays for an embedding. Only when no exact match is
+ * found does this embed the (normalized) query and compare it against the
+ * window's stored embeddings. The returned `embedding` is the vector this
+ * call computed (or `null` when the exact-match path short-circuited, or
+ * the query normalized to empty) — callers reuse it for `recordWebSearchQuery`
+ * instead of embedding a second time, same reuse-not-recompute discipline as
+ * `candidateTopicAlreadyReviewed`/`insertKnowledgeCandidate` (issue #503).
+ *
+ * Pure check otherwise: it prunes window-expired entries (so the stored
+ * history doesn't grow unboundedly across calls that never record) but
+ * never itself records `query` — a genuine repeat is therefore also never
+ * re-recorded, so its timestamp keeps anchoring the original window instead
+ * of extending it. An empty/non-string query (normalizes to `''`) never
+ * matches, so a missing `tool_input.query` can't wedge the guard.
+ *
+ * A thrown/rejected `embed()` call is deliberately NOT caught here — it
+ * propagates to the caller's own fail-closed try/catch (`core.ts`'s
+ * `PreToolUse` hook, issue #412 AC-5 / #589 review), denying the call rather
+ * than silently falling back to exact-match-only (issue #706 SECURITY
+ * criterion).
+ *
+ * Recording is a SEPARATE step (`recordWebSearchQuery`) that callers must
+ * invoke only once the call is actually going to proceed — i.e. AFTER
+ * `reserveWebSearchSlot` also confirms it, not just after this check passes.
+ * Recording here unconditionally (as an earlier version of this guard did)
+ * let a query that was later denied by the volume cap poison the dedup
+ * history: a retry of that exact query would then be wrongly denied as
+ * "already searched" even though no search ever ran (issue #589 review).
+ */
+export async function isDuplicateWebSearchQuery(
+  conversationId: string,
+  query: string,
+  windowMs: number,
+  similarityThreshold: number,
+): Promise<{ duplicate: boolean; embedding: number[] | null }> {
+  const normalized = normalizeWebSearchQuery(query);
+  const now = Date.now();
+  const recent = (webSearchQueryHistoryByConversation.get(conversationId) ?? []).filter(
+    (entry) => now - entry.ts < windowMs,
+  );
+  webSearchQueryHistoryByConversation.set(conversationId, recent);
+  if (normalized.length === 0) return { duplicate: false, embedding: null };
+  if (recent.some((entry) => entry.query === normalized)) {
+    return { duplicate: true, embedding: null };
+  }
+
+  const embedding = await embed(normalized);
+  const duplicate = recent.some((entry) => cosineSim(embedding, entry.embedding) >= similarityThreshold);
+  return { duplicate, embedding };
+}
+
+/**
+ * Record `query` as seen for `conversationId`, trimmed to the last
+ * `historySize` entries (oldest evicted first). `embedding` must be the
+ * SAME vector `isDuplicateWebSearchQuery` already computed for this exact
+ * call — passed through rather than re-embedded (issue #706, mirroring
+ * `candidateTopicAlreadyReviewed`/`insertKnowledgeCandidate`'s reuse
+ * discipline, issue #503). Callers must only call this once a WebSearch
+ * call is confirmed to actually proceed (after BOTH `isDuplicateWebSearchQuery`
+ * returns `duplicate: false` AND `reserveWebSearchSlot` returns true) — see
+ * the ordering note on `isDuplicateWebSearchQuery`. An empty/non-string query
+ * (normalizes to `''`) is never recorded, so a missing `tool_input.query`
+ * can't wedge the guard.
+ */
+export function recordWebSearchQuery(
+  conversationId: string,
+  query: string,
+  windowMs: number,
+  historySize: number,
+  embedding: number[] | null,
+): void {
+  const normalized = normalizeWebSearchQuery(query);
+  if (normalized.length === 0) return;
+  const now = Date.now();
+  const recent = (webSearchQueryHistoryByConversation.get(conversationId) ?? []).filter(
+    (entry) => now - entry.ts < windowMs,
+  );
+  // `embedding` is only ever `null` from `isDuplicateWebSearchQuery` when `normalized` was
+  // already empty (this function's own early return above already excludes that) or on an
+  // exact-match duplicate (which the caller never proceeds to record) — so this `?? []` is
+  // defensive against the parameter's type, not a reachable runtime path.
+  recent.push({ query: normalized, ts: now, embedding: embedding ?? [] });
+  while (recent.length > historySize) recent.shift();
+  webSearchQueryHistoryByConversation.set(conversationId, recent);
+}

--- a/src/util/rateReservation.ts
+++ b/src/util/rateReservation.ts
@@ -1,0 +1,76 @@
+/**
+ * The three in-memory rate-reservation primitives behind every keyed cap in
+ * this codebase, extracted from `agent/tools.ts`'s per-cap copies. All three
+ * share the same posture: in-memory only (a restart forgets the window —
+ * accepted everywhere these are used), reservations are never refunded on a
+ * later failure (a failed attempt still spent the resource being bounded, and
+ * refunds would let induced-failure retry spam bypass the cap), and each
+ * factory call owns a private map, so distinct caps can never consume each
+ * other's budget. Keys are caller-chosen; anything per-user crossing
+ * platforms MUST be platform-qualified (e.g. `` `discord:${senderId}` ``) so
+ * colliding ids on different platforms don't share a bucket (issue #732).
+ */
+
+/**
+ * Rolling sliding-window reserver: at most `limit` reservations per `key`
+ * within the trailing `windowMs`. Returns false without reserving once a key
+ * is at its limit; expired timestamps are pruned on every call, so no
+ * external sweep is needed. Callers that treat `limit` 0 as "unlimited" must
+ * skip the call themselves (the voice-transcription cap's documented
+ * contract) — a literal `limit` of 0 here refuses everything, which is what
+ * the tool caps want.
+ */
+export function makeSlidingWindowReserver(windowMs: number): (key: string, limit: number) => boolean {
+  const timestampsByKey = new Map<string, number[]>();
+  return (key: string, limit: number): boolean => {
+    const now = Date.now();
+    const recent = (timestampsByKey.get(key) ?? []).filter((t) => now - t < windowMs);
+    if (recent.length >= limit) {
+      timestampsByKey.set(key, recent);
+      return false;
+    }
+    recent.push(now);
+    timestampsByKey.set(key, recent);
+    return true;
+  };
+}
+
+/**
+ * UTC-calendar-day reserver: at most `limit` reservations per `key` per UTC
+ * day, resetting at midnight UTC (not a rolling 24h window). A `limit` of 0
+ * or below means unlimited — the daily caps' existing contract, opposite to
+ * the sliding-window reserver above, so callers pick the primitive whose
+ * zero-semantics they documented.
+ */
+export function makeCalendarDayReserver(): (key: string, limit: number) => boolean {
+  const dailyByKey = new Map<string, { day: string; count: number }>();
+  return (key: string, limit: number): boolean => {
+    if (limit <= 0) return true;
+    const today = new Date().toISOString().slice(0, 10);
+    const entry = dailyByKey.get(key);
+    if (!entry || entry.day !== today) {
+      dailyByKey.set(key, { day: today, count: 1 });
+      return true;
+    }
+    if (entry.count >= limit) return false;
+    entry.count += 1;
+    return true;
+  };
+}
+
+/**
+ * Per-key cooldown reserver: one reservation per `key` per trailing
+ * `windowMs`, re-arming only once the full window has elapsed since the last
+ * successful reservation. Unlike the sliding-window reserver this stores a
+ * single timestamp per key, so a refused attempt never extends the cooldown.
+ */
+export function makeCooldownReserver(): (key: string, windowMs: number) => boolean {
+  const lastAtByKey = new Map<string, number>();
+  return (key: string, windowMs: number): boolean => {
+    const now = Date.now();
+    const last = lastAtByKey.get(key);
+    if (last !== undefined && now - last < windowMs) return false;
+    lastAtByKey.set(key, now);
+    return true;
+  };
+}

--- a/tests/agentWebSearchDedupEmbedFailClosed.test.ts
+++ b/tests/agentWebSearchDedupEmbedFailClosed.test.ts
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 // embedding-similarity half of the WebSearch dedup check must still fail
 // closed (deny), extending #412 AC-5 / #589's fail-closed guarantee to the
 // new code path — isDuplicateWebSearchQuery deliberately does NOT catch a
-// thrown embed() itself (see its doc comment in tools.ts), relying on the
+// thrown embed() itself (see its doc comment in webSearchGuard.ts), relying on the
 // SAME outer try/catch in core.ts's PreToolUse hook that
 // tests/agentWebSearchDedupFailClosed.test.ts already pins for a thrown
 // isDuplicateWebSearchQuery. This file exercises that same outer catch via

--- a/tests/agentWebSearchDedupEmbedShortCircuit.test.ts
+++ b/tests/agentWebSearchDedupEmbedShortCircuit.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 // discipline already proven for candidateTopicAlreadyReviewed (repository.ts,
 // issue #503 AC1, tests/knowledgeCandidateDedupDegradation.test.ts). Mocking
 // embed() to throw pins that the exact-match path structurally cannot reach
-// it. Mock BEFORE the first import of core.js/tools.js — a later
+// it. Mock BEFORE the first import of core.js/webSearchGuard.js — a later
 // t.mock.module call can't retarget an already-imported module (same trap
 // noted in tests/agentWebSearchDedupFailClosed.test.ts) — so this lives in
 // its OWN file, same split as that file / tests/agentWebSearchDedupNoLog.test.ts.

--- a/tests/agentWebSearchDedupFailClosed.test.ts
+++ b/tests/agentWebSearchDedupFailClosed.test.ts
@@ -17,8 +17,8 @@ test('SECURITY: AC-4 — a thrown error inside the WebSearch dedup check fails c
   // always throws, so this exercises buildQueryOptions's own fail-closed
   // try/catch rather than any unverifiable SDK default behaviour on a hook
   // exception.
-  const real = await import('../src/agent/tools.js');
-  t.mock.module('../src/agent/tools.js', {
+  const real = await import('../src/agent/webSearchGuard.js');
+  t.mock.module('../src/agent/webSearchGuard.js', {
     namedExports: {
       ...real,
       isDuplicateWebSearchQuery: () => {

--- a/tests/agentWebSearchRateLimitFailClosed.test.ts
+++ b/tests/agentWebSearchRateLimitFailClosed.test.ts
@@ -16,8 +16,8 @@ test('SECURITY: AC-5 — a thrown error inside the WebSearch rate-limit check fa
   // reserveWebSearchSlot, which is replaced with one that always throws, so
   // this exercises buildQueryOptions's own fail-closed try/catch rather than
   // any unverifiable SDK default behaviour on a hook exception.
-  const real = await import('../src/agent/tools.js');
-  t.mock.module('../src/agent/tools.js', {
+  const real = await import('../src/agent/webSearchGuard.js');
+  t.mock.module('../src/agent/webSearchGuard.js', {
     namedExports: {
       ...real,
       reserveWebSearchSlot: () => {

--- a/tests/rateReservation.test.ts
+++ b/tests/rateReservation.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import {
+  makeCalendarDayReserver,
+  makeCooldownReserver,
+  makeSlidingWindowReserver,
+} from '../src/util/rateReservation.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+test('SECURITY: makeSlidingWindowReserver enforces the per-key limit inside the window', () => {
+  const reserve = makeSlidingWindowReserver(HOUR_MS);
+  assert.equal(reserve('conv-1', 2), true);
+  assert.equal(reserve('conv-1', 2), true);
+  assert.equal(reserve('conv-1', 2), false, 'the third reservation inside the window is refused');
+});
+
+test('SECURITY: makeSlidingWindowReserver never refunds — a refused attempt does not consume, a successful one is never returned', () => {
+  const reserve = makeSlidingWindowReserver(HOUR_MS);
+  assert.equal(reserve('conv-1', 1), true);
+  assert.equal(reserve('conv-1', 1), false);
+  assert.equal(reserve('conv-1', 2), true, 'the refusal left only one timestamp in the window');
+  assert.equal(reserve('conv-1', 2), false, 'both successes still count against the raised limit');
+});
+
+test('makeSlidingWindowReserver: keys and factory instances are independent buckets', () => {
+  const a = makeSlidingWindowReserver(HOUR_MS);
+  const b = makeSlidingWindowReserver(HOUR_MS);
+  assert.equal(a('conv-1', 1), true);
+  assert.equal(a('conv-1', 1), false, 'conv-1 is exhausted in window a');
+  assert.equal(a('conv-2', 1), true, 'a different key has its own budget');
+  assert.equal(b('conv-1', 1), true, "window b is unaffected by window a's reservations");
+});
+
+test('makeSlidingWindowReserver: an expired window re-arms', async () => {
+  const reserve = makeSlidingWindowReserver(1);
+  assert.equal(reserve('conv-1', 1), true);
+  await sleep(25);
+  assert.equal(reserve('conv-1', 1), true, 'the old timestamp aged out of the 1ms window');
+});
+
+test('SECURITY: makeCalendarDayReserver enforces the per-key daily limit', () => {
+  const reserve = makeCalendarDayReserver();
+  assert.equal(reserve('user-1', 2), true);
+  assert.equal(reserve('user-1', 2), true);
+  assert.equal(reserve('user-1', 2), false, 'the third reservation today is refused');
+  assert.equal(reserve('user-2', 2), true, 'a different key has its own daily budget');
+});
+
+test('makeCalendarDayReserver: a limit of 0 or below means unlimited (the daily caps’ documented contract)', () => {
+  const reserve = makeCalendarDayReserver();
+  for (let i = 0; i < 50; i += 1) {
+    assert.equal(reserve('user-1', 0), true);
+    assert.equal(reserve('user-1', -1), true);
+  }
+});
+
+test('SECURITY: makeCooldownReserver refuses a second reservation inside the cooldown, and a refused attempt does not extend it', async () => {
+  const reserve = makeCooldownReserver();
+  assert.equal(reserve('caller-1', HOUR_MS), true);
+  assert.equal(reserve('caller-1', HOUR_MS), false, 'still cooling down');
+  assert.equal(reserve('caller-2', HOUR_MS), true, 'a different key has its own cooldown');
+
+  const rearm = makeCooldownReserver();
+  assert.equal(rearm('caller-1', 1), true);
+  await sleep(25);
+  assert.equal(rearm('caller-1', 1), true, 'the cooldown re-arms once the window elapses');
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -118,6 +118,7 @@
   "pipelineOutcomes.test.ts": 2,
   "projectScope.test.ts": 16,
   "rateLimitNotice.router.test.ts": 2,
+  "rateReservation.test.ts": 4,
   "rbac.test.ts": 49,
   "redeploy.test.ts": 2,
   "repeatMaxTurnsShortcutRouter.test.ts": 3,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -31,6 +31,7 @@
     "tests/noticeDebounce.test.ts",
     "tests/notifications.test.ts",
     "tests/projectScope.test.ts",
+    "tests/rateReservation.test.ts",
     "tests/sanitizeName.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
     "tests/usageCostDigest.test.ts",


### PR DESCRIPTION
## Summary

Fifth Phase 1 leaf cleanup from `docs/AGENT-BASE-PLAN.md` (the "move the WebSearch guard + rate-reservation helpers out of `tools.ts` into a base util" item), in two halves.

**WebSearch guard → `src/agent/webSearchGuard.ts`.** The whole PreToolUse guard cluster moves verbatim: the per-conversation hourly volume cap (`reserveWebSearchSlot`, now built on the shared sliding-window primitive below), the exact-then-embedding query dedup (`isDuplicateWebSearchQuery`/`recordWebSearchQuery`, with their normalize/cosine helpers and the never-logged in-memory history), and the per-conversation lock (`withWebSearchDedupLock`) that keeps check-then-record atomic. WebSearch is a built-in SDK tool gated by `core.ts`'s hook — not one of `tools.ts`'s MCP tools — so per the plan's base layout it belongs beside the turn engine. `core.ts` imports the guard directly; `tools.ts` re-exports all four names so the six existing test files' imports are unchanged. Notably, the two fail-closed `SECURITY:` tests that mock the guard to throw had to be retargeted from `tools.js` to `webSearchGuard.js`: after the move, mocking the re-exporting module no longer intercepts what `core.ts` actually calls, and both tests failed until retargeted — the fail-closed coverage is verified live against the real import edge, not assumed.

**Rate-reservation primitives → `src/util/rateReservation.ts`.** Three factories — `makeSlidingWindowReserver(windowMs)`, `makeCalendarDayReserver()`, `makeCooldownReserver()` — replace thirteen structurally identical per-cap copies in `tools.ts` (the poll/end-poll/thread/warn/announce/voice-transcription/WebSearch/human-help sliding windows, the image-gen/issue/dev-team-dispatch/image-input/reaction daily counters, and the appeal cooldown). Every exported reserver keeps its name and signature (`reserveVoiceTranscriptionSlot`, `reserveImageInputDaily`, `reserveDevTeamDispatchDaily`, `reserveWebSearchSlot`), so the three platform adapters, `core.ts`, and all existing tests are untouched. Each family's zero-limit semantics are preserved exactly and documented on the factory: daily caps treat `limit <= 0` as unlimited; sliding windows refuse at 0 (callers that want 0 = unlimited skip the call, the voice cap's existing contract). Each factory call owns a private map, so no cap can consume another's budget.

New `tests/rateReservation.test.ts` (7 tests, ratcheted into `tsconfig.tests.json`) covers per-key limit enforcement, the no-refund invariant, key/instance independence, window re-arm, and the `0 = unlimited` daily contract — the four cap-enforcement cases are `SECURITY:`-prefixed, with `tests/security-floor.json` regenerated in the same diff (158 files, 1240 total). Module map gains 🔒 entries for both new modules.

## Security / privacy impact

No semantic change to any cap or to the WebSearch guard: reserver bodies are structurally identical to the replaced copies, the guard cluster is byte-equivalent, and the dedup history still never touches the DB or logs. Two invariants are strengthened by construction: the never-refund-on-failure posture (previously restated per copy) is now documented once on the factories, and the fail-closed `SECURITY:` tests now mock the exact module `core.ts` imports, so they can't silently regress into testing a stale import edge. No change to auth, tool gating surface, outbound filtering, data access scope, or stored data.

## How verified

`npm run typecheck` clean (including `typecheck:tests`). `npm test` — 3305 tests, 2452 pass, 0 fail (853 skipped: DB-backed tests without a local `DATABASE_URL`, which skip cleanly by design). The pre-existing WebSearch dedup/rate-limit suites (`agentWebSearchDedup*.test.ts`, `agentWebSearchRateLimitFailClosed.test.ts`) and all tool-cap tests pass — the two mock-retargeted tests failed before the retarget and pass after, confirming the mocks now sit on the live import edge. `npm run test:security` — 1240 SECURITY tests ran, exact manifest match across 158 files (4 added by this PR). `npm run context:check`, `npm run format:check`, `npm run build`, and eslint on the changed files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_