### PR TITLE
Cite #960 on the framework-split changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 
 ### Changed
 - **Under the hood: the framework half is now a separate, reusable package**
-  and this repo installs it like any other dependency. Nothing you can see has
+  (#960) and this repo installs it like any other dependency. Nothing you can see has
   changed — same tools, same replies, same wording, same permissions. The
   agent turn engine, the Discord and WhatsApp adapters, memory and storage,
   the router's security checks and the roles system all moved out to
@@ -43,7 +43,7 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
   timezone and locale used to render event times (still New Zealand's), which
   the bot now refuses to start without.
 - **Under the hood: the code is now split into a reusable agent framework and
-  this community's own content** (#959, #960). Nothing you can see has changed —
+  this community's own content** (#959). Nothing you can see has changed —
   same tools, same replies, same wording, same permissions. What moved is
   where the code lives: one half is now the community-agnostic framework (the
   agent turn engine, the Discord and WhatsApp adapters, memory and storage,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
   timezone and locale used to render event times (still New Zealand's), which
   the bot now refuses to start without.
 - **Under the hood: the code is now split into a reusable agent framework and
-  this community's own content** (#959). Nothing you can see has changed —
+  this community's own content** (#959, #960). Nothing you can see has changed —
   same tools, same replies, same wording, same permissions. What moved is
   where the code lives: one half is now the community-agnostic framework (the
   agent turn engine, the Discord and WhatsApp adapters, memory and storage,


### PR DESCRIPTION
The changelog-coverage issue (#931) flags **#960** — the dependency flip — as merged without a `CHANGELOG.md` entry and without a skip-ledger number.

It is the second half of the change #959's entry already describes: #959 split the code into framework and community halves, #960 made the framework an actual npm dependency. Both are invisible to members in exactly the same way, so a second entry would describe the same non-event twice. Citing it on the existing entry is accurate and clears the check.

One-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkgg61b9V5K1tDwE6t6kUs)_