### PR TITLE
Document the CI/CD system as a mechanical reference (docs/CICD.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,10 @@ This bot processes untrusted public chat. Preserve these invariants:
 ## Multi-loop pipeline
 
 This repo is developed by a supervised multi-session pipeline — see
-`docs/PIPELINE.md`. If you are running as one of those loops, obey the
+`docs/PIPELINE.md` for why each loop exists, and `docs/CICD.md` for the
+mechanical reference (every workflow's trigger/permissions/timeout, the CI gate
+and its check scripts, the mechanisms shared across loops, and what is portable
+to another repo). If you are running as one of those loops, obey the
 ownership rules:
 
 - **Only the build loop** writes code or opens PRs. PR-review comments only;

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ human merge**, and branch protection on `main` is the backstop. See
 - [Capability ideas](docs/CAPABILITY-IDEAS.md) — curated backlog of candidate
   directions (not commitments)
 - [Pipeline](docs/PIPELINE.md) — the self-improving research/review/build loops
+- [CI/CD](docs/CICD.md) — mechanical reference for every workflow, the CI gate
+  and its check scripts, the mechanisms shared across the loops, and what is
+  portable to another repo
 - [Personas](docs/PERSONAS.md) — the bot's voice ("Dave")
 - [Community context](docs/COMMUNITY-CONTEXT.md) — auto-generated, anonymised
   export of what the community discusses (aggregate-only, opt-in)

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,649 @@
+# CI/CD reference
+
+The complete mechanical reference for everything under `.github/workflows/`
+plus the delivery path that follows a merge — written so the system can be
+**read as a design**, not just as fifteen YAML files, and so the reusable half
+can be lifted out of this repo (see [§8 Extraction guide](#8-extraction-guide)).
+
+**How this relates to the other docs.** They are complementary, not
+overlapping:
+
+| Doc | Answers |
+|---|---|
+| **this file** | *What* runs, on what trigger, with what permissions; the mechanisms shared across workflows; what is portable |
+| [`PIPELINE.md`](PIPELINE.md) | *Why* the agent loops are shaped the way they are — the incidents, the ownership rules, the loop prompts |
+| [`DEPLOYMENT.md`](DEPLOYMENT.md) | The production host: systemd units, the redeploy timer, rollback |
+| [`SECURITY.md`](SECURITY.md) | The threat model the guardrails below implement |
+| [`STANDARDS.md`](STANDARDS.md) | What a contributor must do before pushing |
+
+When this file and `PIPELINE.md` disagree about a loop's *rationale*,
+`PIPELINE.md` wins. When they disagree about a trigger, permission or
+condition, **the workflow file wins** and both docs are wrong — fix them in the
+same PR.
+
+---
+
+## 1 · The three layers
+
+```
+        ┌──────────────────────────────────────────────────────────┐
+LAYER 1 │  THE GATE — what "green" means                           │
+        │  ci.yml (build · lint · security-invariants)             │
+        │  + the gate scripts in scripts/*.mjs                     │
+        │  Runs on every push to main, every PR, every merge group │
+        └────────────────────────┬─────────────────────────────────┘
+                                 │ the same commands, run by
+                                 ▼
+        ┌──────────────────────────────────────────────────────────┐
+LAYER 2 │  AUTONOMY — the loops that produce and repair PRs        │
+        │  build · pr-review · autofix · conflict · revise         │
+        │  automerge · groundskeeper · retries · janitors          │
+        │  Coordinated ONLY through GitHub issues + labels         │
+        └────────────────────────┬─────────────────────────────────┘
+                                 │ merge to main
+                                 ▼
+        ┌──────────────────────────────────────────────────────────┐
+LAYER 3 │  DELIVERY — pull-based, off GitHub                       │
+        │  scripts/redeploy.sh + systemd timer on the prod host    │
+        │  (nightly 1am NZ; optionally chat-triggered)             │
+        └──────────────────────────────────────────────────────────┘
+```
+
+Three properties hold across all three layers and are the load-bearing design
+decisions:
+
+1. **All state lives in GitHub.** No workflow remembers anything between runs.
+   Every agent worker is a cold session; every deterministic loop reconstructs
+   its view from issues, labels, PR fields and marker comments. A dead run
+   costs nothing but the tokens it burnt.
+2. **The gate is defined once and run everywhere.** Layer 1's command list is
+   what the build worker runs before opening a PR, what the repair loops run
+   before pushing, and what a human runs locally. Divergence between them is
+   the failure mode the design most guards against.
+3. **Deterministic where possible, agentic only where necessary.** Six of the
+   fifteen workflows run no model at all. Every decision expressible as a shell
+   condition is one.
+
+---
+
+## 2 · Workflow inventory
+
+All fifteen workflows, with the facts you need to reason about blast radius.
+`GITHUB_TOKEN` permissions are the workflow-level grant; **⚡** marks a workflow
+that invokes `anthropics/claude-code-action` and therefore spends the shared Max
+pool.
+
+| Workflow | Trigger | Concurrency | Permissions | Timeout | Enabled by |
+|---|---|---|---|---|---|
+| **`ci.yml`** | push `main`, `pull_request`, `merge_group` | `ci-<ref>`, cancel on PR | `contents:read` | job default | always |
+| `ci-retry.yml` | `workflow_run` [CI] completed | — | `actions:write`, `contents:read` | 5 min | always |
+| **`pipeline-build.yml`** ⚡ | `issues.labeled == status:approved` | `pipeline-build-<issue>`, no cancel | `contents`,`issues`,`pull-requests`:write, `id-token:write` | 180 min | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `pipeline-build-retry.yml` | `workflow_run` [build] completed | — | `actions:write` | 5 min | always |
+| **`pipeline-pr-review.yml`** ⚡ | `pull_request` opened/synchronize/reopened/ready_for_review | per-PR, **cancel-in-progress** | `contents:read`, `pull-requests:write`, `actions:write`, `id-token:write` | 20 min | the secret |
+| `pipeline-pr-autofix.yml` ⚡ | `workflow_run` [CI] completed | per head branch | `contents`,`issues`,`pull-requests`:write, `id-token:write` | 45 min | the secret |
+| `pipeline-pr-revise.yml` ⚡ | `workflow_dispatch` (`pr_number`) | per-PR | as autofix | — | the secret |
+| `pipeline-pr-conflict.yml` ⚡ | push `main`, PR opened/ready, hourly, `workflow_dispatch` (`resolve_matrix`) | per-run / per-PR | discover: read; resolve: write set | — | the secret |
+| `pipeline-pr-automerge.yml` | `*/15 * * * *`, `workflow_run` [CI, PR review], dispatch | single group | `contents`,`pull-requests`:write | 10 min | secret **and** `vars.AUTOMERGE_MODE` |
+| `pipeline-groundskeeper.yml` | `17 * * * *`, dispatch | single group | `issues:write`, `pull-requests:read` | 10 min | always |
+| `pipeline-outcomes.yml` | `23 20 * * 1`, dispatch (`window_days`) | single, cancel | `contents:read`, `issues:write`, `pull-requests:read` | 10 min | always |
+| `changelog-coverage.yml` | `17 19 * * *`, dispatch | single, cancel | `contents:read`, `issues:write`, `pull-requests:read` | 10 min | always |
+| `changelog-autofill.yml` ⚡ | `47 19 * * *`, dispatch | single group | `contents`,`pull-requests`:write, `id-token:write` | 30 min | the secret |
+| `branch-janitor.yml` | `0 3 * * 1`, dispatch (`dry_run`, `extra`) | single group | `contents:write`, `pull-requests:read` | 15 min | always |
+| `setup-labels.yml` | `workflow_dispatch` only | — | `contents:read`, `issues:write` | — | manual |
+
+**The single kill switch:** remove the `CLAUDE_CODE_OAUTH_TOKEN` secret and
+every ⚡ workflow goes inert (they log a notice and skip). There is no per-loop
+enable switch except `AUTOMERGE_MODE`; to disable one loop individually, disable
+it in the Actions UI.
+
+**Model and turn budget** for the ⚡ workflows — all currently Sonnet, pinned in
+the workflow file (a session's `/model` does not affect them):
+
+| Workflow | `--max-turns` | Tool grant shape |
+|---|---|---|
+| `pipeline-build.yml` | 300 | broad write set (edit, commit, push, `gh pr create`, `npm`) |
+| `pipeline-pr-autofix.yml` | 200 | write set, push pinned to `git push origin HEAD` |
+| `pipeline-pr-revise.yml` | 200 | as autofix, plus `gh pr comment` |
+| `pipeline-pr-conflict.yml` | 30 (fast path) / 200 | as autofix |
+| `pipeline-pr-review.yml` | 60 | **read-only** — `gh pr diff/view`, Read, Grep, Glob |
+| `changelog-autofill.yml` | 60 | narrow: edit `CHANGELOG.md`, one pinned push, one pinned `gh pr create` |
+
+---
+
+## 3 · Layer 1 — the CI gate (`ci.yml`)
+
+Three parallel jobs. The split is deliberate and each boundary carries meaning.
+
+| Job | Services | Runs | Catches |
+|---|---|---|---|
+| **`build`** | `pgvector/pgvector:pg16` | `npm ci` → `typecheck` → `migrate` → `test` → `build` | type errors, broken migrations, behaviour regressions, missing runtime assets in `dist/` |
+| **`lint`** | none | `npm ci` → `lint` → `format:check` → `context:check` → `imports:check` | style, stale agent context pack, composition-direction violations |
+| **`security-invariants`** | **none, deliberately** | `npm ci` → `test:security` | a deleted/disabled `SECURITY:` test, and the security spine itself |
+
+### 3.1 Why the jobs split this way
+
+- **`lint` has no database and no model** — every check in it is pure and
+  static, so it returns in seconds and gives the fastest signal on the two
+  gates most likely to be forgotten (`context:check`, `imports:check`).
+- **`security-invariants` deliberately leaves `DATABASE_URL` unset.** The
+  DB-backed `SECURITY:` tests key their skip on `Boolean(process.env.DATABASE_URL)`.
+  A *set-but-unreachable* URL would make them **run and fail**; unset makes them
+  skip cleanly. The count gate treats a skip as a pass, so the required count
+  stays stable either way. This job must stay deterministic regardless of DB
+  reachability — that is the whole point of separating it from `build`.
+- **`build` is the only job with Postgres**, so DB-touching changes are
+  genuinely exercised rather than skipped.
+
+### 3.2 The environment contract
+
+Both `build` and `security-invariants` set the same dummy-credential env. Every
+one of these exists for a reason, and a fork of this pipeline will need its own
+equivalent list:
+
+| Var | Value in CI | Why it must be set |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | `ci-dummy-token` | config's zod schema requires it; nothing in CI calls Claude |
+| `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` | dummies | same — config validation, not connectivity |
+| `WHATSAPP_PROVIDER` | `disabled` | keeps the adapter out of the boot path |
+| `DISPLAY_TIMEZONE` | `Pacific/Auckland` | `agentModule.init()` is **boot-fatal** without it (framework defaults to UTC) |
+| `DISPLAY_LOCALE` | `en-NZ` | same |
+| `EMBEDDING_MODEL` | `Xenova/all-MiniLM-L6-v2` | pinned so the cache key derives from it |
+| `DATABASE_URL` | service container URL (`build` only) | unset in `security-invariants` — see above |
+
+### 3.3 The embedding-model cache
+
+`npm ci` wipes `node_modules/@huggingface/transformers/.cache`, so every run
+re-fetched the local embedding model from huggingface.co — wall-clock cost plus
+an external fetch that can flake. `actions/cache` is therefore placed **after**
+`npm ci` (restore happens at the step's position; save happens post-job), and
+the key is `hf-embedding-model-${{ env.EMBEDDING_MODEL }}` — derived from the
+job's own env rather than a hand-bumped suffix, so a model change can never
+serve a stale cache. The same block is repeated in `security-invariants` and in
+the build worker.
+
+### 3.4 The security-floor lowering guard
+
+`security-invariants` sets two extra variables that implement an
+audit finding (H1): a PR may not *reduce* the declared `SECURITY:` test counts
+without a deliberate, labelled human act.
+
+| Var | Source | Effect |
+|---|---|---|
+| `SECURITY_FLOOR_BASELINE_REF` | `github.event.pull_request.base.sha` | the base manifest to diff against; empty on push/merge_group, so the guard is PR-only |
+| `ALLOW_SECURITY_FLOOR_LOWER` | `contains(labels.*.name, 'allow-security-floor-lower')` | the labelled override |
+
+The checkout uses `fetch-depth: 0` specifically so the guard can
+`git show <base>:tests/security-floor.json`; a shallow clone would not have the
+base commit.
+
+> ⚠️ **Gap:** the `allow-security-floor-lower` label is *consumed* by `ci.yml`
+> but is **not created** by `scripts/setup-labels.sh` (19 labels, this is not
+> one of them). A maintainer needing the override must create the label by
+> hand first. See [§7](#7-known-gaps).
+
+### 3.5 The gate scripts
+
+Layer 1's real content is a family of Node scripts. They share a house style —
+each is a *manifest with a gate*, has a mechanical fixer where a fixer can be
+correct, and refuses to have one where it cannot.
+
+| Script | npm script | Manifest / data it enforces | Fixer | Exit behaviour |
+|---|---|---|---|---|
+| `check-security-test-count.mjs` | `test:security` | `tests/security-floor.json` — per-file map of declared `SECURITY:` tests, **exact match**, kept sorted | `test:security:fix` (only ever *raises*; `--allow-lower` for a genuine removal) | fails on count mismatch, unsorted manifest, or any failing test |
+| `check-context-pack.mjs` | `context:check` | `docs/agents/module-map.md` — one entry per `src/` subsystem, unique, sorted, no stubs | `context:fix` — **deliberately cannot make the gate green** (inserts a `TODO` stub) | fails on missing/dangling/unsorted/stub entry |
+| `check-import-direction.mjs` | `imports:check` | three composition rules (no `src/base/`; `src/module/` may not import the root; only the root may call `createAgent`) | none | fails on violation |
+| `check-dist-schema.mjs` | end of `build` | `dist/module/storage/schema/` must match the compiled manifest | none | fails on a forgotten `.sql` copy |
+| `check-db-coverage.mjs` | `pretest` | prints a banner when `DATABASE_URL` is unset so a partial suite is legible | none | banner only, unless `REQUIRE_DATABASE_URL=1` |
+| `check-changelog-coverage.mjs` | `changelog:check` | `CHANGELOG.md` vs merged PRs in a window; skip-ledger HTML comment counts as documented | the autofill loop | **always exits 0** — the caller decides |
+| `pipeline-outcomes.mjs` | (workflow only) | reconstructs a per-loop ledger from marker comments | — | always exits 0 |
+| `handoff-note.mjs` | (workflow only) | renders/resolves the build→review handoff comment | — | best-effort |
+
+The two `--write` fixers differ on purpose: a **count** is derivable from the
+code, so `test:security:fix` may finish the job; a **description** is not, so
+`context:fix` must not. A fixer that could auto-satisfy the context gate would
+defeat the gate's only purpose — stopping a module entering the tree
+undescribed.
+
+### 3.6 The full local gate
+
+The command block a contributor or agent runs before pushing — identical to
+what CI runs, which is the invariant that keeps "green locally" meaningful:
+
+```bash
+npm run typecheck && npm run lint && npm run format:check \
+  && npm run migrate && npm test && npm run build \
+  && npm run test:security && npm run context:check && npm run imports:check
+```
+
+(Also in [`docs/agents/recipes.md`](agents/recipes.md) → "Run the full gate".)
+
+---
+
+## 4 · Layer 2 — the autonomy loops
+
+`PIPELINE.md` documents each loop's purpose, ownership rules and history. What
+follows is the part that document does not isolate: the **mechanisms shared
+across loops**. These, not the individual loops, are the reusable core.
+
+### 4.1 The eleven shared mechanisms
+
+**M1 · The inert gate.** Every ⚡ workflow's first step evaluates
+`HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}` and every subsequent
+step is `if: env.HAS_TOKEN == 'true'`. A workflow merged into a repo without the
+secret logs one notice and does nothing. This is what makes the whole pipeline
+safe to merge before it is configured.
+
+**M2 · Fork safety.** GitHub withholds secrets from fork PRs, so `HAS_TOKEN` is
+empty there and agent workflows skip. The `workflow_run`-triggered loops
+(autofix, automerge) get secrets even for fork PRs, so they *additionally*
+hard-require `head_repository.full_name == github.repository` in the job `if:`.
+
+**M3 · The two-hop dispatch.** `claude-code-action` does not run under
+`push`-shaped payloads, and **GitHub never starts a workflow from a
+`GITHUB_TOKEN`-created event**. Both constraints are dodged the same way: a
+deterministic *discover/post* job self-dispatches the agent job via
+`workflow_dispatch`, which is one of the two documented exceptions to the
+GITHUB_TOKEN rule. Used by the conflict resolver (discover → resolve) and by
+review → revise. Recursion is bounded to depth 1.
+
+**M4 · Never trust the payload.** A dispatch payload carries **identifiers
+only** (a PR number, a list of PR numbers). The receiving job re-derives the
+branch and re-verifies the entire eligibility contract from the API before
+checkout. Anyone with write access can hand-craft a dispatch, so the payload is
+treated as attacker-shapeable; this also makes a superseded duplicate run no-op
+rather than mislabel.
+
+**M5 · The eligibility contract.** Every PR-touching loop filters on the same
+shape, in this order — cheap structural checks first:
+
+- same-repo (never a fork)
+- authored by the expected identity (see [§4.2](#42-the-identity-model))
+- body contains `Closes #<n>` — the build worker's contract, which is what
+  distinguishes a pipeline PR from a Dependabot bump
+- not labelled `needs-human` (any loop's escalation = a hard stop)
+- not labelled the loop's own pin-out label (`no-auto-resolve`, `no-auto-merge`)
+- plus a per-loop live condition (still CONFLICTING; verdict still pending; …)
+
+**M6 · Attempt caps via marker comments.** There is no per-PR counter store, so
+attempts are counted by grepping the PR's comments for a marker HTML comment.
+Two attempts, then escalate `needs-human` and stop. Without the cap a
+fix→fail→fix cycle would drain the weekly token pool.
+
+**M7 · The deterministic checkpoint.** Runs `if: always()` **after the agent
+exits**, and pushes anything the agent committed but never pushed, using the
+job's `GITHUB_TOKEN` (valid for the whole job, unlike the ~1h App token). It
+only ever **fast-forwards**; a diverged remote parks the work on a
+`-ckpt-<run_id>` ref rather than rewriting someone else's push. This exists
+because prompt-only compliance provably fails — agents have finished whole
+builds, and whole conflict resolutions, and then ended their turn without
+pushing. Present in build, autofix, revise and conflict.
+
+**M8 · Verify-else-escalate.** The step after the checkpoint asserts the
+*outcome* deterministically — is there an open PR closing this issue? was a
+commit pushed? — and if not, labels `needs-human`, comments, and **fails the job
+loudly**. An agent that narrates work it did not do must not produce a green
+run.
+
+**M9 · Deterministic lane ownership.** The workflow, not the agent, owns every
+label transition: a Claim step sets `status:building` before the agent runs; the
+verify step sets `status:built` after it confirms the PR. The agent signals a
+deliberate refusal by writing a git-ignored `needs-human.md` file, which the
+verify step turns into the label. The agent is granted **no `gh issue edit`** —
+the tool matcher cannot pin an issue number, so that grant would let an injected
+agent label an *arbitrary* issue `status:approved` and spawn an unreviewed build.
+
+**M10 · Least-privilege tool grants.** `--allowedTools` is an explicit
+allowlist, never a blanket `Bash(gh:*)`. Push is granted as the *exact* string
+`git push origin HEAD` (no `:*`), `gh` is read-only except where a loop must
+comment, and `git checkout`/`switch` are withheld so HEAD cannot leave the
+branch. Checkouts use `persist-credentials: false` so the job token is not left
+readable in `.git/config` where an agent that reads untrusted content could
+exfiltrate it; `GH_TOKEN` is set per-step on deterministic steps only, never on
+the agent step. **This is defence in depth, not a guarantee** — the agents have
+Edit/Write and `node`, i.e. code execution. The enforceable stop is branch
+protection on `main`.
+
+**M11 · The verdict token contract.** Three workflows consume a review verdict,
+and free-prose parsing drifted between them. The verdict is now a typed
+artifact: the model is asked for `<!-- verdict:LGTM -->` /
+`<!-- verdict:CHANGES_REQUESTED -->` / `<!-- verdict:NEEDS_HUMAN -->`, and
+`pipeline-pr-review.yml` — the only place a review comment is composed —
+decides once, strips any model-emitted whole-line token, and stamps exactly one
+authoritative token right after its marker. Consumers read the first token, so a
+review that legitimately quotes one mid-sentence cannot be misread. Both shell
+helpers (`canonical_verdict`, `legacy_verdict`) are duplicated across the three
+workflows and `tests/reviewVerdict.test.ts` fails on drift. An unrecognisable
+verdict routes **nowhere** — a malformed review stalls visibly rather than
+guessing.
+
+### 4.2 The identity model
+
+Three distinct identities act on this repo, and several gates depend on telling
+them apart:
+
+| Identity | Is | Used for | Notable property |
+|---|---|---|---|
+| `claude[bot]` (renders as `app/claude` via GraphQL) | the Claude GitHub App token, minted per-run via OIDC | everything the *agent* does: commits, its PRs, its comments | the **only** identity auto-merge will merge; its pushes **do** re-trigger CI |
+| `github-actions[bot]` | the job's `GITHUB_TOKEN` | deterministic steps: labels, verdict comments, checkpoints, recovery PRs | its events **never** start workflows (hence M3); its PRs can never auto-merge |
+| a human | — | merges everything the loops won't touch | branch protection is the backstop |
+
+Two consequences worth internalising: the build agent **cannot write into the
+handoff channel it feeds** (only `github-actions[bot]` comments are read back),
+and **checkpoint-recovered or workflow-recovered work can never launder itself
+into a merge**, because it is authored by the wrong identity for the auto-merge
+gate.
+
+### 4.3 Marker comment registry
+
+Markers are the pipeline's only persistent per-PR state. All are HTML comments,
+matched on **line 1** so a comment that merely quotes a marker is not mistaken
+for the channel.
+
+| Marker | Written by | Read by |
+|---|---|---|
+| `<!-- pipeline-handoff:build -->` + `<!-- handoff-body:begin/end -->` | build (post step) | review (resolve step, polls ≤60s) |
+| `<!-- pipeline-autofix-attempt -->` | autofix | autofix (cap), outcomes |
+| `<!-- pipeline-autofix-checkpoint -->` | autofix | outcomes |
+| `<!-- pipeline-autofix-escalation -->` | autofix | outcomes |
+| `<!-- pipeline-pr-revise-attempt / -checkpoint / -escalation -->` | revise | revise (cap), outcomes |
+| `<!-- pipeline-pr-conflict-attempt / -checkpoint / -escalation -->` | conflict | conflict (cap), outcomes |
+| `<!-- pipeline-automerge-blocked -->` | automerge | itself (post once) |
+| `<!-- pipeline-automerge-human-ready -->` | automerge | itself (post once) |
+| `<!-- module-map:begin/end -->` | humans / `context:fix` | `check-context-pack.mjs` |
+
+`pipeline-outcomes.yml` exists precisely because these markers already encode
+the record: it counts engaged / recovered / escalated per loop weekly with no
+new state and no writes to any PR. **Recovered** is the number that matters —
+every one is a prompt/harness defect in that loop, not a code defect in the PR.
+
+### 4.4 Escalation and retry map
+
+What happens when each thing fails, in order of who gets there first:
+
+| Failure | First responder | Then | Finally |
+|---|---|---|---|
+| CI red on any PR | `ci-retry.yml` — one blind machine rerun (`run_attempt < 2`), with a staleness guard so a superseded commit is not re-run | `pipeline-pr-autofix.yml` from attempt 2, ≤2 agent attempts | `needs-human` |
+| Build run **fails** | `pipeline-build-retry.yml` — rerun, ≤3 attempts total | build worker escalates on its **final** attempt only, clearing both `status:building` *and* `status:approved` | `needs-human` |
+| Build run **times out** (reports `cancelled`, invisible to the retry loop) | — | `pipeline-groundskeeper.yml` hourly: `status:building` + no open PR + 4h idle | `needs-human` |
+| Build pushed a branch but skipped `gh pr create` | the build workflow's own verify step opens a **draft** recovery PR and sets `status:built` | never overrides a deliberate refusal, never touches a branch that ever had a PR | CI + review adjudicate |
+| Agent committed but never pushed | the checkpoint step (M7) | recovery comment states the work never cleared the gate | CI adjudicates |
+| PR goes CONFLICTING | `pipeline-pr-conflict.yml`, one attempt (deterministic fast path for a `security-floor.json`-only conflict) | `needs-human` | human merges `main` |
+| Review says "Changes requested" | `pipeline-pr-revise.yml`, ≤2 attempts | `needs-human` | human |
+| Review says "Needs a human decision" | review labels `needs-human` directly | — | human |
+| PR green + LGTM but touches a governance path | automerge labels `human-merge-ready` + one comment | keeps scanning for other PRs | human merges |
+| Merged PR has no changelog entry | `changelog-coverage.yml` opens/refreshes one self-closing tracking issue | `changelog-autofill.yml` drafts a PR 30 min later | human merges the autofill PR |
+| Merged branch left behind | `branch-janitor.yml` weekly, ancestry- or all-PRs-merged only | never touches never-PR'd or `-ckpt-` refs | `extra` dispatch input |
+
+---
+
+## 5 · Layer 3 — delivery
+
+Delivery is **pull-based and runs off GitHub entirely** — no workflow deploys.
+The production host fast-forwards itself. Full detail in
+[`DEPLOYMENT.md`](DEPLOYMENT.md); the shape:
+
+- `scripts/redeploy.sh`, invoked by `deploy/community-agent-redeploy.timer`
+  (systemd, nightly 1am `Pacific/Auckland`).
+- Order is **fail-safe**: fast-forward → `npm ci` → `build` → `migrate` →
+  *then* restart. A broken build or migration leaves the running service
+  untouched.
+- Outcomes: already current → cheap no-op; dirty tree or non-fast-forward →
+  abort; build/migrate failure → restore old code, do not restart; restarted but
+  never healthy → roll back code and restart the old build.
+- **Rollback restores code only.** An applied migration is never rolled back,
+  so migrations must stay backward-compatible within a deploy.
+- `flock` serialises the timer against the opt-in chat-triggered redeploy
+  (`redeploy_bot` tool → a pinned `sudo systemctl start` of the same oneshot
+  unit).
+
+The CI/CD seam is therefore just `main`: Layer 2 decides what lands there,
+Layer 3 picks it up on a timer.
+
+---
+
+## 6 · Shared configuration reference
+
+**Secrets** (Settings → Secrets and variables → Actions → Secrets)
+
+| Name | Used by | Effect if absent |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | every ⚡ workflow + automerge's inert check | all agent loops inert; automerge inert |
+| `GITHUB_TOKEN` | automatic | — |
+
+**Variables** (… → Variables)
+
+| Name | Values | Effect |
+|---|---|---|
+| `AUTOMERGE_MODE` | unset (default) / `dry-run` / `live` | inert / log the PR it would merge / actually merge |
+
+**Also required, and not a secret:** the **Claude GitHub App** must be installed
+on the repo, and **branch protection on `main`** must (a) require the CI checks
+and (b) permit the Actions identity to merge if auto-merge is to work — the
+automated review verdict is a *comment*, not an approving review, so protection
+requiring a human review will refuse the merge (the loop then posts one
+`pipeline-automerge-blocked` note rather than silently retrying forever).
+
+**Labels** — 19 created by `scripts/setup-labels.sh` (via the `setup-labels.yml`
+workflow, idempotent `--force`): `proposal`, `status:draft|approved|rejected|building|built`,
+`needs-human`, `no-auto-resolve`, `no-auto-merge`, `human-merge-ready`,
+`community-feedback`, and eight `theme:*` labels. `changelog-autofill` is
+created at runtime by its own workflow. `allow-security-floor-lower` is created
+by nothing — see [§7](#7-known-gaps).
+
+**External dependencies**, all SHA-pinned with a trailing version comment and
+kept fresh by Dependabot (`github-actions` weekly; `npm` grouped monthly, to
+keep Dependabot PRs from streaming through the PR-review worker and spending the
+Max pool):
+
+| Action | Pin |
+|---|---|
+| `actions/checkout` | v7.0.1 |
+| `actions/setup-node` | v7.0.0 (Node 24; `engines` says `>=22`) |
+| `actions/cache` | v6.1.0 |
+| `anthropics/claude-code-action` | v1.0.191 |
+
+**`.github/CODEOWNERS`** routes review for the security spine (`/.github/`,
+`/scripts/`, the tool registry, the module manifest, schema fragments,
+`security-floor.json`, `SECURITY.md`). It is **advisory** — derived by hand from
+the 🔒 markers in `docs/agents/module-map.md`, and a path that no longer exists
+is silently ignored by GitHub, so a move can quietly drop the routing.
+
+---
+
+## 7 · Known gaps
+
+Found while writing this reference. Each is a real divergence between intent and
+wiring; none is fixed here, because each is a behaviour change that deserves its
+own PR.
+
+1. **`allow-security-floor-lower` is never created.** `ci.yml` reads it, but it
+   is not in `scripts/setup-labels.sh`'s 19 labels. A maintainer exercising the
+   documented override must create the label by hand first, and will most likely
+   discover this mid-incident. *Fix: one `label` line in `setup-labels.sh`.*
+2. **`REQUIRE_DATABASE_URL` is documented as CI behaviour but is set nowhere.**
+   `scripts/check-db-coverage.mjs` says setting it to `1` is "what CI does, so a
+   misconfigured CI job that silently stopped running the DB half is caught
+   rather than passing quietly" — no workflow sets it. The intended guard
+   against a `build` job that loses its `DATABASE_URL` and silently skips every
+   DB test is therefore **not armed**. *Fix: add `REQUIRE_DATABASE_URL: '1'` to
+   `ci.yml`'s `build` job env (and the build worker's, which runs the same
+   gate).*
+3. **`ci.yml` had no prose documentation before this file.**
+   `scripts/check-context-pack.mjs` justifies excluding workflows from the
+   context-pack gate on the grounds that "workflows are already documented far
+   better in `docs/PIPELINE.md`" — true of the pipeline loops, but `PIPELINE.md`
+   never covered the CI gate itself, the gate scripts, or the delivery path.
+   That is the hole this document fills; keep it filled.
+4. **`CODEOWNERS` and `module-map.md`'s 🔒 markers are hand-synced.** Nothing
+   gates the pair, so a 🔒 added without a `CODEOWNERS` line silently drops
+   review routing.
+5. **This file is not a governance path.** The auto-merge matcher governs
+   `CLAUDE.md`, `docs/PIPELINE.md`, `docs/SECURITY.md` and `docs/VISION.md`, so
+   a bot PR editing *those* always waits for a human — but a bot PR editing
+   `docs/CICD.md` can auto-merge. That is arguably correct (this file is a
+   reference; the workflow files are the authority) and arguably not (a
+   confidently wrong CI/CD reference misleads exactly the cold agent sessions
+   it is written for). Left as a maintainer decision — adding it to the matcher
+   is a one-line change in `pipeline-pr-automerge.yml`, which is itself a
+   governance path and so needs a human merge either way.
+
+---
+
+## 8 · Extraction guide
+
+What it would take to lift this into a reusable pipeline for other repos.
+
+### 8.1 Portability tiers
+
+| Tier | Meaning | Workflows |
+|---|---|---|
+| **A — portable as-is** | no repo knowledge beyond `GITHUB_TOKEN` | `ci-retry.yml`, `pipeline-build-retry.yml`, `branch-janitor.yml` |
+| **B — portable with inputs** | logic is generic; label names, identities and thresholds are the only couplings | `pipeline-groundskeeper.yml`, `pipeline-pr-automerge.yml`, `pipeline-outcomes.yml`, `setup-labels.yml`, `changelog-coverage.yml` |
+| **C — portable with inputs + a project-supplied gate** | as B, plus each needs to know how to run *this project's* checks and services | `pipeline-build.yml`, `pipeline-pr-review.yml`, `pipeline-pr-autofix.yml`, `pipeline-pr-revise.yml`, `pipeline-pr-conflict.yml`, `changelog-autofill.yml` |
+| **D — project-specific by nature** | the definition of green for one codebase | `ci.yml`, `scripts/check-*.mjs` |
+
+Tier D is not a failure of the design — it is the correct boundary. The
+reusable artifact should *call* a project's gate, never contain it.
+
+### 8.2 The coupling-point inventory
+
+Everything a fork would have to change, grouped by kind. This is the parameter
+list for the reusable version.
+
+**Vocabulary** (appears in ~85 places for `needs-human` alone)
+
+| Coupling | Current value |
+|---|---|
+| lane labels | `status:draft|approved|rejected|building|built` |
+| stop label | `needs-human` |
+| pin-out labels | `no-auto-resolve`, `no-auto-merge` |
+| routing label | `human-merge-ready` |
+| override label | `allow-security-floor-lower` |
+| PR→issue contract | body matches `Closes #<n>` |
+| trigger label | `status:approved` starts a build |
+
+**Identity**
+
+| Coupling | Current value |
+|---|---|
+| build-worker identity auto-merge requires | `claude[bot]` / `app/claude` |
+| review-verdict author auto-merge trusts | `github-actions[bot]` |
+| maintainer allowlist (conflict resolver) | `MAINTAINER_LOGINS: 'swampratnz'` |
+| CODEOWNERS owner | `@swampratnz` |
+
+**Project gate** (the Tier-C dependency)
+
+| Coupling | Current value |
+|---|---|
+| package manager + node | `npm ci`, Node 24 |
+| gate commands | `typecheck`, `lint`, `format:check`, `migrate`, `test`, `build`, `test:security`, `context:check`, `imports:check` |
+| service container | `pgvector/pgvector:pg16` + its health options |
+| boot-required env | `DISPLAY_TIMEZONE`, `DISPLAY_LOCALE`, `DISCORD_*`, `WHATSAPP_PROVIDER`, `EMBEDDING_MODEL` |
+| cache path/key | `node_modules/@huggingface/transformers/.cache` |
+| conflict fast path | knows `tests/security-floor.json` is regenerable via `test:security:fix` |
+
+**Policy**
+
+| Coupling | Current value |
+|---|---|
+| governance paths (never auto-merged) — the literal matcher | `^(\.github/\|scripts/\|CLAUDE\.md$\|docs/PIPELINE\.md$\|docs/SECURITY\.md$\|docs/VISION\.md$\|src/module/agentModule\.ts$\|package(-lock)?\.json$\|tsconfig([.-].*)?\.json$\|eslint\.config\.\|\.prettier)` |
+| attempt caps | 2 (agent loops), 3 (build reruns), 2 (CI reruns) |
+| staleness threshold | 4h (groundskeeper) |
+| schedules | hourly / 15-min / daily 19:17+19:47 UTC / weekly Mon |
+| model + turns | Sonnet; 300/200/60/30 |
+| timeouts | 180/45/30/20/15/10/5 min |
+| changelog date rule | NZ calendar day, not UTC |
+
+**Prose** — the agent prompts embedded in the ⚡ workflows are the largest
+single chunk of repo-specific content (the build prompt alone is several hundred
+lines) and carry project conventions, the context-pack pointer, and the
+security posture. These want to be **files a project supplies**, not workflow
+literals.
+
+### 8.3 Proposed shape of the reusable solution
+
+Three artifacts, in the order they pay off:
+
+**1 · A composite action for the agent-run triad.** M7 (checkpoint), M8
+(verify-else-escalate) and the cost/job-summary steps are near-identical in
+build, autofix, revise and conflict, and their bugs have historically been
+*fixed in one copy and not the others*. Extract:
+
+```
+actions/agent-run/action.yml
+  inputs: prompt-file, allowed-tools, max-turns, model,
+          push-target (branch | pinned HEAD), marker-prefix,
+          verify-command, escalation-label
+```
+
+This alone removes the highest-risk duplication in the repo.
+
+**2 · Reusable workflows (`workflow_call`) for Tiers A and B.** The
+deterministic loops carry no prompts and no project gate, so they parameterise
+cleanly:
+
+```yaml
+uses: <org>/agent-pipeline/.github/workflows/automerge.yml@v1
+with:
+  build-worker-identity: 'claude[bot]'
+  reviewer-identity: 'github-actions[bot]'
+  governance-paths: |
+    .github/**
+    scripts/**
+  labels-stop: 'needs-human,no-auto-merge'
+  mode-variable: AUTOMERGE_MODE
+```
+
+**3 · A "project gate" contract for Tier C.** The clean seam is that a
+consuming repo declares its gate once and every agent loop calls it:
+
+```yaml
+# .github/pipeline.yml (consumed by the reusable workflows)
+gate:
+  setup: npm ci
+  commands: [typecheck, lint, format:check, migrate, test, build, test:security]
+  services: [{ image: pgvector/pgvector:pg16, health: pg_isready }]
+  env: { DISPLAY_TIMEZONE: Pacific/Auckland, ... }
+prompts:
+  build: .github/prompts/build.md
+  review: .github/prompts/review.md
+vocabulary:
+  stop-label: needs-human
+  ...
+```
+
+The gate scripts (Tier D) are better shipped as an **optional starter kit** a
+project copies and owns — `security-floor.json`, the context pack, the import
+direction rules are patterns worth teaching, but a reusable pipeline must not
+require them.
+
+### 8.4 What must not become a parameter
+
+These are the invariants that make the system safe. A reusable version that lets
+a consumer weaken them has extracted the shape and lost the substance:
+
+1. **Fork PRs never receive secrets or run agent code.** Not an input.
+2. **The identity distinction is structural** — the agent must not be able to
+   write into the channels the deterministic steps read (handoff notes, verdict
+   stamps, lane labels).
+3. **Governance paths are always human-merged.** A pipeline that can auto-merge
+   a change to its own gates has no gates. The *list* is a parameter; having a
+   non-empty list must not be.
+4. **Verify-else-escalate must fail loudly.** A run that produced nothing must
+   never be green.
+5. **Branch protection is the enforceable backstop**, and tool allowlists are
+   defence in depth on top of it — never a substitute. Any packaged version must
+   say so as loudly as the workflows currently do.
+6. **Attempt caps exist**, with escalation to a human, on every loop that can
+   re-trigger itself.
+
+### 8.5 Suggested extraction order
+
+1. The composite action (§8.3.1) — in-repo, no consumer needed, immediately
+   removes four-way duplication.
+2. Tier A workflows — trivially portable, prove the packaging.
+3. Tier B, starting with the groundskeeper and outcomes loops (read-mostly, low
+   blast radius) and ending with auto-merge (highest stakes).
+4. Tier C, once the prompt-as-file seam exists.
+5. The gate-script starter kit last, as documentation-plus-code rather than a
+   dependency.

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -82,14 +82,23 @@ pool.
 | **`pipeline-pr-review.yml`** ⚡ | `pull_request` opened/synchronize/reopened/ready_for_review | per-PR, **cancel-in-progress** | `contents:read`, `pull-requests:write`, `actions:write`, `id-token:write` | 20 min | the secret |
 | `pipeline-pr-autofix.yml` ⚡ | `workflow_run` [CI] completed | per head branch | `contents`,`issues`,`pull-requests`:write, `id-token:write` | 45 min | the secret |
 | `pipeline-pr-revise.yml` ⚡ | `workflow_dispatch` (`pr_number`) | per-PR | as autofix | 45 min | the secret |
-| `pipeline-pr-conflict.yml` ⚡ | push `main`, PR opened/ready, hourly, `workflow_dispatch` (`resolve_matrix`) | per-run / per-PR | discover: read; resolve: write set | 10 min (discover) / 45 min (resolve) | the secret |
-| `pipeline-pr-automerge.yml` | `*/15 * * * *`, `workflow_run` [CI, PR review], dispatch | single group | `contents`,`pull-requests`:write | 10 min | secret **and** `vars.AUTOMERGE_MODE` |
+| `pipeline-pr-conflict.yml` ⚡ | push `main`, PR opened/ready, hourly, `workflow_dispatch` (`resolve_matrix`) | per-run / per-PR | **discover** (job override): `contents`,`pull-requests`:read + `actions:write`; **resolve** (inherits): `contents`,`issues`,`pull-requests`:write, `id-token:write` | 10 min (discover) / 45 min (resolve) | the secret |
+| `pipeline-pr-automerge.yml` | `*/15 * * * *`, `workflow_run` [CI, PR review], dispatch | single group | `contents`,`issues`,`pull-requests`:write, `actions:write` | 10 min | secret **and** `vars.AUTOMERGE_MODE` |
 | `pipeline-groundskeeper.yml` | `17 * * * *`, dispatch | single group | `issues:write`, `pull-requests:read` | 10 min | always |
 | `pipeline-outcomes.yml` | `23 20 * * 1`, dispatch (`window_days`) | single, cancel | `contents:read`, `issues:write`, `pull-requests:read` | 10 min | always |
 | `changelog-coverage.yml` | `17 19 * * *`, dispatch | single, cancel | `contents:read`, `issues:write`, `pull-requests:read` | 10 min | always |
 | `changelog-autofill.yml` ⚡ | `47 19 * * *`, dispatch | single group | `contents`,`pull-requests`:write, `id-token:write` | 30 min | the secret |
 | `branch-janitor.yml` | `0 3 * * 1`, dispatch (`dry_run`, `extra`) | single group | `contents:write`, `pull-requests:read` | 15 min | always |
 | `setup-labels.yml` | `workflow_dispatch` only | — | `contents:read`, `issues:write` | — | manual |
+
+Two notes on that permissions column. A **job-level `permissions:` block
+replaces the workflow-level grant outright** rather than adding to it — which is
+what lets the conflict resolver keep every write scope confined to the job that
+runs the agent, while its discover job holds read plus the single `actions:write`
+it needs to self-dispatch. And auto-merge's `issues:write` is not an oversight:
+`gh label create` (ensuring `human-merge-ready` exists) goes through the issues
+API, and `actions:write` is how it dispatches the conflict resolver after a
+merge.
 
 **The single kill switch:** remove the `CLAUDE_CODE_OAUTH_TOKEN` secret and
 every ⚡ workflow goes inert (they log a notice and skip). There is no per-loop

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -81,8 +81,8 @@ pool.
 | `pipeline-build-retry.yml` | `workflow_run` [build] completed | — | `actions:write` | 5 min | always |
 | **`pipeline-pr-review.yml`** ⚡ | `pull_request` opened/synchronize/reopened/ready_for_review | per-PR, **cancel-in-progress** | `contents:read`, `pull-requests:write`, `actions:write`, `id-token:write` | 20 min | the secret |
 | `pipeline-pr-autofix.yml` ⚡ | `workflow_run` [CI] completed | per head branch | `contents`,`issues`,`pull-requests`:write, `id-token:write` | 45 min | the secret |
-| `pipeline-pr-revise.yml` ⚡ | `workflow_dispatch` (`pr_number`) | per-PR | as autofix | — | the secret |
-| `pipeline-pr-conflict.yml` ⚡ | push `main`, PR opened/ready, hourly, `workflow_dispatch` (`resolve_matrix`) | per-run / per-PR | discover: read; resolve: write set | — | the secret |
+| `pipeline-pr-revise.yml` ⚡ | `workflow_dispatch` (`pr_number`) | per-PR | as autofix | 45 min | the secret |
+| `pipeline-pr-conflict.yml` ⚡ | push `main`, PR opened/ready, hourly, `workflow_dispatch` (`resolve_matrix`) | per-run / per-PR | discover: read; resolve: write set | 10 min (discover) / 45 min (resolve) | the secret |
 | `pipeline-pr-automerge.yml` | `*/15 * * * *`, `workflow_run` [CI, PR review], dispatch | single group | `contents`,`pull-requests`:write | 10 min | secret **and** `vars.AUTOMERGE_MODE` |
 | `pipeline-groundskeeper.yml` | `17 * * * *`, dispatch | single group | `issues:write`, `pull-requests:read` | 10 min | always |
 | `pipeline-outcomes.yml` | `23 20 * * 1`, dispatch (`window_days`) | single, cancel | `contents:read`, `issues:write`, `pull-requests:read` | 10 min | always |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -5,6 +5,12 @@ autonomously while keeping a human as the merge gate. Everything coordinates
 **through GitHub issues + labels** (there is no direct session-to-session
 channel — the repo is the bus).
 
+> This document is the **why**: what each loop is for, the ownership rules, and
+> the incidents that shaped them. For the **what** — every workflow's trigger,
+> permissions, concurrency and timeout in one table, the CI gate and its check
+> scripts, the mechanisms shared across loops, and which parts are portable to
+> another repo — see [`docs/CICD.md`](CICD.md).
+
 It started as five concurrent Claude Code sessions each running a recurring
 `/loop`, and the prompts below still describe them that way. Most have since
 moved to GitHub Actions, which is why this document talks about both: the


### PR DESCRIPTION
## Summary

Adds `docs/CICD.md`, a mechanical reference for the whole CI/CD system, as the prerequisite for extracting the reusable half of this pipeline into something another repo can consume.

`docs/PIPELINE.md` already documents the agent loops well, but it is a **why** document — the incidents, the ownership rules, the loop prompts. Three things had no prose home anywhere:

- **`ci.yml` itself** — the three-job split and why each boundary exists (`security-invariants` deliberately leaving `DATABASE_URL` unset; `lint` holding the pure static gates), the dummy-credential env contract, the embedding-model cache placement after `npm ci`, and the security-floor lowering guard (`SECURITY_FLOOR_BASELINE_REF` / `allow-security-floor-lower` / `fetch-depth: 0`).
- **The `scripts/check-*.mjs` family as a family** — what each enforces, which manifest it reads, its exit behaviour, and why the two `--write` fixers differ on purpose (a count is derivable, a description is not).
- **The mechanisms shared across workflows** — the inert gate, fork safety, the two-hop `workflow_dispatch`, never-trust-the-payload, the eligibility contract, marker-comment attempt caps, the deterministic checkpoint, verify-else-escalate, deterministic lane ownership, least-privilege tool grants, and the verdict-token contract. `PIPELINE.md` describes these case-by-case; nothing described them as a set, which is the condition that let the #731 verdict fix land in two of the three consumers.

The document contains: a full inventory of all 15 workflows (trigger, concurrency, permissions, timeout, model, turn budget), the CI gate in detail, the gate scripts, the eleven shared mechanisms, the three-identity model and what depends on telling them apart, a marker-comment registry, an escalation/retry map, the delivery path (Layer 3 is pull-based and runs off GitHub entirely), and a shared-configuration reference for secrets/variables/labels/pinned actions.

Its final section is the **extraction guide**: portability tiers per workflow (A portable as-is → D project-specific by nature), the coupling-point inventory grouped as vocabulary / identity / project gate / policy / prompts, a proposed shape (a composite action for the agent-run triad, `workflow_call` for the deterministic loops, a declared project-gate contract for the rest), the invariants that must never become parameters, and a suggested extraction order.

Also cross-linked from `README.md`, `CLAUDE.md` and the top of `docs/PIPELINE.md`, with the split stated explicitly: `PIPELINE.md` is the why, `CICD.md` is the what, and the workflow file wins over both on any factual disagreement.

### Gaps recorded, not fixed

Four divergences between intent and wiring turned up while writing this. None is fixed here — each is a behaviour change deserving its own PR:

1. `allow-security-floor-lower` is read by `ci.yml` but created by nothing (`setup-labels.sh` has 19 labels; this is not one). The documented override needs a hand-created label first.
2. `REQUIRE_DATABASE_URL` is described in `check-db-coverage.mjs` as "what CI does", but no workflow sets it — so the guard against a `build` job that silently loses its `DATABASE_URL` and skips every DB test is **not armed**.
3. `CODEOWNERS` and the 🔒 markers in `module-map.md` are hand-synced with no gate.
4. `docs/CICD.md` is not itself a governance path for auto-merge, unlike the other governance docs. Flagged as a maintainer decision.

## Security / privacy impact

None. Documentation only — no workflow, script, or source file is changed, so no trigger, permission, tool grant, or gate behaviour moves. The document describes existing guardrails; it adds none and weakens none. It contains no secrets, tokens, env values, or hostnames: secrets are named (`CLAUDE_CODE_OAUTH_TOKEN`, `AUTOMERGE_MODE`) without values, and every configuration value quoted is already public in the repo.

One deliberate editorial choice worth review: §4.1 (M10) and §8.4 restate, rather than soften, that the tool allowlists are defence in depth and **branch protection on `main` is the enforceable stop** — the same framing the workflow headers use, so a reader extracting this cannot mistake the allowlist for the guarantee.

## How verified

- `npm run format:check` — green on all four changed files. Note: the local `node_modules` carried prettier 3.8.1 against the lockfile's 3.9.4, which reports two false positives on files this PR does not touch (`src/module/context/linkCheck.ts`, `tests/tools.test.ts` — a union-formatting change between versions). Re-run under the pinned `prettier@3.9.4`: all matched files clean, including the two. No unrelated files were "fixed".
- `npm run context:check` — 24/24 required paths covered, sorted, no stubs.
- `npm run imports:check` — 68 files obey the composition-direction rules.
- `typecheck` / `test` / `build` not run: the diff is four Markdown files and touches no TypeScript, no schema, and no workflow. CI runs the full gate regardless.
- Every factual claim was checked against the workflow files rather than against `PIPELINE.md` — triggers, `permissions:` blocks, `concurrency` groups, timeouts, `--max-turns` / `--model` per workflow, the literal governance-path regex, `MAINTAINER_LOGINS`, the marker strings, the pinned action SHAs, and the label list from `setup-labels.sh`. The four gaps above are what that cross-check surfaced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AA6sUQWj4645XiRdoJRFHt)_