### PR TITLE
Fix startup: bind the Discord slash commands after createAgent, not at import time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ preamble, which src/module/agent/changelog.ts skips, so `whats_new` never
 shows it to members. Append numbers; never remove them.
 Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 #775 #784 #804 #807 #809 #810 #812 #814 #816 #817 #818 #819 #821 #824 #825
-#868 #896 #899 #904 #949 #950 #951 #952 #953 #954 #955 #956 #957 #958
+#868 #896 #899 #904 #949 #950 #951 #952 #953 #954 #955 #956 #957 #958 #961
 -->
 
 

--- a/src/module/commands.ts
+++ b/src/module/commands.ts
@@ -13,10 +13,15 @@ import { TEXT_COMMAND_UNMATCHED, type RegisteredCommand } from '@swampratnz/agen
  * projects, whois, guidelines, digest), which is also safe for the WhatsApp
  * side because every `!` matcher is anchored and mutually exclusive.
  *
- * The Discord halves are BOUND at the Discord adapter's module-load time
- * (`bindDiscordCommand`, called from slashCommands.ts) rather than defined
- * inline, so this file — loaded by the composition root on every platform —
- * never pulls discord.js into the runtime graph; only its types.
+ * The Discord halves are BOUND by `bindCommunitySlashCommands()`
+ * (slashCommands.ts), which `createConfiguredAdapters()` calls — never at
+ * module load, because binding reads the command list and `createAgent`
+ * registers that list from the manifest only when index.ts's BODY runs, long
+ * after the static import graph has been evaluated. Binding at load threw
+ * `registeredCommands: no command list registered` and killed startup.
+ * Defining them there rather than inline also keeps this file — loaded by the
+ * composition root on every platform — from pulling discord.js into the
+ * runtime graph; only its types.
  *
  * Since the mechanism/content split (plan §Phase-2 Stage 3a) the sentinel,
  * the handler/binding/command types and the registration slot live in

--- a/src/module/platforms/discord/slashCommands.ts
+++ b/src/module/platforms/discord/slashCommands.ts
@@ -27,9 +27,6 @@ import {
 } from '../../agent/tools.js';
 import { chunkText } from '@swampratnz/agent-base/platforms/textChunk.js';
 import { bindDiscordCommand, type SlashCommandDeps } from '@swampratnz/agent-base/commands/registry.js';
-// Importing the community command list runs its self-registration
-// (registerCommands) before the module-scope bindDiscordCommand calls below.
-import '../../commands.js';
 
 /**
  * Discord caps a message (and an interaction reply/follow-up) at 2000 chars —
@@ -265,70 +262,86 @@ async function handleDigest(interaction: ChatInputCommandInteraction, deps: Slas
   await replyEphemeral(interaction, message ?? 'Nothing to report right now.', deps);
 }
 
-// Bind each registry entry's Discord half (registration JSON + handler) at
-// module load — handlers above are hoisted function declarations, so every
-// binding is complete before buildSlashCommands()/handleInteraction() can be
-// called. Builders are byte-identical to the array buildSlashCommands()
-// previously constructed inline.
-bindDiscordCommand('kb', {
-  build: () =>
-    new SlashCommandBuilder()
-      .setName('kb')
-      .setDescription('Search curated community knowledge (FAQs, rules, resources).')
-      .addStringOption((o) => o.setName('query').setDescription('Topic to look up').setRequired(true))
-      .toJSON(),
-  handle: handleKb,
-});
-bindDiscordCommand('projects', {
-  build: () =>
-    new SlashCommandBuilder()
-      .setName('projects')
-      .setDescription('Browse the member-declared project showcase.')
-      .addStringOption((o) =>
-        o.setName('query').setDescription('Optional topic/keyword to search by meaning').setRequired(false),
-      )
-      .addBooleanOption((o) =>
-        o
-          .setName('seeking_collaborators')
-          .setDescription('Only show projects whose owner is looking for collaborators')
-          .setRequired(false),
-      )
-      .addBooleanOption((o) =>
-        o
-          .setName('mine')
-          .setDescription('Only show your own shared projects — ignores query/seeking_collaborators')
-          .setRequired(false),
-      )
-      .toJSON(),
-  handle: handleProjects,
-});
-bindDiscordCommand('whois', {
-  build: () =>
-    new SlashCommandBuilder()
-      .setName('whois')
-      .setDescription('Find members whose published interests match a topic.')
-      .addStringOption((o) =>
-        o
-          .setName('query')
-          .setDescription('Optional topic/keyword; omit to find members like you')
-          .setRequired(false),
-      )
-      .toJSON(),
-  handle: handleWhois,
-});
-bindDiscordCommand('guidelines', {
-  build: () =>
-    new SlashCommandBuilder()
-      .setName('guidelines')
-      .setDescription("Show this community's guidelines/rules.")
-      .toJSON(),
-  handle: handleGuidelines,
-});
-bindDiscordCommand('digest', {
-  build: () =>
-    new SlashCommandBuilder()
-      .setName('digest')
-      .setDescription("Pull this week's community digest on demand — topics, new knowledge, projects.")
-      .toJSON(),
-  handle: handleDigest,
-});
+/**
+ * Bind each registry entry's Discord half (registration JSON + handler).
+ *
+ * Called from `createConfiguredAdapters()`, NOT at module scope. Binding
+ * reads the command list, and under `createAgent` that list is registered
+ * during the singleton-registration phase — which runs when `index.ts`'s BODY
+ * calls `createAgent`, long after this module has been evaluated as part of
+ * its static import graph. Binding at module load therefore always ran before
+ * registration and threw `registeredCommands: no command list registered`,
+ * killing the process at startup. (Under the old side-effect composition
+ * `index.ts` imported the commands module early and the order happened to
+ * work; the flip to `createAgent` inverted it.)
+ *
+ * Idempotent: `bindDiscordCommand` rejects a duplicate name, and tests build
+ * adapters more than once per process.
+ */
+let bound = false;
+export function bindCommunitySlashCommands(): void {
+  if (bound) return;
+  bound = true;
+  bindDiscordCommand('kb', {
+    build: () =>
+      new SlashCommandBuilder()
+        .setName('kb')
+        .setDescription('Search curated community knowledge (FAQs, rules, resources).')
+        .addStringOption((o) => o.setName('query').setDescription('Topic to look up').setRequired(true))
+        .toJSON(),
+    handle: handleKb,
+  });
+  bindDiscordCommand('projects', {
+    build: () =>
+      new SlashCommandBuilder()
+        .setName('projects')
+        .setDescription('Browse the member-declared project showcase.')
+        .addStringOption((o) =>
+          o.setName('query').setDescription('Optional topic/keyword to search by meaning').setRequired(false),
+        )
+        .addBooleanOption((o) =>
+          o
+            .setName('seeking_collaborators')
+            .setDescription('Only show projects whose owner is looking for collaborators')
+            .setRequired(false),
+        )
+        .addBooleanOption((o) =>
+          o
+            .setName('mine')
+            .setDescription('Only show your own shared projects — ignores query/seeking_collaborators')
+            .setRequired(false),
+        )
+        .toJSON(),
+    handle: handleProjects,
+  });
+  bindDiscordCommand('whois', {
+    build: () =>
+      new SlashCommandBuilder()
+        .setName('whois')
+        .setDescription('Find members whose published interests match a topic.')
+        .addStringOption((o) =>
+          o
+            .setName('query')
+            .setDescription('Optional topic/keyword; omit to find members like you')
+            .setRequired(false),
+        )
+        .toJSON(),
+    handle: handleWhois,
+  });
+  bindDiscordCommand('guidelines', {
+    build: () =>
+      new SlashCommandBuilder()
+        .setName('guidelines')
+        .setDescription("Show this community's guidelines/rules.")
+        .toJSON(),
+    handle: handleGuidelines,
+  });
+  bindDiscordCommand('digest', {
+    build: () =>
+      new SlashCommandBuilder()
+        .setName('digest')
+        .setDescription("Pull this week's community digest on demand — topics, new knowledge, projects.")
+        .toJSON(),
+    handle: handleDigest,
+  });
+}

--- a/src/module/platforms/factories.ts
+++ b/src/module/platforms/factories.ts
@@ -16,12 +16,13 @@ import {
   WHATSAPP_CLOUD_TOOL_CAPABILITIES,
 } from '@swampratnz/agent-base/platforms/whatsapp/cloudAdapter.js';
 import { BAILEYS_TEXT_PACK, DISCORD_TEXT_PACK, WHATSAPP_CLOUD_TEXT_PACK } from './textPacks.js';
-// Binds the community slash commands' Discord halves onto their registry
-// entries at module scope. The Discord adapter drives registration/dispatch
-// through the base mechanism (`discord/slashDispatch.ts`) and so no longer
-// imports the commands themselves — this composition file is where they are
-// pulled into the graph, before any adapter it builds can be started.
-import './discord/slashCommands.js';
+// The Discord adapter drives registration/dispatch through the base mechanism
+// (`discord/slashDispatch.ts`) and so no longer imports the commands itself.
+// Binding is CALLED below, from createConfiguredAdapters — never done at
+// module scope, because binding reads the command list and `createAgent`
+// registers that list from the manifest well after this module has been
+// evaluated as part of index.ts's static import graph.
+import { bindCommunitySlashCommands } from './discord/slashCommands.js';
 
 /**
  * The adapter factory registrations (agent-base plan item 9, §3 `adapters`
@@ -85,6 +86,12 @@ export const ADAPTER_FACTORIES: readonly AdapterFactory[] = [
  * the wrong key would otherwise corrupt the router's per-platform lookup.
  */
 export function createConfiguredAdapters(): PlatformAdapter[] {
+  // Bind the slash commands' Discord halves before any adapter exists to
+  // dispatch them. This is the earliest point that is guaranteed to be AFTER
+  // createAgent registered the command list — index.ts calls createAgent, then
+  // this. Doing it at module scope instead threw at startup, because static
+  // imports are evaluated before index.ts's body runs at all.
+  bindCommunitySlashCommands();
   const adapters: PlatformAdapter[] = [];
   for (const factory of ADAPTER_FACTORIES) {
     if (!descriptorFor(factory.platform)) {

--- a/tests/discordSlashCommands.test.ts
+++ b/tests/discordSlashCommands.test.ts
@@ -28,10 +28,13 @@ const { pool } = await import('@swampratnz/agent-base/storage/db.js');
 const { resetPolicyCacheForTests } = await import('@swampratnz/agent-base/storage/policyStore.js');
 // The registration/dispatch mechanism is base (slashDispatch.ts): the command
 // list must be registered (the manifest's `commands` field in production)
-// before slashCommands.ts binds its Discord halves onto the registry at its
-// own module scope.
+// before the Discord halves are bound onto the registry entries. Binding is
+// an explicit call, not a module-scope side effect — in production
+// createConfiguredAdapters() makes it, after createAgent has registered the
+// list; here this file makes it, in the same order.
 await import('./support/registerCommands.js');
-await import('../src/module/platforms/discord/slashCommands.js');
+const { bindCommunitySlashCommands } = await import('../src/module/platforms/discord/slashCommands.js');
+bindCommunitySlashCommands();
 const { handleInteraction, buildSlashCommands, registerSlashCommands } =
   await import('@swampratnz/agent-base/platforms/discord/slashDispatch.js');
 const { buildMemberDigestContent } = await import('../src/module/memberDigest.js');

--- a/tests/platformRegistry.test.ts
+++ b/tests/platformRegistry.test.ts
@@ -29,9 +29,11 @@ process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
 process.env.WHATSAPP_PROVIDER = 'baileys';
 
 const { closeDb } = await import('@swampratnz/agent-base/storage/db.js');
-// factories.ts builds the Discord adapter, whose slash-command module binds
-// onto the command registry at import time — so the command list has to be
-// registered first (the manifest's `commands` field in production).
+// createConfiguredAdapters() binds the slash commands onto the registry as
+// its first act (bindCommunitySlashCommands), so the command list has to be
+// registered before this file calls it — the manifest's `commands` field in
+// production. Nothing binds at import time any more: that ordering could not
+// hold under createAgent and was the startup crash #961 fixed.
 await import('./support/registerCommands.js');
 await import('./support/registerToolRegistry.js');
 const { TOOL_REGISTRY } = await import('../src/module/agent/tools/index.js');


### PR DESCRIPTION
## The bot on `main` does not start

```
Error: registeredCommands: no command list registered — import the community
commands module (src/module/commands.ts) before using a command surface
    at bindDiscordCommand (agent-base/dist/commands/registry.js:47)
    at dist/module/platforms/discord/slashCommands.js:212
```

The process dies during module evaluation, before `main()` runs.

## Why

`slashCommands.ts` called `bindDiscordCommand(...)` at **module scope**. Binding reads the command list — and since #960, that list is registered from the manifest by `createAgent`, during its singleton-registration phase.

`index.ts` statically imports `./module/platforms/factories.js` (line 15), which imported `slashCommands.js`. ES modules evaluate the whole static graph **before** the importing module's body runs, and `createAgent` is called from that body (line 47). So binding preceded registration, always, on every start.

Under the pre-#960 side-effect composition, `index.ts` imported the commands module early and the ordering happened to work. The flip to `createAgent` inverted it. The `import '../../commands.js'` line in `slashCommands.ts` was there to guarantee exactly this ordering, and silently stopped doing so when registration moved out of that module into the manifest — it is now removed rather than left as a false comfort.

`factories.ts`'s own comment shows where the reasoning went wrong: *"before any adapter it builds can be started"*. True, but binding happened at **import**, not at start.

## The fix

The binds move into an exported, idempotent `bindCommunitySlashCommands()`, called at the top of `createConfiguredAdapters()`. That is the earliest point guaranteed to be after `createAgent` has registered the list, and still before any adapter exists to dispatch a command. Idempotent because `bindDiscordCommand` rejects duplicate names and tests build adapters more than once per process.

## Verified by starting the built app

Before — dead on line one. After:

```
Starting Community Agent
Claude subscription auth configured (CLAUDE_CODE_OAUTH_TOKEN)
Database reachable, embedding dimension verified
WhatsApp provider disabled
Applying database schema   (embeddingDim: 384, moduleFragments: 1)
Database schema applied
→ DiscordAdapter.start → DiscordjsError [TokenInvalid]
```

It reaches Discord login and fails only on the deliberately-fake token — the correct stopping point without real credentials. That exercises composition, the module's migration contribution, adapter construction and adapter start.

Also verified on merged `main` beforehand: clean `npm ci`, `migrate` with only `DATABASE_URL` (39 tables, including `language_prefs`, `projects`, `dev_team_watches`, `community_users`), and `build`.

## What this says about the gates

**2,830 tests, every local gate, and a full green CI run all passed on a tree that could not start.** Nothing in the suite boots the built application: the tests exercise composition through fixtures and `planComposition`, which validates that registrations are *complete*, not that they happen in a workable *order* relative to module evaluation.

A smoke test that runs `dist/index.js` far enough to hit adapter login would have caught this in seconds, and would catch the whole class. Worth adding — I have not bundled it here, since this PR should stay the minimal fix for a broken `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_