### PR TITLE
Agent-base Phase 1: inject the sandbox secret-paths list into grokImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ preamble, which src/agent/changelog.ts skips, so `whats_new` never shows it
 to members. Append numbers; never remove them.
 Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 #775 #784 #804 #807 #809 #810 #812 #814 #816 #817 #818 #819 #821 #824 #825
-#868 #896 #899 #904 #949 #950 #951 #952 #953 #954
+#868 #896 #899 #904 #949 #950 #951 #952 #953 #954 #955
 -->
 
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -12,7 +12,7 @@ import {
   makeSlidingWindowReserver,
 } from '../util/rateReservation.js';
 import { isSuperAdmin, resolveRole, superAdminIds } from '../auth/roles.js';
-import { config } from '../config.js';
+import { config, onDiskSecretPaths } from '../config.js';
 import { logger, hashId } from '../logger.js';
 import { queuePendingAlert, type AlertPriority } from '../pendingAlertQueue.js';
 import { WindowClosedError } from '../platforms/types.js';
@@ -8180,7 +8180,7 @@ export function buildToolServer(
       }
       imageGenInFlight.add(key);
       try {
-        const image = await generateImage(args.prompt);
+        const image = await generateImage(args.prompt, onDiskSecretPaths());
         await adapter.sendImage(
           caller.conversationId,
           {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { config as loadEnv } from 'dotenv';
 import { z } from 'zod';
 
@@ -1580,3 +1580,20 @@ export const config = {
 } as const;
 
 export type Config = typeof config;
+
+/**
+ * Absolute paths of THIS deployment's on-disk secrets: the bot's `.env` and
+ * the WhatsApp auth dir (which may be configured relative — the default
+ * `./whatsapp-auth` — so it resolves against cwd). Injected into
+ * `media/grokImage.ts`'s kernel deny-list (issue #225's sandbox): the config
+ * module owns what counts as a secret on disk, and the image-gen client just
+ * denies whatever list it is handed — it has no knowledge of this bot's
+ * secret layout. Parameterised (with production defaults) so tests can pin
+ * the resolution rules without touching real env.
+ */
+export function onDiskSecretPaths(
+  cwd: string = process.cwd(),
+  authDir: string = config.whatsapp.authDir,
+): string[] {
+  return [join(cwd, '.env'), isAbsolute(authDir) ? authDir : join(cwd, authDir)];
+}

--- a/src/media/grokImage.ts
+++ b/src/media/grokImage.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { isAbsolute, join } from 'node:path';
+import { join } from 'node:path';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
 
@@ -80,21 +80,14 @@ export function sandboxBreached(stdout: string, token: string): boolean {
 export const SANDBOX_PROFILE = 'imagegen';
 
 /**
- * Absolute paths grok must be KERNEL-denied from reading during image gen: the
- * bot's `.env` and WhatsApp auth dir (its on-disk secrets), plus a dedicated
- * probe path the self-check uses. Derived from the bot's OWN cwd + config so
- * the deny policy travels with the deployment. `authDir` may be relative
- * (config default `./whatsapp-auth`) — resolve it against cwd.
+ * The dedicated probe path the sandbox self-check plants its token in —
+ * always appended to whatever secret-paths list the caller injects, so the
+ * self-check below always has a KNOWN deny-listed path to probe regardless
+ * of what the deployment's secrets are. Under the bot's own cwd (in
+ * ReadWritePaths). Exported so a test can pin it lands in the deny list.
  */
-export function sandboxDenyPaths(
-  cwd: string,
-  authDir: string,
-): { envPath: string; authPath: string; probePath: string } {
-  return {
-    envPath: join(cwd, '.env'),
-    authPath: isAbsolute(authDir) ? authDir : join(cwd, authDir),
-    probePath: join(cwd, '.grok-image-sandbox-probe'),
-  };
+export function sandboxProbePath(cwd: string): string {
+  return join(cwd, '.grok-image-sandbox-probe');
 }
 
 /**
@@ -139,15 +132,18 @@ ${deny}
  *     generation pays the extra grok call.
  */
 let sandboxReady: Promise<void> | null = null;
-function ensureSandboxReady(): Promise<void> {
+function ensureSandboxReady(secretPaths: readonly string[]): Promise<void> {
   if (!sandboxReady) {
     sandboxReady = (async () => {
       const home = process.env.HOME;
       if (!home) throw new Error('HOME is not set; cannot configure the grok image sandbox.');
-      const { envPath, authPath, probePath } = sandboxDenyPaths(process.cwd(), config.whatsapp.authDir);
+      // First caller's list wins for the process lifetime — same once-per-
+      // process semantics as before the list was injectable, and production
+      // has exactly one call site (generate_image in agent/tools.ts).
+      const probePath = sandboxProbePath(process.cwd());
       await writeFile(
         join(home, '.grok', 'sandbox.toml'),
-        buildSandboxToml([envPath, authPath, probePath]),
+        buildSandboxToml([...secretPaths, probePath]),
         'utf8',
       );
 
@@ -193,7 +189,8 @@ function ensureSandboxReady(): Promise<void> {
  * SECURITY POSTURE (see docs/SECURITY.md) — host-verified controls:
  *  - `--sandbox imagegen`: a custom profile (written by `ensureSandboxReady`)
  *    whose bubblewrap-enforced `deny` list KERNEL-blocks reads of the bot's
- *    secrets (`.env`, WhatsApp auth), and whose `restrict_network` blocks
+ *    secrets (the caller-injected secret-paths list — see `onDiskSecretPaths` in
+ *    `config.ts`), and whose `restrict_network` blocks
  *    child-process network (no exfil). grok REFUSES TO START if bubblewrap is
  *    missing or a deny path can't be bound, so it fails closed. Verified on the
  *    host: a read of `.env` under this profile is kernel-denied (`read_file`
@@ -222,14 +219,14 @@ function ensureSandboxReady(): Promise<void> {
  * `--output-format json`, load the image, and delete the session directory.
  * Throws on timeout, non-zero exit, or if no recognisable image is produced.
  */
-export async function generateImage(prompt: string): Promise<GeneratedImage> {
+export async function generateImage(prompt: string, secretPaths: readonly string[]): Promise<GeneratedImage> {
   const cwd = await mkdtemp(join(tmpdir(), 'grokimg-'));
   // `/imagine` is grok's image-generation skill; the prompt is its description.
   const instruction = `/imagine ${prompt}`;
   let sessionDir: string | undefined;
   try {
     // Write the deny profile + fail closed if the kernel sandbox isn't containing.
-    await ensureSandboxReady();
+    await ensureSandboxReady(secretPaths);
     const stdout = await runGrok(instruction, cwd);
     const sessionId = parseSessionId(stdout);
     if (!sessionId) throw new Error('Grok returned no session id; cannot locate the image.');
@@ -292,7 +289,7 @@ async function locateSessionImage(
  *    tool calls (e.g. shell / file write) instead of running them.
  *  - `--sandbox imagegen`: our custom profile (written by `ensureSandboxReady`),
  *    whose bubblewrap-enforced `deny` list kernel-blocks reads of the bot's
- *    secrets (`.env`, WhatsApp auth) and whose `restrict_network` blocks
+ *    secrets (the caller-injected secret-paths list) and whose `restrict_network` blocks
  *    child-process network. Verified on the host that a read of `.env` is
  *    kernel-denied while `/imagine` still generates. (The built-in `strict`
  *    profile's landlock read-restriction does NOT actually block reads here — so

--- a/tests/grokImage.test.ts
+++ b/tests/grokImage.test.ts
@@ -14,9 +14,10 @@ const {
   grokEnv,
   sandboxBreached,
   SANDBOX_PROFILE,
-  sandboxDenyPaths,
+  sandboxProbePath,
   buildSandboxToml,
 } = await import('../src/media/grokImage.js');
+const { onDiskSecretPaths } = await import('../src/config.js');
 
 test('sniffImageType detects JPEG / PNG / WebP from magic bytes', () => {
   assert.deepEqual(sniffImageType(Buffer.from([0xff, 0xd8, 0xff, 0xe0])), {
@@ -62,7 +63,11 @@ test('SECURITY: buildGrokArgs runs grok under the custom deny sandbox, no --alwa
 test('SECURITY: the sandbox deny profile kernel-denies the bot secrets + resolves a relative auth dir', () => {
   // Platform-agnostic (prod is Linux; `join`/`isAbsolute` differ on Windows).
   const cwd = process.platform === 'win32' ? 'C:\\app' : '/opt/community-agent';
-  const { envPath, authPath, probePath } = sandboxDenyPaths(cwd, './whatsapp-auth');
+  // The secret-paths list is composed by config.ts (the module that owns the
+  // deployment's secret layout) and INJECTED into grokImage — the image-gen
+  // client itself no longer knows what this bot's secrets are.
+  const [envPath, authPath] = onDiskSecretPaths(cwd, './whatsapp-auth');
+  const probePath = sandboxProbePath(cwd);
   // The bot's .env and a dedicated probe path, both under the bot's cwd.
   assert.ok(envPath.startsWith(cwd) && envPath.endsWith('.env'), "the bot's .env must be a deny target");
   assert.ok(probePath.startsWith(cwd) && probePath.endsWith('.grok-image-sandbox-probe'));
@@ -72,9 +77,9 @@ test('SECURITY: the sandbox deny profile kernel-denies the bot secrets + resolve
     'a relative auth dir resolves against cwd',
   );
   const abs = process.platform === 'win32' ? 'C:\\wa' : '/var/wa';
-  assert.equal(sandboxDenyPaths(cwd, abs).authPath, abs, 'an absolute auth dir is used as-is');
+  assert.equal(onDiskSecretPaths(cwd, abs)[1], abs, 'an absolute auth dir is used as-is');
 
-  const toml = buildSandboxToml([envPath, authPath, probePath]);
+  const toml = buildSandboxToml([...onDiskSecretPaths(cwd, './whatsapp-auth'), probePath]);
   assert.match(toml, /\[profiles\.imagegen\]/);
   assert.match(toml, /restrict_network = true/);
   assert.match(toml, /deny = \[/);


### PR DESCRIPTION
## Summary

Seventh and final Phase 1 leaf cleanup from `docs/AGENT-BASE-PLAN.md` (the "fix `grokImage.ts` to take an injected secret-paths list" item). The image-gen client's kernel deny-list was composed inside `grokImage.ts` from `config.whatsapp.authDir` — hardcoding this deployment's secret layout (`.env` + WhatsApp auth dir) into a module the base extraction wants generic.

The seam is now inverted: `generateImage(prompt, secretPaths)` (and `ensureSandboxReady` behind it) take the list as a **required** parameter, and the composition moves to `config.ts` as `onDiskSecretPaths(cwd?, authDir?)` — the module that owns the deployment layout, parameterised with production defaults so tests can pin the resolution rules (relative auth dir resolves against cwd, absolute used as-is) without touching real env. The old `sandboxDenyPaths` helper is deleted; the sandbox self-check's probe path stays `grokImage`-internal (exported as `sandboxProbePath`) and is always appended to whatever list is injected, so the fail-closed probe works regardless of what the deployment's secrets are. The `generate_image` tool passes `onDiskSecretPaths()` at its single call site.

## Security / privacy impact

Behaviour identical, verified through the existing pins: the deny profile written to `~/.grok/sandbox.toml` contains exactly the same three paths as before (`cwd/.env`, resolved auth dir, probe path), the once-per-process self-check semantics are unchanged (first caller's list wins — documented, and production has one call site), and none of the other sandbox controls (`grokEnv` allowlist, no `--always-approve`, `--sandbox imagegen` argv, fail-closed probe) are touched. The `SECURITY:` deny-profile test now pins the same invariants through the new seam — composition in `config.ts`, probe appended, every path present in the TOML deny list — and the `grokEnv`/argv/probe `SECURITY:` tests are unchanged. Test counts are identical, so `tests/security-floor.json` is untouched. The one structural change is an improvement for the base split: the image-gen client can no longer silently know about (or drift from) this bot's secret layout — it denies exactly what the config module hands it.

## How verified

`npm run typecheck` clean (including `typecheck:tests`). `npm test` — 3305 tests, 2452 pass, 0 fail, identical counts to before the change (853 skipped: DB-backed tests without a local `DATABASE_URL`, which skip cleanly by design). The reworked deny-profile test plus the untouched `grokImage` suite (magic-byte sniffing, argv pins, env allowlist, breach detection) and the `generate_image` caption/handler tests all pass. `npm run test:security` — 1240 SECURITY tests ran, exact manifest match across 158 files (none added/removed). `npm run context:check`, `npm run format:check`, `npm run build`, and eslint on the changed files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_