### PR TITLE
Pin @swampratnz/agent-base 0.5.1, and stop refusing tips that only look adjacent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -377,6 +377,18 @@ CONTEXT_BUILDER_MIN_DISTINCT_USERS=3
 # accept_knowledge_candidate (list/decline are also admin-only). Off by
 # default, and has no effect while CONTEXT_BUILDER_ENABLED is false.
 CONTEXT_CANDIDATES_ENABLED=false
+# How similar an existing knowledge entry must be to a proposed topic before
+# that topic counts as ALREADY COVERED — which is what refuses a member's
+# suggest_knowledge tip and suppresses a builder-drafted candidate. This used
+# to reuse the 0.35 retrieval floor, which answers a different question ("is
+# this worth showing to someone who asked?") and is far too eager as a
+# redundancy test: measured against a real corpus, two entries on the same
+# PRODUCT but different TOPICS score ~0.38, so a genuinely new contribution
+# was being turned away as a duplicate. Raise it to refuse fewer tips, lower
+# it to refuse more. Reference points from that corpus: ~0.73 near-identical,
+# ~0.64 same topic in different words, ~0.38 same product/different topic,
+# ~0.10 loosely related.
+KNOWLEDGE_COVERAGE_SIMILARITY_THRESHOLD=0.6
 # Daily knowledge refresh: a scheduled job web-researches a small FIXED set of
 # fast-moving Claude/Anthropic topics and writes each briefing straight into the
 # knowledge base as one upserted, clearly-labelled 'auto-researched' entry per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ Skipped as internal: #707 #725 #731 #749 #750 #751 #767 #769 #770 #779 #780 #790
 -->
 
 
+## 2026-08-17
+
+### Changed
+- **Fewer knowledge tips get turned away as "already covered."** When you
+  offer something with `suggest_knowledge` (or when the offline builder drafts
+  a candidate), the bot checks whether an existing entry already covers the
+  topic and declines if one does. That check was far too eager: it borrowed
+  the threshold used for *search* — which asks the much looser question "is
+  this worth showing to someone who asked?" — so an entry merely about the
+  same product as your tip could be enough to refuse it. Measured against a
+  real corpus, two entries on the same product but on genuinely different
+  topics score about 0.38, comfortably above the old 0.35 bar, so that was
+  not an edge case. The coverage check now has its own threshold, defaulting
+  to 0.6 and tunable per deployment via
+  `KNOWLEDGE_COVERAGE_SIMILARITY_THRESHOLD`. Near-duplicates are still
+  refused; contributions that only *look* adjacent now get through. If a tip
+  of yours was declined in the past and you still think it's not covered, it
+  is worth offering again.
+
 ## 2026-08-15
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1576,7 +1576,10 @@ and review flow above, rather than a separate table or a privileged surface:
 - **Same dedup guard, reused verbatim**: `candidateTopicAlreadyReviewed`
   (exact + semantic match against already-queued/reviewed topics) and
   `findKnowledgeCoveringTopic` (an existing `knowledge` entry that already
-  covers it, above `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD`) both run BEFORE
+  covers it, above `KNOWLEDGE_COVERAGE_SIMILARITY_THRESHOLD` — its own knob
+  since agent-base 0.5.x, default 0.6; it used to borrow the much looser
+  retrieval floor `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD`, which refused
+  same-product/different-topic tips as duplicates) both run BEFORE
   insert; a blocked tip is never queued and the reply tells the member why
   (naming the covering entry's title when that's the reason).
   `findKnowledgeCoveringTopic` is a thin wrapper `knowledgeCoversTopic` (the

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "^0.4.0",
+        "@swampratnz/agent-base": "^0.5.1",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -1755,9 +1755,9 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.4.0.tgz",
-      "integrity": "sha512-LB0/VQWMyG2Wn2ubGgJXoJ0x1Qx7dVGsMw+3/pRHH1Qmg1sRnJJ7HykV0Ea5qD5JA8HkFciQactejYSrV+fc1Q==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.5.1.tgz",
+      "integrity": "sha512-rhkzuzH6Y6yxyhZAuzCgD6l+x/0LMoMonAgp327qrAx6ZvlJYLFUctcE2CLaRx7AQFfy23DJVuDYDy8xc4tAzg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "^0.4.0",
+    "@swampratnz/agent-base": "^0.5.1",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

Bumps the framework pin from `^0.4.0` to `^0.5.1` and brings this repo's own account of the behaviour that changes with it up to date.

The pin is the change, not bookkeeping around it: `^0.4.0` is minor-locked on a `0.x` range, so `0.5.1` could never have been picked up by an install alone.

What arrives with it is one behavioural fix. `findKnowledgeCoveringTopic` — the guard that decides whether a member's `suggest_knowledge` tip, or a builder-drafted candidate, is refused as *already covered* — used to borrow the retrieval floor `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD` (0.35). That threshold answers a different question ("is this worth showing to someone who asked?") and is far too eager as a redundancy test. Measured against a real corpus, two entries on the same **product** but genuinely different **topics** score ~0.38 — above the old bar — so turning a new contribution away as a duplicate was the common case rather than an edge one. It now has its own knob, `KNOWLEDGE_COVERAGE_SIMILARITY_THRESHOLD`, defaulting to 0.6.

The rest of the diff keeps this repo truthful about that:

- **`.env.example`** gains the knob beside `CONTEXT_CANDIDATES_ENABLED`, where its siblings (`KNOWLEDGE_SHORTCUT_THRESHOLD` and friends) already live, with the corpus reference points — ~0.73 near-identical, ~0.64 same topic in different words, ~0.38 same product/different topic, ~0.10 loosely related — so a deployment retuning it has something to aim at rather than a bare number.
- **`docs/ARCHITECTURE.md`** asserted the coverage check fires above `KNOWLEDGE_SEARCH_RELEVANCE_THRESHOLD`. That is now false, so it is corrected rather than left describing the previous build.
- **`CHANGELOG.md`** gets the member-visible half under a new `## 2026-08-17` section: fewer tips turned away, and a tip declined before is worth offering again.

No source change in `src/` — the behaviour lives in the package.

## Security / privacy impact

None. The security spine is untouched: no change to tool gating, tier derivation, the CONFIRM flow, outbound filtering, or the SQL scoping of admin data access.

The one behavioural change moves in the *safe* direction for the human-curation invariant. It only makes the pre-insert dedup guard **less** likely to refuse, and refusing was never the control — nothing reaches `knowledge`/`knowledge_search` without an admin-tier `accept_knowledge_candidate`, and that gate is unchanged. The worst case of a looser threshold is an extra pending candidate for an admin to decline, not an unreviewed publish. The fail-open posture on a null embedding ("not covered") is also unchanged.

`test:security` is unchanged at 1117 `SECURITY:` tests across 152 files, so no security assertion was added, weakened or lost in the bump.

## How verified

Full gate green locally, against a real Postgres 16 + pgvector (not a skipping run):

- `typecheck` (incl. `typecheck:tests`), `lint`, `format:check`, `migrate`, `build`, `context:check` (24 required paths, 67 entries), `imports:check` (68 files) — all clean.
- `npm test` — **2858 tests, 2858 pass, 0 fail, 0 skipped**.
- `npm run test:security` — 1149 cases, 0 fail; gate reports 1117 `SECURITY:`-prefixed tests ran against a manifest total of 1117 across 152 files.
- Installed tree confirmed resolving to `0.5.1`, and all three lockfile/manifest version fields agree.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_