### PR TITLE
Realign VISION and the auto-merge governance list with the agent-base split

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -187,6 +187,32 @@ jobs:
             # — those are per-PR DATA nearly every PR touches; excluding them
             # would merge nothing. This list is the files that change the RULES.)
             #
+            # Three entries are here because of the agent-base split, not CI:
+            #   - src/module/agentModule.ts is THE manifest. Every extension
+            #     point this deployment registers passes through it — tool
+            #     tiers, feature-flag predicates, skills. Before the split the
+            #     same authority was spread across rbac.ts arrays and a
+            #     megaclosure; concentrating it in one file made that file a
+            #     rules file, so it is governed like one. Measured cost: it
+            #     appears in 8% of the last 40 merges, so governing it is
+            #     nearly free.
+            #
+            #     DELIBERATELY NOT src/module/agent/tools/index.ts, which
+            #     defines COMMUNITY_TOOL_TIERS. It is the more dangerous file
+            #     (a one-word 'admin' -> 'member' widens the privileged surface
+            #     while typechecking), but every new tool must register a tier
+            #     there: it appears in 62% of the last 40 merges, so governing
+            #     it would send most feature work to a human press and gut the
+            #     auto-merge loop. It is covered instead by the tier-map
+            #     snapshot in tests/toolTierMap.test.ts, which no tier change
+            #     can pass without editing the expected map in the same PR —
+            #     turning a silent widening into a reviewable diff at zero
+            #     throughput cost.
+            #   - docs/VISION.md is the rubric the research loop proposes
+            #     against and the adversarial loop judges against. Editing it
+            #     changes what the pipeline will build next, which is exactly
+            #     the "rewrite its own guardrails" risk this list exists for.
+            #
             # A governance hit does NOT stop evaluation, only the merge: the
             # pipeline's own acceptance criteria make most feature PRs document
             # themselves in docs/SECURITY.md, so a silent skip here stranded
@@ -196,7 +222,7 @@ jobs:
             # merge it requires actually gets requested.
             files="$(gh pr view "$n" --repo "$REPO" --json files --jq '.files[].path')"
             governance_hit='false'
-            if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/SECURITY\.md$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
+            if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/SECURITY\.md$|docs/VISION\.md$|src/module/agentModule\.ts$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
               governance_hit='true'
               echo "PR #$n: touches a governance/CI/config path (workflows, check machinery, or governance docs) — will never auto-merge; still evaluating for the human-merge-ready escalation."
             fi

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -135,9 +135,19 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   `no-auto-resolve`). Crucially, it **routes any PR touching a governance/CI/
   config path to a human merge** — `.github/**` (workflows/CI, including this
   loop itself), `scripts/**` (the check machinery), `package.json`,
-  typecheck/lint/format config, and the `CLAUDE.md`/`docs/PIPELINE.md`/
-  `docs/SECURITY.md` governance docs — so the pipeline can never auto-merge a
-  change to its own guardrails or to what "green" means (and since
+  typecheck/lint/format config, the `CLAUDE.md`/`docs/PIPELINE.md`/
+  `docs/SECURITY.md`/`docs/VISION.md` governance docs, and
+  `src/module/agentModule.ts` — THE manifest the agent-base split turned into a
+  rules file, since every extension point this deployment registers passes
+  through it — so the pipeline can never auto-merge a
+  change to its own guardrails or to what "green" means. (`docs/VISION.md` is
+  on the list because it is the rubric research proposes against and
+  adversarial judges by: editing it changes what the pipeline builds next.
+  `src/module/agent/tools/index.ts`, which defines the tier map, is
+  deliberately **not** — every new tool registers a tier there, so it appears
+  in 62% of recent merges and governing it would gut auto-merge; the tier-map
+  snapshot in `tests/toolTierMap.test.ts` covers it instead, at no throughput
+  cost.) (and since
   `pull_request` CI runs the workflow version from the PR branch, a PR could
   otherwise weaken a check and still show it "passing"). Because the pipeline's
   own acceptance criteria make most feature PRs document themselves in

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -4,6 +4,38 @@ The shared north star for the pipeline. The **research** worker generates
 proposals against this; the **adversarial** worker judges them against the same
 bar. Tune quality by editing this file, not the loop prompts.
 
+## Where this repo ends
+
+This repo is a **module on a framework**, not the whole agent. The framework is
+[`@swampratnz/agent-base`](https://github.com/swampratnz/agent-base), consumed
+as an npm package; this repo is `src/module/` plus the composition root, and
+`src/module/agentModule.ts` is the manifest that registers everything it
+contributes.
+
+That boundary decides what is proposable here, because **the build worker can
+only edit this repo**. A proposal needing a base change cannot be built no
+matter how good it is — it has to land in agent-base first and arrive as a
+version bump.
+
+Roughly:
+
+- **This repo** — tools and their tiers, community prompt sections and persona,
+  notice/string packs (including te reo), skills, module schema fragments,
+  community jobs and digests, moderation *policy*, ingest sources and topics.
+- **agent-base** — the turn engine and prompt spine, the router's security
+  sequence, CONFIRM and outbound filtering, RBAC mechanism, platform adapters,
+  storage/migration machinery, the job runner, retention and budgets, health,
+  and the config schema itself (so **a new env var is an agent-base change**).
+
+Two consequences worth internalising before proposing:
+
+- Some theme areas below are now mostly base-owned — **Reliability & ops** and
+  **Cost efficiency** especially, and parts of **Accessibility & inclusion**
+  (base selects the language/style axis; this repo supplies the strings). Prefer
+  the module-side half of those themes, or pick another theme.
+- "Make the bot do X" is usually module work. "Make the *framework* do X" is
+  not proposable here, however desirable.
+
 ## Mission
 
 Make the **NZ Claude Community** more valuable to its members and lower-effort
@@ -100,11 +132,21 @@ Each research run is memoryless, so deliberately vary across:
 - **Moderation & safety** — lighter, safer admin workflows; abuse handling.
 - **Admin insight** — analytics, digests, what the community is asking about.
 - **Reliability & ops** — resilience, observability, graceful degradation.
+  *Mostly agent-base-owned; only the module-side half is proposable here.*
 - **Cost efficiency** — doing more within the subscription's usage limits.
+  *The turn engine and shortcuts are agent-base; module-side levers are job
+  cadence, digest scope and prompt-section size.*
 - **Accessibility & inclusion** — clarity, language, reachability.
 
 ## Guardrails — do NOT propose
 
+- **Anything requiring an `@swampratnz/agent-base` change** — a new or changed
+  env var, or behaviour owned by the turn engine, router security sequence,
+  CONFIRM/outbound filtering, adapters, storage/migration machinery, the job
+  runner, retention/budgets or health. The build worker cannot edit the
+  framework, so such a proposal is unbuildable here however strong it is; it
+  belongs in the agent-base repo. See "Where this repo ends" above. If the
+  module-side half is independently valuable, propose only that half.
 - **Rewrites** or sweeping refactors; anything not shippable in ~one PR.
 - Features that **expand the attack surface** (new privileged tools, broader
   data access, new untrusted inputs) without a clear, proportionate payoff.

--- a/tests/dumpToolTiers.ts
+++ b/tests/dumpToolTiers.ts
@@ -1,0 +1,13 @@
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+const { COMMUNITY_TOOL_TIERS } = await import('./../src/module/agent/tools/index.js');
+const strip = (t: string) => t.replace('mcp__community__', '');
+for (const key of ['member', 'admin', 'superAdmin', 'discordOnly'] as const) {
+  const list = [...COMMUNITY_TOOL_TIERS[key]].map(strip).sort();
+  console.log(`  ${key}: [`);
+  for (const t of list) console.log(`    '${t}',`);
+  console.log(`  ],`);
+}

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -132,6 +132,7 @@
   "systemPrompt.test.ts": 21,
   "systemPromptSlots.test.ts": 5,
   "toolRegistry.test.ts": 4,
+  "toolTierMap.test.ts": 2,
   "tools.test.ts": 302,
   "unhelpfulAnswerEscalationRouter.test.ts": 2,
   "usageAlertPendingQueue.test.ts": 3,

--- a/tests/toolTierMap.test.ts
+++ b/tests/toolTierMap.test.ts
@@ -1,0 +1,203 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The tier map, pinned exactly (issue: post-agent-base-split governance).
+//
+// WHY THIS FILE EXISTS, and why it is a snapshot rather than a property test:
+//
+// `src/module/agent/tools/index.ts` decides which tier may call which tool. A
+// one-word edit there — 'admin' -> 'member' on a single entry — widens the
+// privileged surface, and it typechecks, and it passes every other test in the
+// suite. The existing SECURITY: cases in tests/agentOptions.test.ts assert
+// CONSISTENCY ("allowedTools tracks toolsForRole exactly, no drift"), which a
+// tier move preserves: both sides move together and agree. Per-tool guards
+// exist only for tools someone happened to write a case for.
+//
+// The obvious alternative was to route the file to a mandatory human merge via
+// the auto-merge governance list. Measured against the last 40 merges, that
+// file appears in 62% of them (every new tool must register a tier), versus 8%
+// for the manifest — governing it would have sent most feature work to a human
+// press and gutted the auto-merge loop. This snapshot buys the same protection
+// at zero throughput cost: a tier change cannot pass CI without editing the
+// expected map in the SAME PR, so a silent widening becomes a reviewable diff
+// that the PR-review loop, the adversarial pass and a human all see.
+//
+// MAINTENANCE: adding a tool means adding one line here. That is the intended
+// friction, not an accident — the diff is the audit trail. Regenerate with
+// `npx tsx tests/dumpToolTiers.ts` if the list drifts wholesale.
+process.env.CLAUDE_CODE_OAUTH_TOKEN ??= 'test-token';
+process.env.DISCORD_BOT_TOKEN ??= 'test-token';
+process.env.DISCORD_GUILD_ID ??= '1';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+process.env.WHATSAPP_PROVIDER ??= 'disabled';
+
+const { COMMUNITY_TOOL_TIERS } = await import('../src/module/agent/tools/index.js');
+
+/** Authored tier registration, prefixes stripped, sorted. */
+const EXPECTED: Record<string, readonly string[]> = {
+  member: [
+    'appeal_moderation',
+    'catch_up',
+    'check_status',
+    'community_digest',
+    'community_guidelines',
+    'community_info',
+    'find_helper',
+    'forget_me',
+    'knowledge_search',
+    'list_events',
+    'list_knowledge_topics',
+    'list_projects',
+    'my_data',
+    'my_submissions',
+    'my_warnings',
+    'project_list',
+    'project_note',
+    'project_recall',
+    'rate_answer',
+    'react_to_message',
+    'remember_search',
+    'report_content',
+    'request_human_help',
+    'request_project_connection',
+    'set_helper_availability',
+    'set_language_preference',
+    'set_my_interests',
+    'set_response_style',
+    'share_project',
+    'suggest_improvement',
+    'suggest_knowledge',
+    'who_is_into',
+    'withdraw_knowledge_tip',
+    'withdraw_report',
+  ],
+  admin: [
+    'accept_knowledge_candidate',
+    'add_member',
+    'add_member_note',
+    'admin_digest',
+    'announce',
+    'archive_thread',
+    'assign_community_role',
+    'cancel_event',
+    'clear_warnings',
+    'create_event',
+    'create_poll',
+    'create_thread',
+    'decline_knowledge_candidate',
+    'delete_knowledge',
+    'delete_member_note',
+    'end_poll',
+    'generate_image',
+    'link_member',
+    'list_access_requests',
+    'list_answer_feedback',
+    'list_appeals',
+    'list_assignable_roles',
+    'list_blocked_members',
+    'list_context_digests',
+    'list_duplicate_knowledge',
+    'list_knowledge',
+    'list_knowledge_candidates',
+    'list_knowledge_conflicts',
+    'list_knowledge_gaps',
+    'list_low_rated_knowledge',
+    'list_member_notes',
+    'list_member_warnings',
+    'list_muted_members',
+    'list_reports',
+    'list_roster',
+    'list_suggestions',
+    'list_unhelpful_themes',
+    'merge_knowledge',
+    'moderate',
+    'moderation_history',
+    'project_add_member',
+    'project_archive',
+    'project_bind_here',
+    'project_create',
+    'project_info',
+    'project_remove_member',
+    'project_unarchive',
+    'project_unbind_here',
+    'question_digest',
+    'remove_community_role',
+    'remove_member',
+    'resolve_appeal',
+    'resolve_report',
+    'resolve_suggestion',
+    'response_latency',
+    'review_queue',
+    'save_knowledge',
+    'set_community_guidelines',
+    'set_welcome_message',
+    'team_setup',
+    'unlink_member',
+    'update_knowledge',
+    'user_history',
+    'whats_new',
+  ],
+  superAdmin: [
+    'admin_activity',
+    'audit_view',
+    'dev_team_backlog',
+    'dev_team_dispatch',
+    'dev_team_findings',
+    'dev_team_result',
+    'dev_team_status',
+    'dev_team_verify',
+    'engagement_stats',
+    'feature_flags',
+    'grant_admin',
+    'list_admins',
+    'pause_bot',
+    'purge_user_data',
+    'redeploy_bot',
+    'resume_bot',
+    'revoke_admin',
+    'set_policy',
+    'suggest_issue',
+    'usage_stats',
+  ],
+  discordOnly: [
+    'archive_thread',
+    'assign_community_role',
+    'cancel_event',
+    'create_event',
+    'create_poll',
+    'create_thread',
+    'end_poll',
+    'list_assignable_roles',
+    'list_events',
+    'remove_community_role',
+  ],
+};
+
+const strip = (t: string) => t.replace('mcp__community__', '');
+
+test('SECURITY: the tool tier map is exactly as pinned — no tool silently changes tier, and no tool joins a tier undeclared', () => {
+  for (const key of ['member', 'admin', 'superAdmin', 'discordOnly'] as const) {
+    const actual = [...COMMUNITY_TOOL_TIERS[key]].map(strip).sort();
+    const expected = [...EXPECTED[key]].sort();
+
+    const added = actual.filter((t) => !expected.includes(t));
+    const removed = expected.filter((t) => !actual.includes(t));
+    assert.deepEqual(
+      { added, removed },
+      { added: [], removed: [] },
+      `tier '${key}' changed. If this is intentional, update EXPECTED in the same PR — that diff IS the ` +
+        `review record for a privilege change. Added: [${added.join(', ')}]  Removed: [${removed.join(', ')}]`,
+    );
+  }
+});
+
+test('SECURITY: no tool appears in more than one tier list — a duplicate would make the effective tier depend on lookup order', () => {
+  const seen = new Map<string, string>();
+  for (const key of ['member', 'admin', 'superAdmin'] as const) {
+    for (const raw of COMMUNITY_TOOL_TIERS[key]) {
+      const t = strip(raw);
+      assert.equal(seen.has(t), false, `${t} is in both '${seen.get(t)}' and '${key}'`);
+      seen.set(t, key);
+    }
+  }
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -37,6 +37,7 @@
     "tests/projectScope.test.ts",
     "tests/routerInterceptChain.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
+    "tests/toolTierMap.test.ts",
     "tests/stringsCatalogue.test.ts",
     "tests/systemPromptByteStability.test.ts",
     "tests/systemPromptSlots.test.ts",


### PR DESCRIPTION
Post-refactor review of the two pipeline inputs that did not follow the framework out of this repo.

## 1. `docs/VISION.md` was stale in a way that costs loop budget

Last touched **2026-07-27**, before the split, and it contained **no mention of agent-base**. Its mission, audience and metrics are all module-level, so the substance is still right — but it is the rubric the **research** loop proposes against and the **adversarial** loop judges by, and neither knew this repo is now a module on a framework.

`CLAUDE.md` does say so (it even states a new env var is an agent-base change), but that reaches the **build** worker — by which point a proposal is approved and claimed. **Reliability & ops** and **Cost efficiency** are now largely base-owned, and research *rotates themes for diversity*, so it would keep producing approved-but-unbuildable proposals.

Adds a `Where this repo ends` section (what is module vs base, and that the build worker can only edit this repo), a guardrail against proposing agent-base changes, and inline notes on the two affected themes.

## 2. Governance list: added the manifest, deliberately not the tier map

`src/module/agentModule.ts` is THE manifest — every extension point this deployment registers passes through it. Before the split that authority was spread across `rbac.ts` arrays and a megaclosure; concentrating it made it a rules file. `docs/VISION.md` joins for the same reason: editing it changes what the pipeline builds next.

Both are cheap — **8%** and **0%** of the last 40 merges.

I did **not** add `src/module/agent/tools/index.ts`, despite it being the more dangerous file (a one-word `admin` → `member` widens the privileged surface, typechecks, and passes the existing tests — which assert *consistency* between rbac and core, a property a tier move preserves). Measured against the last 40 merges it appears in **62%**, because every new tool registers a tier there. Governing it would have sent most feature work to a human press and gutted the auto-merge loop.

## 3. `tests/toolTierMap.test.ts` covers it instead, at zero throughput cost

A snapshot of the authored tier registration. A tier change cannot pass CI without editing the expected map **in the same PR**, so a silent widening becomes a reviewable diff the PR-review loop, the adversarial pass and a human all see.

Snapshotting the *authored* registration rather than `toolsForRole` output is deliberate — guest and member derive identically in open mode, so a derived snapshot would be config-dependent.

**Verified non-vacuous:** simulating the real attack (`list_reports`, admin-only report reading, moved to member) fails both cases with `Added: [list_reports]`.

## Dropped: the context-pack gate is fine

I had flagged it as weakened from 41 required paths to 3. That was **my measurement error** — the bare script defaults to `--src src`; CI runs `npm run context:check`, which passes `--src src --src src/module` and requires **24**. No change.

## Verification

Full gates green locally: typecheck (src + tests), lint, prettier, `context:check`, `imports:check`, and the new tests. Security floor regenerated (+2). `toolTierMap.test.ts` added to the `tsconfig.tests.json` ratchet.

Regex tested both directions — catches the three governance paths, and leaves `tools/index.ts`, sibling tool files and ordinary feature work auto-mergeable.

**This PR touches `.github/` and `docs/VISION.md`, so by its own rules it can never auto-merge — expect `human-merge-ready`.**
