### PR TITLE
Bump undici, brace-expansion and @hono/node-server past their advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.0.0",
         "qrcode-terminal": "^0.12.0",
-        "undici": "^6.27.0",
+        "undici": "^6.28.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -972,9 +972,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2398,9 +2398,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5369,9 +5369,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   },
   "overrides": {
     "adm-zip": "^0.6.0",
-    "undici": "^6.27.0",
-    "brace-expansion": "^5.0.8",
+    "undici": "^6.28.0",
+    "brace-expansion": "^5.0.9",
+    "@hono/node-server": "^1.19.15",
     "protobufjs": "^7.6.5",
     "sharp": "^0.35.3"
   },
@@ -51,7 +52,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",
     "qrcode-terminal": "^0.12.0",
-    "undici": "^6.27.0",
+    "undici": "^6.28.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Clears the open Dependabot advisories. `npm audit` against the current lockfile reports three vulnerable packages carrying five advisories:

| Package | Installed | Severity | Advisory |
|---|---|---|---|
| `brace-expansion` | 5.0.8 | **High** (7.5) | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
| `@hono/node-server` | 1.19.14 | Moderate (5.9) | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — path traversal in `serve-static` on Windows via encoded backslash |
| `undici` | 6.27.0 | Moderate (4.8) | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) — downstream response desynchronization via the retry interceptor |
| `undici` | 6.27.0 | Moderate (4.2) | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) — CRLF injection via a blob-like body `type` |
| `undici` | 6.27.0 | Moderate (4.8) | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) — cookie attribute injection via unsanitized domain and unparsed `setCookie` fields |

Fixed by raising floors in the existing `overrides` block — already this repo's mechanism for pinning transitive deps up — plus the direct `undici` dependency: `undici` `^6.28.0` (resolves 6.28.0), `brace-expansion` `^5.0.9` (5.0.9), and a new `@hono/node-server` `^1.19.15` (1.19.17).

Two things worth flagging for review:

**The old ranges already permitted the fixes.** `^6.27.0` and `^5.0.8` both admit the patched versions; only the lockfile was holding the vulnerable ones. Regenerating alone would have cleared today's alerts, but raising the floors is what stops a future resolve from walking back below the patch.

**`@hono/node-server` is capped inside 1.x deliberately.** Latest is 2.1.1, but it arrives via `@modelcontextprotocol/sdk`, which asks for `^1.19.9` — overriding to 2.x would be an override fighting its own dependent. 1.19.17 is the newest 1.x and is past the fix.

## Security / privacy impact

Positive and confined to dependency versions. No source change, and nothing on the security spine is touched — no change to tool gating, tier derivation, the CONFIRM flow, outbound filtering, or the SQL scoping of admin data access.

Exposure before this bump was real but narrow. `undici` is the HTTP client behind the outbound fetch paths, so the response-desync and CRLF advisories are the ones that matter here; the `@hono/node-server` path traversal is Windows-and-`serve-static` specific and this deployment is neither, so it is patched for hygiene rather than reachable risk.

`test:security` counts are unchanged — no test files are touched, so `security-floor.json` needs no update and gets none.

## How verified

- Post-install `npm audit` reports **0 vulnerabilities** (from 3 packages / 5 advisories).
- Installed tree confirmed at `undici` 6.28.0, `brace-expansion` 5.0.9, `@hono/node-server` 1.19.17.
- Full gate run against a real Postgres 16 + pgvector — results reported in a follow-up comment once complete; this PR stays in draft until then.

One process note: an earlier local run of this gate reported ~560 failures, which I initially attributed to CPU contention. That was wrong — the local Postgres had been killed outright (its log ends mid-checkpoint with no shutdown entry, under memory pressure from two concurrent suites), so `DATABASE_URL` was set but unreachable and DB tests failed instead of skipping. The bump was never implicated. Re-running against a live database.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_