### PR TITLE
Extract the agent checkpoint and verify steps into shared composite actions

### DIFF
--- a/.github/actions/agent-checkpoint/action.yml
+++ b/.github/actions/agent-checkpoint/action.yml
@@ -1,0 +1,246 @@
+name: Agent checkpoint
+description: >-
+  Push work an agent COMMITTED but never PUSHED, after the agent step has
+  exited. Fast-forward only; a diverged remote is parked on a side ref rather
+  than rewritten. Shared by the build worker and the three PR-repair loops.
+
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS (see docs/CICD.md §4.1 M7, docs/PIPELINE.md)
+#
+# Prompt-only compliance is unreliable. Agents have finished whole builds and
+# whole conflict resolutions and then ended their turn without pushing — PR
+# #606 ("I'll wait for the monitor notification before continuing…"), PR #609,
+# and issue #633's third attempt (implementation done, gates green, zero
+# pushes). Everything died with the runner. This step runs AFTER the agent
+# process is gone and publishes whatever it committed.
+#
+# WHY IT IS SHARED
+#
+# Four workflows carried near-identical copies of this logic and they DRIFTED.
+# At extraction time the three PR loops had two hardenings the build worker
+# never received:
+#
+#   * the 40-hex guard on the `gh api` result — a failed/404 lookup passes an
+#     error body straight through `--jq` (the literal "null"), and an unguarded
+#     value diverts a perfectly fast-forwardable recovery onto a side ref;
+#   * the `merge-base --is-ancestor` pre-check, which decides divergence
+#     BEFORE attempting the push instead of inferring it from a push failure.
+#
+# Conversely the build worker had a fallback the other three lacked: if the
+# push to the work branch fails at all, try the side ref. This action keeps
+# BOTH — the pre-check and the fallback — so every caller now gets the union,
+# which is the entire point of having one copy.
+#
+# WHY CALLERS MUST PIN THIS TO THE DEFAULT BRANCH, NOT `./`
+#
+# A local `uses: ./.github/actions/...` is resolved from the WORKSPACE at the
+# moment the step runs. The three PR loops check out the pull request's head
+# branch, and the agent then edits that tree — so `./` would let PR-head
+# content define the step that decides whether the agent's work is published
+# and whether the run escalates. That inverts the trust model: today these
+# workflow FILES always come from the default branch (their triggers are
+# issues / workflow_run / workflow_dispatch), and this action must inherit
+# that property. Callers therefore use the repo-qualified form:
+#
+#   uses: swampratnz/community-agent/.github/actions/agent-checkpoint@main
+#
+# which the runner fetches from `main` independently of the workspace.
+# tests/agentRunActions.test.ts pins that (a SECURITY: test) — a caller that
+# regresses to `./` fails the suite.
+#
+# TOKEN NOTE: this pushes with the CALLER'S GITHUB_TOKEN, deliberately. It is
+# valid for the whole job (the agent's App token expires after ~1h against a
+# 180-min build budget), and a GITHUB_TOKEN push starts no workflow run — which
+# is what makes checkpointing a branch free of side effects.
+# ---------------------------------------------------------------------------
+
+inputs:
+  github-token:
+    description: 'Token used for the push and the `gh` calls (the job GITHUB_TOKEN).'
+    required: true
+  repository:
+    description: 'owner/repo to push to.'
+    required: false
+    default: ${{ github.repository }}
+  branch:
+    description: >-
+      Work branch to checkpoint. Leave empty to detect it from HEAD (the build
+      worker's case — the agent creates the branch at run time).
+    required: false
+    default: ''
+  head-before:
+    description: >-
+      HEAD sha recorded before the agent ran. When set, "the agent committed
+      nothing" is decided by comparing against it. Leave empty to decide by
+      "is HEAD ahead of the default branch" instead (the build worker's case,
+      where there is no pre-agent commit to compare with).
+    required: false
+    default: ''
+  default-branch:
+    description: 'Trunk name, used for the ahead-of-trunk test and as a refusal guard.'
+    required: false
+    default: 'main'
+  pr-number:
+    description: >-
+      PR to comment on when work is recovered. Leave empty to skip the comment
+      (the build worker has no PR yet at checkpoint time).
+    required: false
+    default: ''
+  checkpoint-marker:
+    description: 'Marker HTML comment, emitted as line 1 so pipeline-outcomes.mjs can count it.'
+    required: false
+    default: ''
+  loop-name:
+    description: 'How the loop refers to itself in the recovery comment, e.g. "autofix agent".'
+    required: false
+    default: 'agent'
+  subject:
+    description: 'Subject of the "… was not verified by the agent" sentence.'
+    required: false
+    default: 'This'
+
+outputs:
+  ref:
+    description: 'Branch or side ref the work now lives on (empty if nothing was checkpointed).'
+    value: ${{ steps.checkpoint.outputs.ref }}
+  sha:
+    description: 'Commit sha that ref points at (empty if nothing was checkpointed).'
+    value: ${{ steps.checkpoint.outputs.sha }}
+  checkpointed:
+    description: "'true' only when this step actually pushed something."
+    value: ${{ steps.checkpoint.outputs.checkpointed }}
+
+runs:
+  using: composite
+  steps:
+    - id: checkpoint
+      shell: bash
+      # Every input reaches the script through env, never ${{ }}-interpolated
+      # into the body: a git ref name may legally contain shell metacharacters,
+      # and template interpolation splices them in (with the token live) before
+      # the shell parses the line — the classic Actions injection.
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        BRANCH: ${{ inputs.branch }}
+        HEAD_BEFORE: ${{ inputs.head-before }}
+        DEFAULT_BRANCH: ${{ inputs.default-branch }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        CHECKPOINT_MARKER: ${{ inputs.checkpoint-marker }}
+        LOOP_NAME: ${{ inputs.loop-name }}
+        SUBJECT: ${{ inputs.subject }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        # Every exit path goes through finish(), so each output key is written
+        # EXACTLY once. Writing defaults up-front and overwriting them later
+        # would leave duplicate keys in $GITHUB_OUTPUT and lean on last-wins
+        # parsing, which is not a contract worth betting a recovery path on.
+        finish() { # ref sha checkpointed
+          {
+            echo "ref=$1"
+            echo "sha=$2"
+            echo "checkpointed=$3"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+
+        branch="${BRANCH}"
+        if [ -z "${branch}" ]; then
+          branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        fi
+        # Refuse to treat trunk (or a detached HEAD) as a work branch: the
+        # build worker reaches this step even when its agent never created a
+        # branch, and pushing HEAD to `main` from here is exactly the thing
+        # branch protection exists to stop.
+        if [ -z "${branch}" ] || [ "${branch}" = "HEAD" ] || [ "${branch}" = "${DEFAULT_BRANCH}" ]; then
+          echo "No work branch in the workspace — nothing to checkpoint."
+          finish "" "" false
+        fi
+
+        head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+        if [ -z "${head_sha}" ]; then
+          echo "No HEAD in the workspace — nothing to checkpoint."
+          finish "" "" false
+        fi
+
+        if [ -n "${HEAD_BEFORE}" ]; then
+          if [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
+            echo "Agent committed nothing — nothing to checkpoint."
+            finish "" "" false
+          fi
+        else
+          ahead="$(git rev-list --count "origin/${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
+          if [ "${ahead}" -eq 0 ]; then
+            echo "No commits beyond origin/${DEFAULT_BRANCH} — nothing to checkpoint."
+            finish "" "" false
+          fi
+        fi
+
+        remote_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)"
+        # A failed/404 `gh api` call can leave a NON-sha here (an error body
+        # passed straight through --jq, e.g. the literal "null"). Treat anything
+        # that is not a 40-hex sha as "remote tip unknown": blanking it skips
+        # the divergence pre-check and attempts the ordinary NON-FORCE push,
+        # which the server rejects unless it is a fast-forward.
+        if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
+
+        if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
+          echo "Agent already pushed ${head_sha} to ${branch} — nothing to checkpoint."
+          # Still report the ref: a caller's verify step uses it to find the
+          # surviving branch (the build worker's resume/recovery path).
+          finish "${branch}" "${head_sha}" false
+        fi
+
+        target="${branch}"
+        if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
+          target="${branch}-ckpt-${RUN_ID}"
+          echo "Remote ${branch} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
+        fi
+
+        push_url="https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
+        if ! git push "${push_url}" "HEAD:refs/heads/${target}" 2>/dev/null; then
+          if [ "${target}" = "${branch}" ]; then
+            # The pre-check said fast-forward but the server disagreed (a race,
+            # or a tip the API had not caught up with). Fall back to the side
+            # ref rather than losing the work — the build worker's original
+            # behaviour, kept for every caller.
+            target="${branch}-ckpt-${RUN_ID}"
+            echo "Push to ${branch} was rejected; falling back to ${target}."
+            if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
+              echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
+              finish "" "" false
+            fi
+          else
+            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
+            finish "" "" false
+          fi
+        fi
+
+        echo "Checkpointed ${head_sha} to ${target}."
+        # Written inline rather than via finish(): the recovery comment below
+        # still has to run. Nothing has written these keys on this path.
+        {
+          echo "ref=${target}"
+          echo "sha=${head_sha}"
+          echo "checkpointed=true"
+        } >> "$GITHUB_OUTPUT"
+
+        if [ -z "${PR_NUMBER}" ] || [ -z "${CHECKPOINT_MARKER}" ]; then
+          exit 0
+        fi
+
+        # Built with printf rather than an indented YAML string: the inline
+        # `--body "…"` form the four workflows used carried its own YAML block
+        # indentation into the comment, so every line after the marker arrived
+        # with ten leading spaces and GitHub rendered the explanation as a code
+        # block. The marker must stay on line 1 (handoff/outcome consumers match
+        # position, not just text).
+        {
+          printf '%s\n' "${CHECKPOINT_MARKER}"
+          printf '🤖 Recovered work the %s committed but never pushed — it ended its turn without pushing. Checkpointed `%s` to `%s`.\n\n' \
+            "${LOOP_NAME}" "${head_sha}" "${target}"
+          printf '⚠️ %s was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge.\n' \
+            "${SUBJECT}"
+        } | gh pr comment "${PR_NUMBER}" --repo "${REPOSITORY}" --body-file - || true

--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -1,0 +1,149 @@
+name: Agent verify push
+description: >-
+  Assert deterministically that an agent actually pushed something to a PR
+  branch; if it did not, label the PR for a human, explain why on the PR, and
+  FAIL the job loudly. Shared by the three PR-repair loops.
+
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS (see docs/CICD.md §4.1 M8)
+#
+# An agent that narrates work it did not do must not produce a green run. The
+# build worker learned this the expensive way: a run finished
+# conclusion=success with twelve permission denials, no branch, no PR and no
+# relabel — it described the work instead of doing it, and nothing failed. Every
+# agent loop therefore ends with a deterministic assertion on the OUTCOME
+# (did the branch tip move?), not on the agent's self-report.
+#
+# It is separate from agent-checkpoint deliberately, even though the two always
+# run together: the checkpoint may legitimately publish work AND the verify may
+# still escalate, because checkpointed work never cleared the agent's own gate.
+# Merging them would make "recovered" and "succeeded" the same outcome, which
+# is precisely the distinction pipeline-outcomes.yml reports on.
+#
+# The build worker does NOT use this action. Its verify step asserts a PR
+# exists rather than a commit landing, and additionally owns lane labels, the
+# resume pointer and the recovery-PR path — a different contract that happens
+# to share a name.
+#
+# WHY CALLERS MUST PIN THIS TO THE DEFAULT BRANCH, NOT `./` — see the long
+# note in ../agent-checkpoint/action.yml. It matters more here: this is the
+# step that decides whether a run escalates, so PR-head content must never be
+# able to define it.
+# ---------------------------------------------------------------------------
+
+inputs:
+  github-token:
+    description: 'Token for the `gh` calls (the job GITHUB_TOKEN).'
+    required: true
+  repository:
+    description: 'owner/repo the PR belongs to.'
+    required: false
+    default: ${{ github.repository }}
+  pr-number:
+    description: 'PR whose head is being checked.'
+    required: true
+  head-before:
+    description: 'Head sha recorded before the agent ran. An unchanged tip means the agent pushed nothing.'
+    required: true
+  success-message:
+    description: 'Logged when the tip moved.'
+    required: false
+    default: 'Agent pushed a change; CI will re-run on the new commit.'
+  error-message:
+    description: 'Emitted as a ::error:: annotation when the tip did not move.'
+    required: false
+    default: 'Agent produced no new commit.'
+  escalation-label:
+    description: 'Label added to the PR on failure.'
+    required: false
+    default: 'needs-human'
+  escalate-marker:
+    description: 'Marker HTML comment, emitted as line 1 so pipeline-outcomes.mjs can count the escalation.'
+    required: true
+  escalation-body:
+    description: 'Loop-specific prose explaining the escalation. Emitted verbatim under the marker.'
+    required: true
+  summary-title:
+    description: "<details> summary for the agent's captured final message."
+    required: false
+    default: "Agent's final summary (what it says blocked it)"
+  no-summary-note:
+    description: >-
+      Printed when no agent summary could be captured. Leave empty to print
+      nothing at all (a silent stop is itself the tell).
+    required: false
+    default: ''
+  execution-file:
+    description: "Path to the agent step's execution log, for extracting its final message."
+    required: false
+    default: ''
+  fallback-execution-file:
+    description: 'Second execution log to try when the first is empty (the conflict resolver has two agent paths).'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      # Inputs reach the script through env, never ${{ }}-interpolated into the
+      # body — see ../agent-checkpoint/action.yml for why.
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        HEAD_BEFORE: ${{ inputs.head-before }}
+        SUCCESS_MESSAGE: ${{ inputs.success-message }}
+        ERROR_MESSAGE: ${{ inputs.error-message }}
+        ESCALATION_LABEL: ${{ inputs.escalation-label }}
+        ESCALATE_MARKER: ${{ inputs.escalate-marker }}
+        ESCALATION_BODY: ${{ inputs.escalation-body }}
+        SUMMARY_TITLE: ${{ inputs.summary-title }}
+        NO_SUMMARY_NOTE: ${{ inputs.no-summary-note }}
+        EXECUTION_FILE: ${{ inputs.execution-file }}
+        FALLBACK_EXECUTION_FILE: ${{ inputs.fallback-execution-file }}
+      run: |
+        set -euo pipefail
+
+        # Read the branch's current remote tip via the API rather than
+        # `git fetch`: every caller checks out with persist-credentials:false,
+        # so there is no git credential in .git/config for a fetch, and this
+        # avoids reintroducing one. head-before was captured from the local
+        # checkout (`git rev-parse HEAD` needs no credential).
+        after="$(gh pr view "${PR_NUMBER}" --repo "${REPOSITORY}" --json headRefOid --jq '.headRefOid')"
+        if [ "${after}" != "${HEAD_BEFORE}" ]; then
+          echo "${SUCCESS_MESSAGE}"
+          exit 0
+        fi
+
+        echo "::error::${ERROR_MESSAGE}"
+        gh pr edit "${PR_NUMBER}" --repo "${REPOSITORY}" --add-label "${ESCALATION_LABEL}" || true
+
+        # Surface the agent's OWN final message (best-effort) so a maintainer
+        # sees the blocker instead of reverse-engineering it from run logs —
+        # the transparency the build worker got in #251. A silent stop leaves
+        # no summary, which is itself diagnostic: it usually means a gate the
+        # agent could not make green, or a change it is not allowed to push.
+        summary=""
+        exec_file="${EXECUTION_FILE}"
+        if [ -z "${exec_file}" ]; then exec_file="${FALLBACK_EXECUTION_FILE}"; fi
+        if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
+          summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
+        fi
+
+        # printf '%s' throughout: the body and the captured summary are data,
+        # never format strings (the summary is agent-authored text that can
+        # contain % sequences).
+        {
+          printf '%s\n' "${ESCALATE_MARKER}"
+          printf '%s\n' "${ESCALATION_BODY}"
+          if [ -n "${summary}" ]; then
+            printf '\n<details><summary>%s</summary>\n\n' "${SUMMARY_TITLE}"
+            printf '%s\n' "${summary}"
+            printf '\n</details>\n'
+          elif [ -n "${NO_SUMMARY_NOTE}" ]; then
+            printf '\n%s\n' "${NO_SUMMARY_NOTE}"
+          fi
+        } | gh pr comment "${PR_NUMBER}" --repo "${REPOSITORY}" --body-file - || true
+
+        exit 1

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -482,55 +482,34 @@ jobs:
 
       # Deterministic safety net for the incremental-push mandate: agents have
       # completed multi-hour builds and still never pushed (issue #633's third
-      # attempt: implementation done, gates green, zero pushes — everything
-      # died with the runner). Prompt-only compliance is unreliable, so after
-      # the agent has EXITED, push whatever it committed. This is the #663
-      # adversarial review's own recommended shape: a post-step publish with
-      # the job's GITHUB_TOKEN (valid for the whole job, unlike the ~1h App
-      # token), no adversarial-exfil window (the agent process is gone), and
-      # branch pushes trigger no workflows. If the remote branch exists with
-      # different history (a prior attempt), the checkpoint goes to a unique
-      # -ckpt-<run_id> ref instead of force-pushing over anything.
+      # attempt: implementation done, gates green, zero pushes — everything died
+      # with the runner). Prompt-only compliance is unreliable, so after the
+      # agent has EXITED, push whatever it committed.
+      #
+      # Shared with the three PR-repair loops since the extraction — the copies
+      # had drifted, and this worker's was the one MISSING the 40-hex guard on
+      # the `gh api` lookup and the ancestor pre-check. It has no PR yet, so it
+      # passes no pr-number (no recovery comment) and no head-before (the
+      # "did the agent commit anything" test falls back to "is HEAD ahead of
+      # main"). Pinned to @main, never `./` — see the action's header.
       - name: Checkpoint unpushed work (deterministic)
+        id: checkpoint
         if: always() && env.HAS_TOKEN == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-          if [ -z "${branch}" ] || [ "${branch}" = "main" ] || [ "${branch}" = "HEAD" ]; then
-            echo "No work branch in the workspace — nothing to checkpoint."; exit 0
-          fi
-          ahead="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
-          if [ "${ahead}" -eq 0 ]; then
-            echo "No commits beyond origin/main — nothing to checkpoint."; exit 0
-          fi
-          head_sha="$(git rev-parse HEAD)"
-          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)"
-          if [ "${remote_sha}" = "${head_sha}" ]; then
-            echo "Branch ${branch} already pushed at ${head_sha}.";
-            echo "CKPT_REF=${branch}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if git push "${push_url}" "HEAD:refs/heads/${branch}" 2>/dev/null; then
-            echo "Checkpointed ${branch} at ${head_sha}."
-            echo "CKPT_REF=${branch}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
-          else
-            alt="${branch}-ckpt-${{ github.run_id }}"
-            if git push "${push_url}" "HEAD:refs/heads/${alt}"; then
-              echo "Remote ${branch} diverged; checkpointed to ${alt} at ${head_sha}."
-              echo "CKPT_REF=${alt}" >> "$GITHUB_ENV"; echo "CKPT_SHA=${head_sha}" >> "$GITHUB_ENV"
-            else
-              echo "::warning::Checkpoint push failed — unpushed work will die with this runner."
-            fi
-          fi
+        uses: swampratnz/community-agent/.github/actions/agent-checkpoint@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify a PR was produced (else escalate + fail loudly)
         id: verify
         if: always() && env.HAS_TOKEN == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The surviving-branch pointer this step publishes, from the shared
+          # checkpoint action. Previously the checkpoint step wrote these two
+          # straight to $GITHUB_ENV; an action reports them as outputs, so they
+          # are re-bound here and the script below reads them unchanged.
+          CKPT_REF: ${{ steps.checkpoint.outputs.ref }}
+          CKPT_SHA: ${{ steps.checkpoint.outputs.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -312,93 +312,43 @@ jobs:
       # agent against the same long gate, so it carries the same risk and gets
       # the same backstop, mirroring the build worker's checkpoint (#633/#682).
       #
-      # Safe by construction: runs only AFTER the agent has exited (no process
-      # left to influence it or read the token), uses the job's GITHUB_TOKEN
-      # (valid for the whole job, unlike the agent's ~1h App token), and only
-      # ever FAST-FORWARDS the PR branch — if the remote moved under us the
-      # work is parked on a side ref rather than rewriting someone else's push.
       # Placed BEFORE the verify step so a successful recovery is seen as the
       # new commit it is.
+      #
+      # Deterministic recovery + assertion. Both are shared with the build
+      # worker and the other two PR-repair loops — see
+      # .github/actions/agent-checkpoint/action.yml for why one copy exists and
+      # why these are pinned to @main rather than referenced as `./`: this job
+      # checks out the PULL REQUEST'S head and the agent edits that tree, so a
+      # local reference would let PR content define the step that publishes the
+      # agent's work and the step that decides whether to escalate.
       - name: Checkpoint unpushed work (deterministic)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Passed via env, never ${{ }}-interpolated into the script body: a
-          # git ref name may legally contain shell metacharacters. Uses the
-          # same source expression as the checkout above rather than the
-          # job-level HEAD_BRANCH, so this step is self-contained.
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
-        run: |
-          set -euo pipefail
-          n="${{ steps.pr.outputs.number }}"
-          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
-          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
-            echo "Agent committed nothing — nothing to checkpoint."; exit 0
-          fi
-          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
-          # body passed straight through --jq, e.g. the literal "null") — the
-          # same trap pipeline-build.yml had to harden after a real incident.
-          # Treat anything that is not a 40-hex sha as "remote tip unknown":
-          # blanking it skips the divergence pre-check and attempts the ordinary
-          # NON-FORCE push, which the server rejects unless it is a
-          # fast-forward. Without this a bogus value fails the ancestor test and
-          # diverts a perfectly fast-forwardable recovery onto a side ref.
-          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
-          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
-            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
-          fi
-          target="${BRANCH}"
-          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
-            target="${BRANCH}-ckpt-${{ github.run_id }}"
-            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
-          fi
-          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
-            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
-            exit 0
-          fi
-          echo "Checkpointed ${head_sha} to ${target}."
-          gh pr comment "$n" --body "${CHECKPOINT_MARKER}
-          🤖 Recovered work the autofix agent committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
-
-          ⚠️ This was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
+        uses: swampratnz/community-agent/.github/actions/agent-checkpoint@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.workflow_run.head_branch }}
+          head-before: ${{ steps.mark.outputs.head_before }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          checkpoint-marker: ${{ env.CHECKPOINT_MARKER }}
+          loop-name: autofix agent
 
       - name: Verify a fix was pushed (else escalate loudly)
         if: always() && env.HAS_TOKEN == 'true' && steps.mark.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          n="${{ steps.pr.outputs.number }}"
-          # Read the branch's current remote tip via the API (gh/GH_TOKEN) rather
-          # than `git fetch` — with persist-credentials:false there is no git
-          # credential in .git/config for a fetch, and this avoids reintroducing
-          # one. head_before was captured from the local checkout (git rev-parse
-          # HEAD needs no credential).
-          after="$(gh pr view "$n" --json headRefOid --jq '.headRefOid')"
-          if [ "$after" != "${{ steps.mark.outputs.head_before }}" ]; then
-            echo "Autofix pushed a change; CI will re-run on the new commit."
-            exit 0
-          fi
-          echo "::error::Autofix produced no new commit on ${HEAD_BRANCH}."
-          gh pr edit "$n" --add-label needs-human || true
-          # Surface the agent's own final summary (best-effort) so a maintainer
-          # sees the blocker instead of re-deriving it from run logs — same
-          # transparency the build worker got in #251. A silent stop leaves none,
-          # which is itself the tell (usually a gate it couldn't make green).
-          summary=""
-          exec_file="${{ steps.fix.outputs.execution_file }}"
-          if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
-            summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
-          fi
-          {
-            printf '%s\n🤖 Autofix attempt %s pushed no fix — the cause needs a workflow-file change I can'\''t push, or it was not safely fixable. Labelled `needs-human`.\n' "${ESCALATE_MARKER}" "${{ steps.mark.outputs.attempt }}"
-            if [ -n "${summary}" ]; then
-              printf '\n<details><summary>Autofix agent'\''s final summary (what it says blocked it)</summary>\n\n%s\n\n</details>\n' "${summary}"
-            else
-              printf '\n_No agent summary was captured — it stopped without explaining, which usually means a CI gate it could not make green. Check the run log: %s/%s/actions/runs/%s_\n' "${{ github.server_url }}" "${{ github.repository }}" "${RUN_ID}"
-            fi
-          } | gh pr comment "$n" --body-file -
-          exit 1
+        uses: swampratnz/community-agent/.github/actions/agent-verify-push@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          head-before: ${{ steps.mark.outputs.head_before }}
+          execution-file: ${{ steps.fix.outputs.execution_file }}
+          escalate-marker: ${{ env.ESCALATE_MARKER }}
+          success-message: Autofix pushed a change; CI will re-run on the new commit.
+          error-message: Autofix produced no new commit on ${{ env.HEAD_BRANCH }}.
+          escalation-body: >-
+            🤖 Autofix attempt ${{ steps.mark.outputs.attempt }} pushed no fix — the cause needs a
+            workflow-file change I can't push, or it was not safely fixable. Labelled `needs-human`.
+          summary-title: Autofix agent's final summary (what it says blocked it)
+          no-summary-note: >-
+            _No agent summary was captured — it stopped without explaining, which usually means a CI
+            gate it could not make green. Check the run log:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.RUN_ID }}_

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -623,98 +623,44 @@ jobs:
       # not sufficient, so this is the deterministic backstop, mirroring the
       # build worker's own checkpoint for the identical failure (#633/#682).
       #
-      # Safe by construction: runs only AFTER the agent has exited (no process
-      # left to influence it or read the token), uses the job's GITHUB_TOKEN
-      # (valid for the whole job, unlike the agent's ~1h App token), and only
-      # ever FAST-FORWARDS the PR branch — if the remote moved under us the
-      # work is parked on a side ref rather than rewriting someone else's push.
       # Placed BEFORE the verify step so a successful recovery is seen as the
       # new commit it is.
+      #
+      # Deterministic recovery + assertion — shared, and pinned to @main rather
+      # than `./` for the reason spelled out in
+      # .github/actions/agent-checkpoint/action.yml: this job checks out the
+      # PR's head branch, so a local action reference would let PR content
+      # define the steps that publish work and decide escalation.
       - name: Checkpoint unpushed work (deterministic)
         if: always() && steps.precheck.outputs.proceed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Passed via env, never ${{ }}-interpolated into the script body —
-          # see the verify step below for why.
-          BRANCH: ${{ steps.precheck.outputs.branch }}
-          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
-        run: |
-          set -euo pipefail
-          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
-          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
-            echo "Agent committed nothing — nothing to checkpoint."; exit 0
-          fi
-          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
-          # body passed straight through --jq, e.g. the literal "null") — the
-          # same trap pipeline-build.yml had to harden after a real incident.
-          # Treat anything that is not a 40-hex sha as "remote tip unknown":
-          # blanking it skips the divergence pre-check and attempts the ordinary
-          # NON-FORCE push, which the server rejects unless it is a
-          # fast-forward. Without this a bogus value fails the ancestor test and
-          # diverts a perfectly fast-forwardable recovery onto a side ref.
-          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
-          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
-            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
-          fi
-          target="${BRANCH}"
-          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
-            target="${BRANCH}-ckpt-${{ github.run_id }}"
-            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
-          fi
-          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
-            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
-            exit 0
-          fi
-          echo "Checkpointed ${head_sha} to ${target}."
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "${CHECKPOINT_MARKER}
-          🤖 Recovered work the conflict resolver committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
-
-          ⚠️ This resolution was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
+        uses: swampratnz/community-agent/.github/actions/agent-checkpoint@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.precheck.outputs.branch }}
+          head-before: ${{ steps.mark.outputs.head_before }}
+          pr-number: ${{ env.PR_NUMBER }}
+          checkpoint-marker: ${{ env.CHECKPOINT_MARKER }}
+          loop-name: conflict resolver
+          subject: This resolution
 
       - name: Verify the conflict was resolved (else escalate loudly)
         if: always() && steps.precheck.outputs.proceed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Passed via env, NEVER ${{ }}-interpolated into the script body: a
-          # git ref name may legally contain shell metacharacters, and template
-          # interpolation would splice them into this script (with GH_TOKEN
-          # live) before the shell runs — the classic Actions injection.
-          HEAD_BRANCH: ${{ steps.precheck.outputs.branch }}
-        run: |
-          set -euo pipefail
-          # Read the branch's current remote tip via the API (gh/GH_TOKEN) rather
-          # than `git fetch` — with persist-credentials:false there is no git
-          # credential in .git/config for a fetch, and this avoids reintroducing
-          # one. head_before was captured from the local checkout (git rev-parse
-          # HEAD needs no credential).
-          after="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
-          if [ "$after" != "${{ steps.mark.outputs.head_before }}" ]; then
-            echo "Resolver pushed a merge commit; CI will re-run on the new commit."
-            exit 0
-          fi
-          echo "::error::Conflict resolver produced no new commit on ${HEAD_BRANCH}."
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label needs-human || true
-          # Surface the agent's own final summary (best-effort) so a maintainer
-          # can see WHICH files couldn't be reconciled, instead of re-deriving it
-          # from run logs — the escalation was previously opaque ("incompatible
-          # OR needs a workflows change" with no way to tell which). Same
-          # transparency the build worker got in #251.
-          summary=""
+        uses: swampratnz/community-agent/.github/actions/agent-verify-push@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ env.PR_NUMBER }}
+          head-before: ${{ steps.mark.outputs.head_before }}
           # Whichever path ran: the full resolve agent, or the fast-path's lean
           # verify+push step (a security-floor.json-only resolution whose gate
-          # failed). Fall back to the fast-path's transcript so its blocker
-          # isn't opaque either.
-          exec_file="${{ steps.fix.outputs.execution_file }}"
-          if [ -z "${exec_file}" ]; then exec_file="${{ steps.fastpush.outputs.execution_file }}"; fi
-          if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
-            summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
-          fi
-          {
-            printf '%s\n🤖 Could not automatically resolve this PR'\''s conflict with `main` — the two sides are semantically incompatible, or the fix needs a `.github/workflows/` change I can'\''t push. Labelled `needs-human` for a maintainer. Run: %s/%s/actions/runs/%s\n' "${ESCALATE_MARKER}" "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
-            if [ -n "${summary}" ]; then
-              printf '\n<details><summary>Conflict resolver'\''s final summary (what it says blocked it)</summary>\n\n%s\n\n</details>\n' "${summary}"
-            fi
-          } | gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file -
-          exit 1
+          # failed). The fallback keeps the fast-path's blocker legible too.
+          execution-file: ${{ steps.fix.outputs.execution_file }}
+          fallback-execution-file: ${{ steps.fastpush.outputs.execution_file }}
+          escalate-marker: ${{ env.ESCALATE_MARKER }}
+          success-message: Resolver pushed a merge commit; CI will re-run on the new commit.
+          error-message: Conflict resolver produced no new commit on ${{ steps.precheck.outputs.branch }}.
+          escalation-body: >-
+            🤖 Could not automatically resolve this PR's conflict with `main` — the two sides are
+            semantically incompatible, or the fix needs a `.github/workflows/` change I can't push.
+            Labelled `needs-human` for a maintainer. Run:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          summary-title: Conflict resolver's final summary (what it says blocked it)

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -332,92 +332,43 @@ jobs:
       # sufficient, so this is the deterministic backstop, mirroring the build
       # worker's own checkpoint for the identical failure (#633/#682).
       #
-      # Safe by construction: it runs only AFTER the agent has exited (no
-      # process left to influence it or read the token), uses the job's
-      # GITHUB_TOKEN (valid for the whole job, unlike the agent's ~1h App
-      # token), and only ever FAST-FORWARDS the PR branch — if the remote moved
-      # under us the work is parked on a side ref rather than rewriting
-      # someone else's push. Placed BEFORE the verify step on purpose, so a
-      # successful recovery is seen as the new commit it is.
+      # Placed BEFORE the verify step so a successful recovery is seen as the
+      # new commit it is.
+      #
+      # Deterministic recovery + assertion — shared, and pinned to @main rather
+      # than `./` for the reason spelled out in
+      # .github/actions/agent-checkpoint/action.yml: this job checks out the
+      # PR's head branch, so a local action reference would let PR content
+      # define the steps that publish work and decide escalation.
       - name: Checkpoint unpushed work (deterministic)
         if: always() && steps.mark.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ steps.precheck.outputs.branch }}
-          HEAD_BEFORE: ${{ steps.mark.outputs.head_before }}
-        run: |
-          set -euo pipefail
-          head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
-          if [ -z "${head_sha}" ] || [ "${head_sha}" = "${HEAD_BEFORE}" ]; then
-            echo "Agent committed nothing — nothing to checkpoint."; exit 0
-          fi
-          remote_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          # A failed/404 gh api call can leave a NON-sha in remote_sha (an error
-          # body passed straight through --jq, e.g. the literal "null") — the
-          # same trap pipeline-build.yml had to harden after a real incident.
-          # Treat anything that is not a 40-hex sha as "remote tip unknown":
-          # blanking it skips the divergence pre-check and attempts the ordinary
-          # NON-FORCE push, which the server rejects unless it is a
-          # fast-forward. Without this a bogus value fails the ancestor test and
-          # diverts a perfectly fast-forwardable recovery onto a side ref.
-          if ! printf '%s' "${remote_sha}" | grep -qE '^[0-9a-f]{40}$'; then remote_sha=""; fi
-          if [ -n "${remote_sha}" ] && [ "${head_sha}" = "${remote_sha}" ]; then
-            echo "Agent already pushed ${head_sha} — nothing to checkpoint."; exit 0
-          fi
-          target="${BRANCH}"
-          if [ -n "${remote_sha}" ] && ! git merge-base --is-ancestor "${remote_sha}" HEAD 2>/dev/null; then
-            target="${BRANCH}-ckpt-${{ github.run_id }}"
-            echo "Remote ${BRANCH} moved to ${remote_sha}; parking on ${target} rather than rewriting it."
-          fi
-          push_url="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if ! git push "${push_url}" "HEAD:refs/heads/${target}"; then
-            echo "::warning::Checkpoint push failed — the agent's committed work dies with this runner."
-            exit 0
-          fi
-          echo "Checkpointed ${head_sha} to ${target}."
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "${CHECKPOINT_MARKER}
-          🤖 Recovered work the revise agent committed but never pushed — it ended its turn without pushing. Checkpointed \`${head_sha}\` to \`${target}\`.
-
-          ⚠️ This was **not verified by the agent** (it stopped before finishing the gate). CI on this push is the adjudicator, and the automated review still has to pass before anything can merge." || true
+        uses: swampratnz/community-agent/.github/actions/agent-checkpoint@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.precheck.outputs.branch }}
+          head-before: ${{ steps.mark.outputs.head_before }}
+          pr-number: ${{ env.PR_NUMBER }}
+          checkpoint-marker: ${{ env.CHECKPOINT_MARKER }}
+          loop-name: revise agent
 
       - name: Verify a revision was pushed (else escalate loudly)
         if: always() && steps.mark.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Read the branch's current remote tip via the API (gh/GH_TOKEN)
-          # rather than `git fetch` — with persist-credentials:false there is
-          # no git credential in .git/config for a fetch (see autofix).
-          after="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
-          if [ "$after" != "${{ steps.mark.outputs.head_before }}" ]; then
-            echo "Revise worker pushed a change; CI and the review worker will re-run on the new commit."
-            exit 0
-          fi
-          echo "::error::Revise worker produced no new commit on PR #${PR_NUMBER}."
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label needs-human || true
-
-          # Surface WHY (mirrors pipeline-build.yml's #251 escalation): pull the
-          # revise agent's own final summary from its execution log, so the
-          # escalation says what actually stopped it — a principled refusal, a
-          # `.github/workflows/` change it can't push, a gate it couldn't make
-          # green, or a run that flaked — instead of the three-way guess this
-          # comment used to make (which a maintainer then had to reverse-engineer
-          # from the run log). Best-effort: a silent no-op leaves no summary,
-          # which is itself the tell.
-          summary=""
-          exec_file="${{ steps.fix.outputs.execution_file }}"
-          if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
-            summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
-          fi
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          {
-            printf '%s\n🤖 Revise attempt %s pushed no revision — labelled `needs-human` for a maintainer. Run: %s\n' \
-              "${ESCALATE_MARKER}" "${{ steps.precheck.outputs.attempt }}" "${run_url}"
-            if [ -n "${summary}" ]; then
-              printf '\n<details><summary>Revise worker'\''s final summary (what it says stopped it)</summary>\n\n%s\n\n</details>\n' "${summary}"
-            else
-              printf '\n_No agent summary was captured — it ended without pushing **and** without a `gh pr comment`. That usually means a gate it could not make green, a `.github/workflows/` change it cannot push, or a disagreement with the review it did not voice. Check the run log above._\n'
-            fi
-          } | gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file - || true
-          exit 1
+        uses: swampratnz/community-agent/.github/actions/agent-verify-push@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ env.PR_NUMBER }}
+          head-before: ${{ steps.mark.outputs.head_before }}
+          execution-file: ${{ steps.fix.outputs.execution_file }}
+          escalate-marker: ${{ env.ESCALATE_MARKER }}
+          success-message: Revise worker pushed a change; CI and the review worker will re-run on the new commit.
+          error-message: Revise worker produced no new commit on PR #${{ env.PR_NUMBER }}.
+          escalation-body: >-
+            🤖 Revise attempt ${{ steps.precheck.outputs.attempt }} pushed no revision — labelled
+            `needs-human` for a maintainer. Run:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          summary-title: Revise worker's final summary (what it says stopped it)
+          no-summary-note: >-
+            _No agent summary was captured — it ended without pushing **and** without a
+            `gh pr comment`. That usually means a gate it could not make green, a
+            `.github/workflows/` change it cannot push, or a disagreement with the review it did not
+            voice. Check the run log above._

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -285,13 +285,25 @@ only ever **fast-forwards**; a diverged remote parks the work on a
 `-ckpt-<run_id>` ref rather than rewriting someone else's push. This exists
 because prompt-only compliance provably fails — agents have finished whole
 builds, and whole conflict resolutions, and then ended their turn without
-pushing. Present in build, autofix, revise and conflict.
+pushing. Present in build, autofix, revise and conflict — as ONE implementation
+since the extraction: [`.github/actions/agent-checkpoint`](../.github/actions/agent-checkpoint/action.yml)
+(see [§8.3](#83-proposed-shape-of-the-reusable-solution)).
 
 **M8 · Verify-else-escalate.** The step after the checkpoint asserts the
 *outcome* deterministically — is there an open PR closing this issue? was a
 commit pushed? — and if not, labels `needs-human`, comments, and **fails the job
 loudly**. An agent that narrates work it did not do must not produce a green
-run.
+run. The three PR loops share one implementation,
+[`.github/actions/agent-verify-push`](../.github/actions/agent-verify-push/action.yml);
+the build worker keeps its own, because its version asserts a *PR exists* rather
+than a commit landing and additionally owns the lane labels, the resume pointer
+and the recovery-PR path — a different contract that merely shares a name.
+
+Note that M7 and M8 stay **separate steps** even though they always run
+together: a checkpoint may legitimately publish work *and* the verify still
+escalate, because checkpointed work never cleared the agent's own gate. Folding
+them into one action would collapse "recovered" and "succeeded" into the same
+outcome, which is exactly the distinction `pipeline-outcomes.yml` reports on.
 
 **M9 · Deterministic lane ownership.** The workflow, not the agent, owns every
 label transition: a Claim step sets `status:building` before the agent runs; the
@@ -573,19 +585,42 @@ literals.
 
 Three artifacts, in the order they pay off:
 
-**1 · A composite action for the agent-run triad.** M7 (checkpoint), M8
-(verify-else-escalate) and the cost/job-summary steps are near-identical in
-build, autofix, revise and conflict, and their bugs have historically been
-*fixed in one copy and not the others*. Extract:
+**1 · A composite action for the agent-run triad — DONE.** M7 (checkpoint) and
+M8 (verify-else-escalate) were near-identical in build, autofix, revise and
+conflict, and their bugs had historically been *fixed in one copy and not the
+others*. They now live in two composite actions:
 
 ```
-actions/agent-run/action.yml
-  inputs: prompt-file, allowed-tools, max-turns, model,
-          push-target (branch | pinned HEAD), marker-prefix,
-          verify-command, escalation-label
+.github/actions/agent-checkpoint/action.yml    ← build, autofix, revise, conflict
+.github/actions/agent-verify-push/action.yml   ← autofix, revise, conflict
 ```
 
-This alone removes the highest-risk duplication in the repo.
+Three things that extraction settled, and that any port of this pattern has to
+settle too:
+
+- **The reference must be pinned to the default branch, never `./`.** A local
+  `uses: ./.github/actions/…` resolves from the *workspace* when the step runs,
+  and the three PR loops check out the pull request's head branch — so `./`
+  would let PR-controlled content define the step that publishes an agent's work
+  and the step that decides whether the run escalates. The repo-qualified
+  `swampratnz/community-agent/.github/actions/…@main` form is fetched from the
+  default branch, which is the property these workflow *files* already have
+  (their triggers only ever run `main`'s copy). `tests/agentRunActions.test.ts`
+  pins it as a `SECURITY:` test. There is no bootstrap gap: workflow and action
+  land on `main` in the same merge.
+- **Composite actions ignore unknown `with:` keys silently.** A renamed input
+  degrades to its default with no error anywhere — for the checkpoint that means
+  no recovery comment; for the verify step it means the escalation loses the
+  marker `pipeline-outcomes.yml` counts. The same test cross-checks every passed
+  key against the action's declared inputs.
+- **One implementation means taking the union of the drift.** At extraction the
+  three PR loops had two hardenings the build worker never received (the 40-hex
+  guard on the `gh api` lookup; the `merge-base --is-ancestor` pre-check), while
+  the build worker had a push-failure fallback to the side ref that the other
+  three lacked. The shared action keeps all three.
+
+The cost/job-summary step was left alone: it appears in only two workflows
+(build and review) and they format different things.
 
 **2 · Reusable workflows (`workflow_call`) for Tiers A and B.** The
 deterministic loops carry no prompts and no project gate, so they parameterise
@@ -648,8 +683,7 @@ a consumer weaken them has extracted the shape and lost the substance:
 
 ### 8.5 Suggested extraction order
 
-1. The composite action (§8.3.1) — in-repo, no consumer needed, immediately
-   removes four-way duplication.
+1. ~~The composite action (§8.3.1)~~ — **done**; see above.
 2. Tier A workflows — trivially portable, prove the packaging.
 3. Tier B, starting with the groundskeeper and outcomes loops (read-mostly, low
    blast radius) and ending with auto-merge (highest stakes).

--- a/tests/agentRunActions.test.ts
+++ b/tests/agentRunActions.test.ts
@@ -1,0 +1,450 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The shared agent-run actions (.github/actions/agent-checkpoint,
+ * .github/actions/agent-verify-push).
+ *
+ * Four workflows carried near-identical copies of the checkpoint step and three
+ * carried near-identical copies of the verify step, and they DRIFTED: at
+ * extraction time only the three PR loops had the 40-hex guard on the `gh api`
+ * lookup and the ancestor pre-check, while only the build worker had the
+ * push-failure fallback to a side ref. That is the same failure mode the
+ * review-verdict contract hit (#731) — one fix, landed in some copies.
+ *
+ * These tests pin the two halves that a refactor like this can silently break:
+ *
+ *   1. WIRING. Composite actions ignore unknown `with:` keys silently, so a
+ *      renamed input degrades to the default with no error anywhere — for the
+ *      checkpoint that means "no recovery comment", for the verify step it
+ *      means the escalation loses its marker. And a caller that regresses to a
+ *      LOCAL `./` reference would hand PR-head content the definition of the
+ *      steps that publish work and decide escalation.
+ *   2. BEHAVIOUR. The extracted shell is executed against stub `git`/`gh`
+ *      binaries, so the guards are tested rather than assumed — the same
+ *      approach tests/reviewVerdict.test.ts takes with the verdict helpers.
+ */
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const readRepoFile = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+const CHECKPOINT_ACTION = '.github/actions/agent-checkpoint/action.yml';
+const VERIFY_ACTION = '.github/actions/agent-verify-push/action.yml';
+
+/** Workflows that must use the shared actions, and which ones each one calls. */
+const CALLERS: Record<string, { checkpoint: boolean; verify: boolean }> = {
+  'pipeline-build.yml': { checkpoint: true, verify: false },
+  'pipeline-pr-autofix.yml': { checkpoint: true, verify: true },
+  'pipeline-pr-revise.yml': { checkpoint: true, verify: true },
+  'pipeline-pr-conflict.yml': { checkpoint: true, verify: true },
+};
+
+const OWNER_REPO = 'swampratnz/community-agent';
+/** The repo-qualified, default-branch-pinned form callers must use. */
+const CHECKPOINT_REF = `${OWNER_REPO}/.github/actions/agent-checkpoint@main`;
+const VERIFY_REF = `${OWNER_REPO}/.github/actions/agent-verify-push@main`;
+
+/**
+ * Pull the `run: |` body out of a composite action and strip the YAML block
+ * indentation, so it can be executed directly.
+ */
+function extractRunBody(source: string): string {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line.trim() === 'run: |');
+  assert.notEqual(start, -1, 'no `run: |` block found');
+  const body = lines.slice(start + 1);
+  const indent = body[0].length - body[0].trimStart().length;
+  const out: string[] = [];
+  for (const line of body) {
+    if (line.trim() !== '' && line.length - line.trimStart().length < indent) break;
+    out.push(line.slice(indent));
+  }
+  return out.join('\n');
+}
+
+/** Declared input names of a composite action (top-level keys under `inputs:`). */
+function declaredInputs(source: string): Set<string> {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line === 'inputs:');
+  assert.notEqual(start, -1, 'no `inputs:` block');
+  const names = new Set<string>();
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    const match = /^ {2}([a-z0-9-]+):\s*$/.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+/** The `with:` keys a workflow passes at each `uses:` of the given action. */
+function withKeysFor(workflow: string, usesRef: string): string[][] {
+  const lines = workflow.split('\n');
+  const calls: string[][] = [];
+  lines.forEach((line, i) => {
+    if (!line.trim().endsWith(`uses: ${usesRef}`) && line.trim() !== `uses: ${usesRef}`) return;
+    const keys: string[] = [];
+    let seenWith = false;
+    for (const next of lines.slice(i + 1)) {
+      if (next.trim() === 'with:') {
+        seenWith = true;
+        continue;
+      }
+      if (!seenWith) {
+        if (next.trim().startsWith('- ') || next.trim() === '') break;
+        continue;
+      }
+      // Stop at the next step (a `- name:`/`- uses:` bullet) or a dedent.
+      if (/^\s*- /.test(next)) break;
+      const match = /^\s{10}([a-z0-9-]+):/.exec(next);
+      if (match) keys.push(match[1]);
+      else if (next.trim() !== '' && !/^\s{12,}/.test(next) && !next.trim().startsWith('#')) break;
+    }
+    calls.push(keys);
+  });
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// 1 · Wiring
+// ---------------------------------------------------------------------------
+
+test('SECURITY: the shared agent actions are pinned to the default branch, never referenced locally', () => {
+  // A local `./.github/actions/...` reference resolves from the WORKSPACE at
+  // step-run time. The three PR loops check out the pull request's head branch
+  // and the agent edits that tree, so `./` would let PR-controlled content
+  // define the step that publishes the agent's work and the step that decides
+  // whether the run escalates to a human. The repo-qualified `@main` form is
+  // fetched from the default branch instead, matching the property these
+  // workflow FILES already have (their triggers only ever run main's copy).
+  for (const name of Object.keys(CALLERS)) {
+    const source = readRepoFile(`.github/workflows/${name}`);
+    assert.equal(
+      /uses:\s*\.\//.test(source),
+      false,
+      `${name} references an action by local ./ path; PR-head content must never define the checkpoint or verify steps`,
+    );
+    for (const line of source.match(/^.*uses:.*agent-(checkpoint|verify-push).*$/gm) ?? []) {
+      assert.match(
+        line.trim(),
+        /^uses: swampratnz\/community-agent\/\.github\/actions\/agent-(checkpoint|verify-push)@main$/,
+        `${name} must pin the shared action to the default branch (found: ${line.trim()})`,
+      );
+    }
+  }
+});
+
+test('every workflow that runs a repair agent uses the shared checkpoint and verify actions', () => {
+  for (const [name, expected] of Object.entries(CALLERS)) {
+    const source = readRepoFile(`.github/workflows/${name}`);
+    assert.equal(
+      source.includes(`uses: ${CHECKPOINT_REF}`),
+      expected.checkpoint,
+      `${name} checkpoint wiring`,
+    );
+    assert.equal(source.includes(`uses: ${VERIFY_REF}`), expected.verify, `${name} verify wiring`);
+  }
+});
+
+test('no workflow keeps an inline copy of the checkpoint or verify logic', () => {
+  // The drift guard: the fragments below are load-bearing lines of the two
+  // extracted implementations. If one reappears in a workflow, the copies are
+  // back and the next fix will land in some of them.
+  for (const [name, expected] of Object.entries(CALLERS)) {
+    const source = readRepoFile(`.github/workflows/${name}`);
+    assert.equal(
+      source.includes('-ckpt-'),
+      false,
+      `${name} builds a -ckpt- side ref inline — that belongs to the shared checkpoint action`,
+    );
+    assert.equal(
+      source.includes('--json headRefOid'),
+      false,
+      `${name} reads the PR head tip inline — that belongs to the shared verify action`,
+    );
+    // The agent's-final-summary extraction. The build worker keeps its own
+    // (its verify step asserts a PR exists, owns the lane labels and the
+    // recovery-PR path — a different contract that shares only a name), so it
+    // is the one workflow allowed to retain this.
+    assert.equal(
+      source.includes('select(.type? == "result")'),
+      !expected.verify,
+      `${name}: inline summary extraction should exist only in the build worker's bespoke verify step`,
+    );
+  }
+});
+
+test('SECURITY: every `with:` key a caller passes is a declared input of the action', () => {
+  // GitHub silently IGNORES unknown inputs on a composite action, so a typo or
+  // a rename degrades to the default with no error: `checkpoint-marker` would
+  // become empty (no recovery comment) and `escalate-marker` would drop the
+  // marker the outcomes ledger counts escalations by.
+  const specs = [
+    { action: CHECKPOINT_ACTION, ref: CHECKPOINT_REF, key: 'checkpoint' as const },
+    { action: VERIFY_ACTION, ref: VERIFY_REF, key: 'verify' as const },
+  ];
+  for (const { action, ref, key } of specs) {
+    const inputs = declaredInputs(readRepoFile(action));
+    for (const [name, expected] of Object.entries(CALLERS)) {
+      if (!expected[key]) continue;
+      const calls = withKeysFor(readRepoFile(`.github/workflows/${name}`), ref);
+      assert.ok(calls.length > 0, `${name} does not call ${ref}`);
+      for (const keys of calls) {
+        for (const passed of keys) {
+          assert.ok(
+            inputs.has(passed),
+            `${name} passes \`${passed}\` to ${path.basename(path.dirname(action))}, which declares no such input`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('required inputs of the shared actions are passed by every caller', () => {
+  const required = (source: string) => {
+    const names = new Set<string>();
+    const lines = source.split('\n');
+    const start = lines.findIndex((line) => line === 'inputs:');
+    let current = '';
+    for (const line of lines.slice(start + 1)) {
+      if (/^\S/.test(line)) break;
+      const head = /^ {2}([a-z0-9-]+):\s*$/.exec(line);
+      if (head) current = head[1];
+      else if (/^ {4}required:\s*true\s*$/.test(line) && current) names.add(current);
+    }
+    return names;
+  };
+  for (const { action, ref, key } of [
+    { action: CHECKPOINT_ACTION, ref: CHECKPOINT_REF, key: 'checkpoint' as const },
+    { action: VERIFY_ACTION, ref: VERIFY_REF, key: 'verify' as const },
+  ]) {
+    const need = required(readRepoFile(action));
+    for (const [name, expected] of Object.entries(CALLERS)) {
+      if (!expected[key]) continue;
+      for (const keys of withKeysFor(readRepoFile(`.github/workflows/${name}`), ref)) {
+        for (const req of need) {
+          assert.ok(keys.includes(req), `${name} omits required input \`${req}\` of ${ref}`);
+        }
+      }
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2 · Behaviour — run the extracted shell against stub git/gh
+// ---------------------------------------------------------------------------
+
+type StubEnv = Record<string, string>;
+
+/**
+ * Execute the checkpoint script with stub `git` and `gh` on PATH. The stubs
+ * append every interesting call to $STUB_LOG so the test can assert on what
+ * the script actually did.
+ */
+function runCheckpoint(env: StubEnv): {
+  code: number;
+  log: string[];
+  outputs: Record<string, string>;
+  stdout: string;
+} {
+  const dir = mkdtempSync(path.join(tmpdir(), 'ckpt-'));
+  try {
+    const bin = path.join(dir, 'bin');
+    mkdirSync(bin);
+    const log = path.join(dir, 'log');
+    writeFileSync(log, '');
+    const outputs = path.join(dir, 'outputs');
+    writeFileSync(outputs, '');
+
+    // `git push <url> HEAD:refs/heads/<target>` — log the TARGET only, never
+    // the URL (it carries the token).
+    writeFileSync(
+      path.join(bin, 'git'),
+      `#!/usr/bin/env bash
+case "$1 $2" in
+  "rev-parse --abbrev-ref") echo "\${STUB_BRANCH}" ;;
+  "rev-parse HEAD") [ -n "\${STUB_HEAD}" ] && echo "\${STUB_HEAD}" || exit 1 ;;
+  "rev-list --count") echo "\${STUB_AHEAD:-0}" ;;
+  "merge-base --is-ancestor") exit "\${STUB_ANCESTOR:-0}" ;;
+  "push "*)
+    target="\${3#HEAD:refs/heads/}"
+    echo "push \${target}" >> "\${STUB_LOG}"
+    if [ "\${target}" = "\${STUB_PUSH_REJECTS:-}" ]; then exit 1; fi
+    ;;
+  *) : ;;
+esac
+exit 0
+`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(bin, 'gh'),
+      `#!/usr/bin/env bash
+if [ "$1" = "api" ]; then printf '%s' "\${STUB_REMOTE_SHA:-}"; echo; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+  body="$(cat)"
+  { echo "comment \${3}"; echo "\${body}"; } >> "\${STUB_LOG}"
+  exit 0
+fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+    chmodSync(path.join(bin, 'git'), 0o755);
+    chmodSync(path.join(bin, 'gh'), 0o755);
+
+    const script = extractRunBody(readRepoFile(CHECKPOINT_ACTION));
+    const result = spawnSync('bash', ['-c', script], {
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        GITHUB_OUTPUT: outputs,
+        STUB_LOG: log,
+        GH_TOKEN: 'stub-token',
+        REPOSITORY: OWNER_REPO,
+        DEFAULT_BRANCH: 'main',
+        RUN_ID: '4242',
+        BRANCH: '',
+        HEAD_BEFORE: '',
+        PR_NUMBER: '',
+        CHECKPOINT_MARKER: '',
+        LOOP_NAME: 'test agent',
+        SUBJECT: 'This',
+        ...env,
+      },
+      encoding: 'utf8',
+    });
+    const parsed: Record<string, string> = {};
+    for (const line of readFileSync(outputs, 'utf8').split('\n')) {
+      const match = /^([a-z]+)=(.*)$/.exec(line);
+      if (match) {
+        assert.equal(parsed[match[1]], undefined, `output key ${match[1]} written more than once`);
+        parsed[match[1]] = match[2];
+      }
+    }
+    return {
+      code: result.status ?? -1,
+      log: readFileSync(log, 'utf8').split('\n').filter(Boolean),
+      outputs: parsed,
+      stdout: `${result.stdout}${result.stderr}`,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+
+test('checkpoint: an agent that committed nothing pushes nothing', () => {
+  const run = runCheckpoint({ BRANCH: 'fix/x', STUB_HEAD: SHA_A, HEAD_BEFORE: SHA_A });
+  assert.deepEqual(run.log, []);
+  assert.equal(run.outputs.checkpointed, 'false');
+  assert.equal(run.code, 0);
+});
+
+test('SECURITY: checkpoint refuses to treat the default branch or a detached HEAD as a work branch', () => {
+  for (const branch of ['main', 'HEAD', '']) {
+    const run = runCheckpoint({ BRANCH: '', STUB_BRANCH: branch, STUB_HEAD: SHA_B, STUB_AHEAD: '3' });
+    assert.deepEqual(run.log, [], `pushed something with branch=${branch || '(empty)'}`);
+    assert.equal(run.outputs.checkpointed, 'false');
+  }
+});
+
+test('checkpoint: with no head-before it falls back to "ahead of the default branch" (the build worker)', () => {
+  const behind = runCheckpoint({ BRANCH: '', STUB_BRANCH: 'feat/y', STUB_HEAD: SHA_A, STUB_AHEAD: '0' });
+  assert.deepEqual(behind.log, []);
+
+  const ahead = runCheckpoint({ BRANCH: '', STUB_BRANCH: 'feat/y', STUB_HEAD: SHA_A, STUB_AHEAD: '2' });
+  assert.deepEqual(ahead.log, ['push feat/y']);
+  assert.equal(ahead.outputs.checkpointed, 'true');
+  assert.equal(ahead.outputs.ref, 'feat/y');
+  assert.equal(ahead.outputs.sha, SHA_A);
+});
+
+test('checkpoint: a non-sha API response still fast-forwards onto the work branch', () => {
+  // The 40-hex guard. `gh api` prints its ERROR BODY to stdout on a 404, so an
+  // unguarded value fails the ancestor test and diverts a perfectly
+  // fast-forwardable recovery onto a side ref.
+  const run = runCheckpoint({
+    BRANCH: 'fix/x',
+    STUB_HEAD: SHA_A,
+    HEAD_BEFORE: SHA_B,
+    STUB_REMOTE_SHA: 'null',
+    STUB_ANCESTOR: '1', // would divert, if the guard did not blank the value first
+  });
+  assert.deepEqual(run.log, ['push fix/x']);
+  assert.equal(run.outputs.ref, 'fix/x');
+});
+
+test('checkpoint: a diverged remote is parked on a side ref, never rewritten', () => {
+  const run = runCheckpoint({
+    BRANCH: 'fix/x',
+    STUB_HEAD: SHA_A,
+    HEAD_BEFORE: SHA_B,
+    STUB_REMOTE_SHA: SHA_B,
+    STUB_ANCESTOR: '1',
+  });
+  assert.deepEqual(run.log, ['push fix/x-ckpt-4242']);
+  assert.equal(run.outputs.ref, 'fix/x-ckpt-4242');
+  assert.equal(run.outputs.checkpointed, 'true');
+});
+
+test('checkpoint: a rejected fast-forward push falls back to the side ref (the build worker behaviour)', () => {
+  const run = runCheckpoint({
+    BRANCH: 'fix/x',
+    STUB_HEAD: SHA_A,
+    HEAD_BEFORE: SHA_B,
+    STUB_REMOTE_SHA: SHA_B,
+    STUB_ANCESTOR: '0', // pre-check says fast-forward…
+    STUB_PUSH_REJECTS: 'fix/x', // …but the server disagrees
+  });
+  assert.deepEqual(run.log, ['push fix/x', 'push fix/x-ckpt-4242']);
+  assert.equal(run.outputs.ref, 'fix/x-ckpt-4242');
+});
+
+test('checkpoint: an already-pushed head reports the ref without pushing again', () => {
+  const run = runCheckpoint({
+    BRANCH: 'fix/x',
+    STUB_HEAD: SHA_A,
+    HEAD_BEFORE: SHA_B,
+    STUB_REMOTE_SHA: SHA_A,
+  });
+  assert.deepEqual(run.log, []);
+  assert.equal(run.outputs.ref, 'fix/x', 'the surviving branch must still be reported for the resume path');
+  assert.equal(run.outputs.checkpointed, 'false');
+});
+
+test('checkpoint: the recovery comment leads with the marker and is skipped without a PR', () => {
+  const withPr = runCheckpoint({
+    BRANCH: 'fix/x',
+    STUB_HEAD: SHA_A,
+    HEAD_BEFORE: SHA_B,
+    PR_NUMBER: '77',
+    CHECKPOINT_MARKER: '<!-- pipeline-autofix-checkpoint -->',
+    LOOP_NAME: 'autofix agent',
+  });
+  const commentAt = withPr.log.indexOf('comment 77');
+  assert.notEqual(commentAt, -1, 'no recovery comment posted');
+  // Marker on line 1 — pipeline-outcomes.mjs and the handoff resolver match on
+  // position, not just on the text appearing somewhere.
+  assert.equal(withPr.log[commentAt + 1], '<!-- pipeline-autofix-checkpoint -->');
+  const body = withPr.log.slice(commentAt + 1).join('\n');
+  assert.match(body, /autofix agent/);
+  assert.match(body, /not verified by the agent/);
+  // The old inline form carried its YAML block indentation into the comment,
+  // so GitHub rendered the explanation as a code block.
+  assert.equal(/^ {4}/m.test(body), false, 'comment body is indented — it will render as a code block');
+
+  const noPr = runCheckpoint({ BRANCH: 'fix/x', STUB_HEAD: SHA_A, HEAD_BEFORE: SHA_B });
+  assert.equal(
+    noPr.log.some((line) => line.startsWith('comment')),
+    false,
+    'commented without a PR number',
+  );
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -23,6 +23,7 @@
   "agentModelTiering.test.ts": 1,
   "agentModule.test.ts": 1,
   "agentOptions.test.ts": 13,
+  "agentRunActions.test.ts": 3,
   "agentSkillsEnabled.test.ts": 7,
   "agentWebSearchDedup.test.ts": 3,
   "agentWebSearchDedupEmbedFailClosed.test.ts": 1,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -27,6 +27,7 @@
   "include": [
     "src/**/*.ts",
     "tests/agentModule.test.ts",
+    "tests/agentRunActions.test.ts",
     "tests/backgroundJobCostAlert.test.ts",
     "tests/dbCoverageCheck.test.ts",
     "tests/displayTime.test.ts",


### PR DESCRIPTION
Follow-up to #991, which proposed this as the first extraction step (§8.3).

## Summary

The build worker and the three PR-repair loops each carried their own copy of the **checkpoint** step (publish work an agent committed but never pushed) and — for the three PR loops — the **verify-else-escalate** step. 290 lines of near-identical shell across four files, and they had already drifted **in both directions**:

| Hardening | build | autofix | revise | conflict |
|---|---|---|---|---|
| 40-hex guard on the `gh api` lookup | ❌ | ✅ | ✅ | ✅ |
| `merge-base --is-ancestor` pre-check | ❌ | ✅ | ✅ | ✅ |
| Fallback to `-ckpt-<run_id>` when the push is rejected | ✅ | ❌ | ❌ | ❌ |

That is the failure mode the review-verdict contract hit in #731 — one fix, landed in some copies — and it matters most here, because these are the steps that decide whether an agent's work survives the runner and whether a run escalates to a human.

Both now live in `.github/actions/`, and the shared implementation keeps the **union** of the drift: pre-check, guard *and* fallback.

```
.github/actions/agent-checkpoint/action.yml    ← build, autofix, revise, conflict
.github/actions/agent-verify-push/action.yml   ← autofix, revise, conflict
```

## Three decisions that want a reviewer's eye

**1 · Callers pin to the default branch, never `./`.** A local `uses: ./.github/actions/…` resolves from the **workspace** when the step runs, and the three PR loops check out the *pull request's head branch* which the agent then edits. A local reference would therefore let PR-controlled content define the step that publishes work and the step that decides escalation — strictly weaker than today, where these workflow files only ever run `main`'s copy (their triggers are `issues` / `workflow_run` / `workflow_dispatch`). The repo-qualified `swampratnz/community-agent/.github/actions/…@main` form is fetched from `main` independently of the workspace, preserving that property. **No bootstrap gap**: workflow and action land on `main` in the same merge, and for these triggers only `main`'s copy ever runs.

**2 · Checkpoint and verify stay separate actions**, though they always run together. A checkpoint may legitimately publish work *and* the verify still escalate, because checkpointed work never cleared the agent's own gate. Merging them would collapse "recovered" and "succeeded" into one outcome — precisely the distinction `pipeline-outcomes.yml` reports on.

**3 · The build worker keeps its own bespoke verify step.** It asserts *a PR exists* rather than *a commit landed*, and owns lane labels, the resume pointer and the recovery-PR path — a different contract that only shares a name. It does adopt the shared checkpoint, reading the surviving-branch pointer from the action's outputs instead of `$GITHUB_ENV`.

## Behaviour changes

Deliberately none, beyond the union above. Every `if:` condition, prose string, marker, attempt number and run URL is preserved verbatim — including the autofix escalation's run URL, which points at the *CI* run rather than the autofix run. That looks like a pre-existing bug, but a behaviour-preserving refactor is the wrong place to fix it; flagging it as a follow-up instead.

Two incidental fixes worth naming:

- **`$GITHUB_OUTPUT` keys are now written exactly once per exit path.** The straightforward extraction wrote defaults up-front and overwrote them later, which leans on last-wins parsing of duplicate keys — not a contract worth betting a recovery path on. The test asserts no key is written twice.
- **The recovery comment no longer renders as a code block.** The inline `--body "…"` form carried its own YAML block indentation into the comment, so every line after the marker arrived with ten leading spaces. Now built with `printf`.

## Security / privacy impact

This touches security-relevant machinery, so in detail:

- **Trust boundary preserved, deliberately** — decision 1 above is the whole point. `tests/agentRunActions.test.ts` pins it as a `SECURITY:` test: a caller that regresses to `./` fails the suite.
- **Injection discipline preserved.** Every input reaches the script through `env:`, never `${{ }}`-interpolated into a `run:` body — a git ref name may legally contain shell metacharacters. The agent-authored summary is printed with `printf '%s'`, never as a format string.
- **Token handling unchanged.** Still the job's `GITHUB_TOKEN` (valid for the whole job, unlike the agent's ~1h App token), still only after the agent process has exited, still fast-forward-only with a side ref for a diverged remote. `persist-credentials: false` on every checkout is untouched. The test stubs log the push *target* only, never the token-bearing URL.
- **New guard:** the checkpoint now explicitly refuses to treat the default branch or a detached HEAD as a work branch (`SECURITY:` test covers `main`, `HEAD` and empty). The build worker had this; the extraction makes it universal.
- **One trade-off to be aware of:** logic moved out of `.github/workflows/` into `.github/actions/`, and the agent loops' App token lacks the `workflows` scope — so they cannot push workflow changes but *can* push changes under `.github/actions/`. The mitigations are the ones already in place: `.github/**` is a governance path, so the auto-merge loop will never merge such a PR; `CODEOWNERS` routes `/.github/` review; and the `@main` pinning means a modified copy on a PR branch does not take effect until a human merges it.

## How verified

Full gate green locally:

- `npm run typecheck` (incl. `typecheck:tests`) · `npm run lint` · `npm run format:check` · `npm run build` — clean.
- `npm test` — 2871 tests, **0 failures** (538 DB-gated tests skipped: no local Postgres; CI runs them against the pgvector container).
- `npm run test:security` — 1120 `SECURITY:` tests across 153 files, manifest matches. Regenerated with `npm run test:security:fix` (+3, one new file entry).
- `npm run context:check` · `npm run imports:check` — clean.
- All 17 workflow/action YAML files parse; a script cross-checked every `uses:` against the actions' declared inputs (no extra keys, no missing required ones) and confirmed each step's `if:` condition is byte-identical to the one it replaced.
- `tests/agentRunActions.test.ts` (new, 13 tests, 3 `SECURITY:`) executes the extracted shell against stub `git`/`gh` binaries and covers: nothing-committed, trunk/detached-HEAD refusal, the ahead-of-trunk fallback, a non-sha API response still fast-forwarding, a diverged remote parking on the side ref, a rejected push falling back, an already-pushed head still reporting its ref, and the marker-on-line-1 comment. Added to `tsconfig.tests.json`'s ratchet.

**What local verification cannot cover:** these four workflows only ever run from `main`, so the first real exercise of the wiring is the first firing after merge. The tests cover the shell logic and the wiring statically; they cannot prove GitHub resolves the pinned reference in this repo's visibility settings. Worth watching the first autofix or conflict-resolver run after merge — a resolution failure would surface as a loud "action not found" step failure, not as silent skipping.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AA6sUQWj4645XiRdoJRFHt)_