### PR TITLE
Bring README up to date after the agent-base extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ reviews, and builds its own features.
   messages so spoken questions get answered too.
 - **Auto-answer mode** (Discord, opt-in): recognises repeat questions in
   allowed channels and offers the KB answer without being addressed.
+- **Agent Skills** (opt-in, `AGENT_SKILLS_ENABLED`): six bundled skills the
+  model loads only when a turn needs one — reviewing a member's prompt or tool
+  schema, critiquing an agent/pipeline design, walking through Claude Code
+  setup, choosing a model or plan, sequencing a learning path, and handling
+  project showcases. Enabling it also moves the prompt-review checklist out of
+  the always-on system prompt and into a skill loaded only when needed, so the
+  per-turn cached prefix shrinks for the majority of turns that never invoke
+  it.
 
 **Community & members**
 - **Discord slash commands** (opt-in): `/kb`, `/whois`, `/projects`,
@@ -191,6 +199,14 @@ human merge**, and branch protection on `main` is the backstop. See
 - [Personas](docs/PERSONAS.md) — the bot's voice ("Dave")
 - [Community context](docs/COMMUNITY-CONTEXT.md) — auto-generated, anonymised
   export of what the community discusses (aggregate-only, opt-in)
+- [Agent-base plan](docs/AGENT-BASE-PLAN.md) — the plan the framework
+  extraction followed: what split base from module, the module API, and what
+  the extraction still owes. Kept as the record of what was decided, with
+  per-phase status notes, not as a description of the tree
+- [Tool registry design](docs/TOOL-REGISTRY-DESIGN.md) — the pre-work design
+  sketch for the declarative tool registry that replaced the hand-maintained
+  tier arrays. Shipped; likewise a record rather than current documentation —
+  for how it works now, read `docs/agents/module-map.md` and the code
 - [Standards](docs/STANDARDS.md) · [Red-team](docs/RED-TEAM.md)
-- [Slide deck](docs/SLIDE-DECK.md) — presentable 11-slide overview of the repo,
+- [Slide deck](docs/SLIDE-DECK.md) — presentable 12-slide overview of the repo,
   the pipeline, and how the design maps to agentic best practice


### PR DESCRIPTION
The extraction PR (#963) rewrote the layout and framework sections correctly. These are the three things it left behind.

I verified the rest rather than assuming it: every directory and file the layout section claims **exists**, the quick-start scripts all **resolve** in `package.json`, and production really is **Node 24** as the stack table says.

## 1. Two design docs were never indexed

`docs/AGENT-BASE-PLAN.md` (403 lines) and `docs/TOOL-REGISTRY-DESIGN.md` (258 lines) were added by the extraction and are the only `docs/*.md` files not linked from README.

Both are explicitly **historical records**, not current documentation — the tool-registry sketch opens by saying it is written in the future tense and kept as the record of what was decided, and the plan carries per-phase status notes. The index entries say so, because otherwise a reader finds a 403-line future-tense plan and takes it for a description of the tree.

## 2. Slide count was stale

The deck gained a slide in its extraction refresh (#964) — `docs/SLIDE-DECK.md` says "12-slide" and has 12 `## ` headings. README still advertised 11.

## 3. Agent Skills were missing from "What it does"

Six bundled skills, live in production behind `AGENT_SKILLS_ENABLED`, and the feature list covers much smaller things (voice notes, polls).

The bullet is deliberately careful about the cached-prefix claim: only **prompt-review** had inline guidance to move out of the always-on system prompt. The other five never did, so a blanket "loading on demand shrinks the prefix" would have overstated it.

## Deliberately not changed

README lists `redeploy` among super-admin ops, and the tool targets `community-agent-redeploy.service` — which is **not installed** on ubuntu-com-agents, so that tool would fail there today. But `docs/DEPLOYMENT.md` documents installing the unit, so the README is accurate about the *software*; the gap is in that deployment. Recorded in the ops repo rather than papered over here.

## Verification

`prettier --check`, `eslint`, and `context:check` all pass. Docs-only — no code, no tests, no schema.