### PR TITLE
Repair three pipeline workflows broken by a misindented env block

### DIFF
--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -178,11 +178,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
           # migrate loads config.ts which requires this; migrate never calls
           # Claude, so a dummy satisfies the schema (see pipeline-build.yml).
           CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
@@ -200,11 +200,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # This workflow fires on workflow_run of a CI run whose actor is the

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -354,11 +354,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
           # migrate loads config.ts which requires this; migrate never calls
           # Claude, so a dummy satisfies the schema (see pipeline-build.yml).
           CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
@@ -395,11 +395,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
         run: |
           set -uo pipefail
           git config user.name 'github-actions[bot]'
@@ -463,11 +463,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'
@@ -504,11 +504,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The dispatched run's actor is github-actions[bot] (discover created

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -229,11 +229,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
           # migrate loads config.ts which requires this; migrate never calls
           # Claude, so a dummy satisfies the schema (see pipeline-build.yml).
           CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token
@@ -251,11 +251,11 @@ jobs:
           DISCORD_BOT_TOKEN: ci-dummy-token
           DISCORD_GUILD_ID: ci-dummy-guild
           WHATSAPP_PROVIDER: disabled
-      # This deployment renders member-facing times in NZ local time; the
-      # framework package defaults them to UTC/en-GB and the module manifest's
-      # init() refuses to boot on anything else (see .env.example).
-      DISPLAY_TIMEZONE: Pacific/Auckland
-      DISPLAY_LOCALE: en-NZ
+          # This deployment renders member-facing times in NZ local time; the
+          # framework package defaults them to UTC/en-GB and the module manifest's
+          # init() refuses to boot on anything else (see .env.example).
+          DISPLAY_TIMEZONE: Pacific/Auckland
+          DISPLAY_LOCALE: en-NZ
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The dispatched run's actor is github-actions[bot] (the review


### PR DESCRIPTION
**Three pipeline workflows have failed to start on every push for days.** `pipeline-pr-autofix.yml`, `pipeline-pr-conflict.yml` and `pipeline-pr-revise.yml` are not valid YAML:

```yaml
          WHATSAPP_PROVIDER: disabled
      # This deployment renders member-facing times in NZ local time; the      ← 6
      # framework package defaults them to UTC/en-GB and the module manifest's ← 6
      # init() refuses to boot on anything else (see .env.example).            ← 6
      DISPLAY_TIMEZONE: Pacific/Auckland                                       ← 6
      DISPLAY_LOCALE: en-NZ                                                    ← 6
          # migrate loads config.ts which requires this; migrate never calls   ← 10
          CLAUDE_CODE_OAUTH_TOKEN: ci-dummy-token                              ← 10
```

When `DISPLAY_TIMEZONE`/`DISPLAY_LOCALE` were added to the CI env blocks, the inserted block — three comment lines and both keys — landed at 6 spaces inside `env:` maps whose keys sit at 10. Eight occurrences across the three files.

## Why nothing noticed

- **Workflows are covered by no gate.** `lint`, `format:check` and the test suite do not parse `.github/workflows/`, and there is no YAML parser in the dependency tree — not even transitively.
- **A startup failure produces a run with zero jobs.** There is no failing step to open and no log beyond the parse error, so it does not look like a normal red check.
- **The pipeline is currently switched off**, so no loop was actually missed.
- The runs are there if you look: **8 of the last 8** `pipeline-pr-conflict` runs failed, on every branch including `main`, going back to 08-03.

The tell that something was structurally wrong: those runs fired on pushes to *feature branches*, though the workflow's `on:` restricts push to `[main]`. GitHub could not parse the file well enough to evaluate its own triggers.

## The fix

Whitespace only — the block moves to its siblings' indent in all eight places. No logic, no step, no permission changes.

## Verified

- Every one of the **15** workflow files in the directory parses (all 15 checked, not just the three).
- The three fixed files were loaded and asserted to expose `DISPLAY_TIMEZONE`/`DISPLAY_LOCALE` as real `env:` entries on the steps that need them — parsing alone would not prove they landed in the right map:

```
pipeline-pr-autofix:  Migrate base schema…, Fix the failing checks
pipeline-pr-conflict: Migrate base schema…, Fast-path resolve…, Fast-path verify…, Resolve the merge conflict
pipeline-pr-revise:   Migrate base schema…, Address the requested changes
```

## Worth deciding separately: a guard

This class of defect is invisible to every gate here. Options, roughly in order of value:

1. **`actionlint`** as a CI step — catches invalid YAML *plus* bad `if:` expressions, unknown contexts and shellcheck issues in `run:` blocks. Industry standard for exactly this. Costs a third-party action (this repo pins actions by SHA, so that convention would apply).
2. **A `scripts/check-workflows.mjs` gate** parsing every workflow — needs a YAML devDependency (`js-yaml`), which this lean 25-dependency tree currently avoids.
3. Nothing, and rely on watching Actions.

I have not bundled any of them: adding a third-party action or a dependency to a security-conscious pipeline is an owner's call, not something to slip into a repair PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_