### PR TITLE
Extract the tier A loops into reusable workflows, and add the adoption playbook

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -1,28 +1,8 @@
 name: Branch janitor
 
-# Deterministic, no-LLM cleanup of stale branches — same trust class as the
-# groundskeeper and auto-merge loops: reads branch/PR state only as data,
-# runs no branch-controlled code (no checkout of the branches it judges).
-#
-# WHY: the auto-merge loop only started deleting head branches on merge
-# recently (`--delete-branch`), and the user-driven squash merges before it
-# never did — by 2026-07-26 the repo had ~76 dead branches. Squash merges
-# also mean `merge-base --is-ancestor` finds almost nothing (1 of 76), so
-# the PR ledger, not git ancestry, is the reliable "this work landed" signal.
-#
-# DELETION RULES (a branch must clear one to be deleted; anything else stays):
-#   1. Ancestry-merged: its tip is an ancestor of the default branch.
-#   2. PR-merged: it is the head of at least one PR and EVERY PR with this
-#      head is MERGED (covers squash merges; a single open or closed-unmerged
-#      PR vetoes — an open PR is live work, a closed-unmerged one is a human
-#      rejection whose branch a human may still want).
-#   3. Explicitly named in the `extra` dispatch input by a maintainer —
-#      the escape hatch for branches rules 1-2 deliberately leave (e.g. a
-#      never-PR'd checkpoint branch whose content shipped via another PR).
-#      Never-PR'd branches and `-ckpt-` refs are otherwise NEVER touched.
-#
-# `main` (the default branch) is excluded structurally, and branch
-# protection on it is the enforceable backstop as everywhere else.
+# Weekly sweep of stale branches. The rules, the trust rationale and the
+# sweep itself live in .github/workflows/reusable-branch-janitor.yml; this
+# file is the schedule, the manual escape hatch, and the dry-run mapping.
 
 on:
   schedule:
@@ -33,10 +13,7 @@ on:
         description: 'List what would be deleted without deleting'
         type: boolean
         # true so a bare manual dispatch can never accidentally sweep live —
-        # a live manual run must say dry_run=false explicitly. The weekly
-        # cron supplies no inputs at all, so this default does NOT apply
-        # there: `inputs.dry_run` renders empty, != 'true', and the
-        # scheduled sweep runs live as intended.
+        # a live manual run must say dry_run=false explicitly.
         default: true
       extra:
         description: 'Comma-separated branch names to also delete (rule 3)'
@@ -53,77 +30,20 @@ permissions:
 
 jobs:
   sweep:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      DRY_RUN: ${{ inputs.dry_run }}
-      EXTRA: ${{ inputs.extra }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Sweep stale branches
-        run: |
-          set -euo pipefail
-          default="$(gh api "repos/$REPO" --jq '.default_branch')"
-          git fetch --prune origin "+refs/heads/*:refs/remotes/origin/*"
-          deleted=0; kept=0
-          delete_ref() {
-            local b="$1" why="$2"
-            if [ "$DRY_RUN" = 'true' ]; then
-              echo "DRY RUN: would delete '$b' ($why)"
-            else
-              if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null; then
-                echo "Deleted '$b' ($why)"
-              else
-                echo "::warning::Failed to delete '$b' — skipping."
-                return 0
-              fi
-            fi
-            deleted=$((deleted+1))
-          }
-          for b in $(git for-each-ref 'refs/remotes/origin/**' --format='%(refname:lstrip=3)'); do
-            [ "$b" = "$default" ] && continue
-            [ "$b" = 'HEAD' ] && continue
-            # Rule 1: ancestry-merged into the default branch.
-            if git merge-base --is-ancestor "refs/remotes/origin/$b" "refs/remotes/origin/$default"; then
-              delete_ref "$b" 'ancestry-merged'
-              continue
-            fi
-            # Rule 2: every PR with this head is MERGED (>=1 PR required).
-            # States read strictly as jq data from the PR ledger.
-            # --limit 100: the default (30) could silently truncate the state
-            # list for a branch with many reopened PRs, and a truncated list
-            # that happened to be all-MERGED would wrongly qualify a branch
-            # that still has an open/rejected PR beyond the cap.
-            states="$(gh pr list --repo "$REPO" --head "$b" --state all --limit 100 \
-              --json state --jq 'map(.state) | unique | join(",")' 2>/dev/null || echo '')"
-            if [ "$states" = 'MERGED' ]; then
-              delete_ref "$b" 'all PRs merged'
-              continue
-            fi
-            kept=$((kept+1))
-            echo "Kept '$b' (PR states: ${states:-none})"
-          done
-          # Rule 3: maintainer-named extras, validated to exist and to not be
-          # the default branch. Comma-separated; whitespace trimmed.
-          if [ -n "$EXTRA" ]; then
-            IFS=',' read -ra extras <<<"$EXTRA"
-            for raw in "${extras[@]}"; do
-              b="$(echo "$raw" | xargs)"
-              [ -z "$b" ] && continue
-              if [ "$b" = "$default" ]; then
-                echo "::warning::Refusing to delete the default branch via extra input."
-                continue
-              fi
-              if git show-ref --verify --quiet "refs/remotes/origin/$b"; then
-                delete_ref "$b" 'maintainer-named (extra input)'
-              else
-                echo "::warning::extra branch '$b' does not exist — skipping."
-              fi
-            done
-          fi
-          echo "Sweep done: $deleted deleted, $kept kept."
+    uses: ./.github/workflows/reusable-branch-janitor.yml
+    permissions:
+      contents: write
+      pull-requests: read
+    with:
+      # `|| 'false'` is load-bearing, not defensive noise. The weekly cron
+      # supplies no inputs at all, so `inputs.dry_run` renders EMPTY there —
+      # the dispatch default does NOT apply to a scheduled run. Passing it
+      # bare would hand the reusable workflow an empty string, which its
+      # "anything but 'true' sweeps live" rule reads as live: correct today,
+      # but by accident. This maps every path to an explicit literal instead —
+      # cron and a deliberate dry_run=false both yield 'false' (live), a bare
+      # or dry_run=true dispatch yields 'true' (dry). Same behaviour as
+      # before the extraction; tests/reusableWorkflows.test.ts pins it,
+      # because getting it wrong deletes branches for real.
+      dry-run: ${{ inputs.dry_run || 'false' }}
+      extra-branches: ${{ inputs.extra }}

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -2,24 +2,15 @@ name: CI retry
 
 # One free machine rerun for a failed CI run, before any agent gets involved.
 #
-# Evidence this class is real (2026-07-04): `npm ci` died with
-# `AggregateError [ETIMEDOUT]` reaching the npm registry on runs 28703072249
-# (PR #112 — a human had to push an empty "ci: retry" commit) and 28715457148
-# (a push to main), and a 16:34–18:04 UTC cluster of six zero-step
-# runner-provisioning failures (runner_id 0, logs 404) took out runs across
-# four workflows. All of these recover on a plain rerun; none need a code fix.
+# The mechanism, the evidence for a blind retry, and the staleness guard live
+# in .github/workflows/reusable-rerun-failed-run.yml — this file is the CI
+# half of the contract: the trigger, the attempt cap, and the payload facts.
 #
-# This intentionally does NOT inspect logs to classify the failure first: a
-# blind single retry costs one bounded CI run in the real-failure case, while
-# a classifier is another thing to maintain and another way to be wrong. The
-# division of labour downstream is explicit: pipeline-pr-autofix.yml only
-# engages from run_attempt >= 2, i.e. after this free retry has already been
-# spent, so a genuine failure flows attempt 1 (fail) → rerun (fail) → fix
-# agent → needs-human, and a flake costs zero agent tokens.
-#
-# Same mechanism and cap discipline as pipeline-build-retry.yml: `gh run
-# rerun --failed` re-runs only the failed jobs of the SAME run (run_attempt
-# increments), and the `< 2` guard means exactly one automatic retry.
+# The division of labour downstream is explicit: pipeline-pr-autofix.yml only
+# engages from run_attempt >= 2, i.e. after this free retry has been spent, so
+# a genuine failure flows attempt 1 (fail) → rerun (fail) → fix agent →
+# needs-human, and a flake costs zero agent tokens. Keep the `< 2` bound and
+# `max-attempts` equal — tests/reusableWorkflows.test.ts pins that.
 
 on:
   workflow_run:
@@ -35,30 +26,17 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt < 2
-    runs-on: ubuntu-latest
-    timeout-minutes: 5 # a single gh call; don't let a hung runner sit for the 6 h default
-    steps:
-      - name: Re-run the failed jobs once (unless the commit was superseded)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          FAILED_SHA: ${{ github.event.workflow_run.head_sha }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          set -euo pipefail
-          # Staleness guard (issue #223): `gh run rerun` re-enters CI's
-          # `cancel-in-progress` concurrency group as the newest arrival, so
-          # rerunning a commit that a newer push has already superseded would
-          # CANCEL the newer commit's in-flight CI (and a cancelled run is
-          # invisible to this loop and to autofix — the branch would end with
-          # no CI verdict). Only rerun if the failed run's commit is still the
-          # branch tip. A fork PR's branch isn't in this repo (404) — treat an
-          # unresolvable tip as "not stale" and rerun, matching the prior
-          # always-rerun behaviour for that case.
-          tip="$(gh api "repos/${{ github.repository }}/commits/${HEAD_BRANCH}" --jq '.sha' 2>/dev/null || echo "")"
-          if [ -n "$tip" ] && [ "$tip" != "$FAILED_SHA" ]; then
-            echo "CI run ${RUN_ID} was for ${FAILED_SHA}, but ${HEAD_BRANCH} is now at ${tip} — superseded, not rerunning (the newer commit has its own CI)."
-            exit 0
-          fi
-          echo "CI run ${RUN_ID} failed on attempt ${{ github.event.workflow_run.run_attempt }} — re-running failed jobs (one free retry)."
-          gh run rerun "${RUN_ID}" --failed -R "${{ github.repository }}"
+    uses: ./.github/workflows/reusable-rerun-failed-run.yml
+    permissions:
+      actions: write
+      contents: read
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      run-attempt: ${{ github.event.workflow_run.run_attempt }}
+      max-attempts: 2
+      # Re-run only the failed jobs: a CI run's green jobs do not need redoing.
+      failed-jobs-only: true
+      # CI is keyed to a branch tip, so the staleness guard applies here.
+      staleness-branch: ${{ github.event.workflow_run.head_branch }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
+      label: CI run

--- a/.github/workflows/pipeline-build-retry.yml
+++ b/.github/workflows/pipeline-build-retry.yml
@@ -3,21 +3,21 @@ name: Pipeline build retry
 # Auto-recover the build worker from transient/infra failures so a human is
 # only pinged for PERSISTENT ones. When a "Pipeline build worker" run fails
 # (its verify step found no PR — a flake, a cold-start timing blip, a transient
-# DB/pool hiccup, etc.), re-run it via `gh run rerun`, bounded by run_attempt.
-# The build worker's verify step only labels the issue `needs-human` on its
-# FINAL attempt, so escalation happens once retries are exhausted — replacing
-# the manual "toggle status:approved to re-trigger" that a human kept doing.
+# DB/pool hiccup), re-run it, bounded by run_attempt. The build worker's verify
+# step only labels the issue `needs-human` on its FINAL attempt, so escalation
+# happens once retries are exhausted — replacing the manual "toggle
+# status:approved to re-trigger" that a human kept doing.
 #
-# Why `gh run rerun` rather than re-adding a label: a GITHUB_TOKEN label edit
-# does NOT re-trigger the build worker (GitHub does not let Actions trigger
-# Actions via the default token — the same rule that stops GITHUB_TOKEN pushes
-# from re-running CI). Re-running the failed run is the reliable, no-PAT
-# mechanism, and it re-uses the original `issues` event so it rebuilds exactly
-# the same proposal with a fresh checkout, DB, and agent budget.
+# The rerun mechanism lives in
+# .github/workflows/reusable-rerun-failed-run.yml; this file is the build
+# half: the trigger, the cap, and the payload facts.
 #
-# A PERSISTENT failure (a real bug, or an exhausted Max pool) fails all attempts
-# and correctly lands at needs-human — auto-retry recovers flakes, it does not
-# paper over genuine breakage.
+# A PERSISTENT failure (a real bug, or an exhausted Max pool) fails all
+# attempts and correctly lands at needs-human — auto-retry recovers flakes, it
+# does not paper over genuine breakage.
+#
+# No staleness guard here, deliberately: a build run is keyed to an ISSUE, not
+# to a branch tip, so there is no "superseded commit" to detect.
 
 on:
   workflow_run:
@@ -33,18 +33,17 @@ jobs:
     # while under the attempt cap. run_attempt is 1 on the first run and
     # increments on each rerun, so `< 3` = at most two auto-reruns before the
     # build worker's own final-attempt escalation stands. MUST stay in sync with
-    # the `>= 3` cap in pipeline-build.yml's verify step.
+    # the `>= 3` cap in pipeline-build.yml's verify step, and with
+    # `max-attempts` below — tests/reusableWorkflows.test.ts pins both.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'issues' &&
       github.event.workflow_run.run_attempt < 3
-    runs-on: ubuntu-latest
-    timeout-minutes: 5 # a single gh call; don't let a hung runner sit for the 6 h default
-    steps:
-      - name: Re-run the failed build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          echo "Build run ${{ github.event.workflow_run.id }} failed on attempt ${{ github.event.workflow_run.run_attempt }} — re-running (cap 3)."
-          gh run rerun "${{ github.event.workflow_run.id }}" -R "${{ github.repository }}"
+    uses: ./.github/workflows/reusable-rerun-failed-run.yml
+    permissions:
+      actions: write
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      run-attempt: ${{ github.event.workflow_run.run_attempt }}
+      max-attempts: 3
+      label: Build run

--- a/.github/workflows/reusable-branch-janitor.yml
+++ b/.github/workflows/reusable-branch-janitor.yml
@@ -1,0 +1,133 @@
+name: Reusable — branch janitor
+
+# Deterministic, no-LLM cleanup of stale branches. Reads branch/PR state only
+# as data and runs no branch-controlled code (it never checks out the branches
+# it judges), which is what puts it in the same trust class as a groundskeeper
+# or auto-merge loop rather than with the agent workers.
+#
+# WHY IT EXISTS: squash merges leave no ancestry trail, so `merge-base
+# --is-ancestor` finds almost nothing (1 of 76 stale branches when this
+# shipped) — the PR ledger, not git ancestry, is the reliable "this work
+# landed" signal.
+#
+# DELETION RULES (a branch must clear one; anything else stays):
+#   1. Ancestry-merged: its tip is an ancestor of the default branch.
+#   2. PR-merged: it is the head of at least one PR and EVERY PR with this
+#      head is MERGED (covers squash merges; a single open or closed-unmerged
+#      PR vetoes — an open PR is live work, a closed-unmerged one is a human
+#      rejection whose branch a human may still want).
+#   3. Explicitly named in `extra-branches` by a maintainer — the escape hatch
+#      for branches rules 1-2 deliberately leave (e.g. a never-PR'd checkpoint
+#      branch whose content shipped via another PR).
+#
+# Because rule 2 requires at least one PR, never-PR'd branches — including the
+# `-ckpt-` refs the agent checkpoint parks work on — are never swept
+# automatically. That exemption is emergent from the rule, not a name pattern.
+#
+# The default branch is excluded structurally, and branch protection on it is
+# the enforceable backstop as everywhere else.
+#
+# PORTABILITY: nothing here knows anything about this repository. The default
+# branch is read from the API, and `github.repository` resolves to whichever
+# repo is calling.
+
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        description: >-
+          The literal string 'true' lists what would be deleted and deletes
+          NOTHING. ANY other value sweeps live, so pass this explicitly rather
+          than relying on an expression that can render empty. The default is
+          the safe one, so an omitted input never deletes.
+        required: false
+        default: 'true'
+        type: string
+      extra-branches:
+        description: 'Comma-separated branch names to also delete (rule 3). Whitespace is trimmed.'
+        required: false
+        default: ''
+        type: string
+      pr-list-limit:
+        description: >-
+          How many PRs to read per branch when applying rule 2. The gh default
+          (30) could silently truncate the state list for a branch with many
+          reopened PRs, and a truncated all-MERGED list would wrongly qualify a
+          branch that still has an open or rejected PR beyond the cap.
+        required: false
+        default: 100
+        type: number
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ inputs.dry-run }}
+      EXTRA: ${{ inputs.extra-branches }}
+      PR_LIMIT: ${{ inputs.pr-list-limit }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Sweep stale branches
+        run: |
+          set -euo pipefail
+          default="$(gh api "repos/$REPO" --jq '.default_branch')"
+          git fetch --prune origin "+refs/heads/*:refs/remotes/origin/*"
+          deleted=0; kept=0
+          delete_ref() {
+            local b="$1" why="$2"
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo "DRY RUN: would delete '$b' ($why)"
+            else
+              if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null; then
+                echo "Deleted '$b' ($why)"
+              else
+                echo "::warning::Failed to delete '$b' — skipping."
+                return 0
+              fi
+            fi
+            deleted=$((deleted+1))
+          }
+          for b in $(git for-each-ref 'refs/remotes/origin/**' --format='%(refname:lstrip=3)'); do
+            [ "$b" = "$default" ] && continue
+            [ "$b" = 'HEAD' ] && continue
+            # Rule 1: ancestry-merged into the default branch.
+            if git merge-base --is-ancestor "refs/remotes/origin/$b" "refs/remotes/origin/$default"; then
+              delete_ref "$b" 'ancestry-merged'
+              continue
+            fi
+            # Rule 2: every PR with this head is MERGED (>=1 PR required).
+            # States read strictly as jq data from the PR ledger.
+            states="$(gh pr list --repo "$REPO" --head "$b" --state all --limit "$PR_LIMIT" \
+              --json state --jq 'map(.state) | unique | join(",")' 2>/dev/null || echo '')"
+            if [ "$states" = 'MERGED' ]; then
+              delete_ref "$b" 'all PRs merged'
+              continue
+            fi
+            kept=$((kept+1))
+            echo "Kept '$b' (PR states: ${states:-none})"
+          done
+          # Rule 3: maintainer-named extras, validated to exist and to not be
+          # the default branch. Comma-separated; whitespace trimmed.
+          if [ -n "$EXTRA" ]; then
+            IFS=',' read -ra extras <<<"$EXTRA"
+            for raw in "${extras[@]}"; do
+              b="$(echo "$raw" | xargs)"
+              [ -z "$b" ] && continue
+              if [ "$b" = "$default" ]; then
+                echo "::warning::Refusing to delete the default branch via extra input."
+                continue
+              fi
+              if git show-ref --verify --quiet "refs/remotes/origin/$b"; then
+                delete_ref "$b" 'maintainer-named (extra input)'
+              else
+                echo "::warning::extra branch '$b' does not exist — skipping."
+              fi
+            done
+          fi
+          echo "Sweep done: $deleted deleted, $kept kept."

--- a/.github/workflows/reusable-rerun-failed-run.yml
+++ b/.github/workflows/reusable-rerun-failed-run.yml
@@ -1,0 +1,124 @@
+name: Reusable — rerun a failed workflow run
+
+# Re-run a failed workflow run, bounded by attempt count. Called by
+# ci-retry.yml and pipeline-build-retry.yml, which were the same mechanism
+# with different caps and one extra guard.
+#
+# WHY A BLIND RETRY AND NOT A CLASSIFIER (the evidence, 2026-07-04): `npm ci`
+# died with `AggregateError [ETIMEDOUT]` reaching the npm registry on runs
+# 28703072249 (PR #112 — a human had to push an empty "ci: retry" commit) and
+# 28715457148 (a push to main), and a 16:34–18:04 UTC cluster of six zero-step
+# runner-provisioning failures (runner_id 0, logs 404) took out runs across
+# four workflows. All recover on a plain rerun; none need a code fix. A blind
+# single retry costs one bounded run in the real-failure case, while a log
+# classifier is another thing to maintain and another way to be wrong.
+#
+# WHY `gh run rerun` AND NOT A LABEL TOGGLE: a GITHUB_TOKEN label edit does
+# NOT re-trigger a workflow (GitHub does not let Actions trigger Actions via
+# the default token — the same rule that stops GITHUB_TOKEN pushes from
+# re-running CI). Re-running the failed run is the reliable, no-PAT mechanism,
+# and it re-uses the original event, so it repeats exactly the same work with
+# a fresh checkout, DB and agent budget.
+#
+# THE CAP IS CHECKED TWICE, ON PURPOSE. A caller gates on `run_attempt` in its
+# job `if:` (cheapest — no runner is claimed), and this workflow re-checks the
+# same bound before calling the API. The `if:` cannot be moved in here because
+# `on:` triggers and their payload conditions belong to the caller, so without
+# the second check a caller that forgot its `if:` would rerun forever.
+#
+# PORTABILITY: nothing here knows anything about this repository. A consumer
+# supplies the trigger and the payload facts; `github.repository` resolves to
+# whichever repo is calling.
+
+on:
+  workflow_call:
+    inputs:
+      run-id:
+        description: 'The failed run to re-run.'
+        required: true
+        type: string
+      run-attempt:
+        description: 'That run''s attempt number (1 on the first run).'
+        required: true
+        type: number
+      max-attempts:
+        description: >-
+          Total attempts allowed. `run-attempt` must be strictly below this or
+          the rerun is refused. Keep it equal to the bound in the caller's `if:`.
+        required: true
+        type: number
+      failed-jobs-only:
+        description: 'Pass --failed, re-running only the failed jobs of the run.'
+        required: false
+        default: false
+        type: boolean
+      staleness-branch:
+        description: >-
+          Branch to compare against before rerunning. When set, the rerun is
+          SKIPPED if this branch has moved past `head-sha` — see the staleness
+          guard below. Leave empty for a run that is not keyed to a branch tip
+          (an issue-triggered build, say), where staleness is meaningless.
+        required: false
+        default: ''
+        type: string
+      head-sha:
+        description: 'Commit the failed run was for. Required when staleness-branch is set.'
+        required: false
+        default: ''
+        type: string
+      label:
+        description: 'How to name the run in log lines, e.g. "CI run".'
+        required: false
+        default: 'Run'
+        type: string
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # a single gh call; don't let a hung runner sit for the 6 h default
+    steps:
+      - name: Re-run the failed run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ inputs.run-id }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+          MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+          FAILED_ONLY: ${{ inputs.failed-jobs-only }}
+          STALENESS_BRANCH: ${{ inputs.staleness-branch }}
+          HEAD_SHA: ${{ inputs.head-sha }}
+          LABEL: ${{ inputs.label }}
+        run: |
+          set -euo pipefail
+
+          # Second cap check — see the header. A caller whose `if:` is missing
+          # or wrong stops here rather than rerunning without bound.
+          if [ "${RUN_ATTEMPT}" -ge "${MAX_ATTEMPTS}" ]; then
+            echo "${LABEL} ${RUN_ID} is on attempt ${RUN_ATTEMPT} of ${MAX_ATTEMPTS} — cap reached, not rerunning."
+            exit 0
+          fi
+
+          # Staleness guard (issue #223): `gh run rerun` re-enters the target
+          # workflow's `cancel-in-progress` concurrency group as the NEWEST
+          # arrival, so rerunning a commit that a newer push has already
+          # superseded would CANCEL the newer commit's in-flight run — and a
+          # cancelled run is invisible to both this loop and the fix agents, so
+          # the branch would end with no verdict at all. Only rerun while the
+          # failed run's commit is still the branch tip. A fork PR's branch is
+          # not in this repo (404): treat an unresolvable tip as "not stale"
+          # and rerun, matching the always-rerun behaviour for that case.
+          if [ -n "${STALENESS_BRANCH}" ]; then
+            tip="$(gh api "repos/${REPO}/commits/${STALENESS_BRANCH}" --jq '.sha' 2>/dev/null || echo "")"
+            if [ -n "${tip}" ] && [ "${tip}" != "${HEAD_SHA}" ]; then
+              echo "${LABEL} ${RUN_ID} was for ${HEAD_SHA}, but ${STALENESS_BRANCH} is now at ${tip} — superseded, not rerunning (the newer commit has its own run)."
+              exit 0
+            fi
+          fi
+
+          if [ "${FAILED_ONLY}" = 'true' ]; then
+            echo "${LABEL} ${RUN_ID} failed on attempt ${RUN_ATTEMPT} — re-running failed jobs (cap ${MAX_ATTEMPTS})."
+            gh run rerun "${RUN_ID}" --failed -R "${REPO}"
+          else
+            echo "${LABEL} ${RUN_ID} failed on attempt ${RUN_ATTEMPT} — re-running (cap ${MAX_ATTEMPTS})."
+            gh run rerun "${RUN_ID}" -R "${REPO}"
+          fi

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ human merge**, and branch protection on `main` is the backstop. See
 - [Capability ideas](docs/CAPABILITY-IDEAS.md) — curated backlog of candidate
   directions (not commitments)
 - [Pipeline](docs/PIPELINE.md) — the self-improving research/review/build loops
+- [Pipeline playbook](docs/PIPELINE-PLAYBOOK.md) — how to adopt this
+  automation on ANOTHER repo: the assessment questions, the component
+  catalogue, a staged rollout, and the failure modes worth knowing first
 - [CI/CD](docs/CICD.md) — mechanical reference for every workflow, the CI gate
   and its check scripts, the mechanisms shared across the loops, and what is
   portable to another repo

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -15,6 +15,7 @@ overlapping:
 | [`DEPLOYMENT.md`](DEPLOYMENT.md) | The production host: systemd units, the redeploy timer, rollback |
 | [`SECURITY.md`](SECURITY.md) | The threat model the guardrails below implement |
 | [`STANDARDS.md`](STANDARDS.md) | What a contributor must do before pushing |
+| [`PIPELINE-PLAYBOOK.md`](PIPELINE-PLAYBOOK.md) | How to adopt this automation on a DIFFERENT repo — assessment, staged rollout, portable failure modes |
 
 When this file and `PIPELINE.md` disagree about a loop's *rationale*,
 `PIPELINE.md` wins. When they disagree about a trigger, permission or

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -91,6 +91,13 @@ pool.
 | `branch-janitor.yml` | `0 3 * * 1`, dispatch (`dry_run`, `extra`) | single group | `contents:write`, `pull-requests:read` | 15 min | always |
 | `setup-labels.yml` | `workflow_dispatch` only | — | `contents:read`, `issues:write` | — | manual |
 
+Three workflows in that table are thin callers: `ci-retry.yml` and
+`pipeline-build-retry.yml` delegate to `reusable-rerun-failed-run.yml`, and
+`branch-janitor.yml` to `reusable-branch-janitor.yml`. The two `reusable-*.yml`
+files are `workflow_call`-only — they never run on their own, hold no trigger,
+and appear in the Actions list without runs of their own (a caller's run
+contains their jobs). See [§8.3](#83-proposed-shape-of-the-reusable-solution).
+
 Two notes on that permissions column. A **job-level `permissions:` block
 replaces the workflow-level grant outright** rather than adding to it — which is
 what lets the conflict resolver keep every write scope confined to the job that
@@ -518,7 +525,7 @@ What it would take to lift this into a reusable pipeline for other repos.
 
 | Tier | Meaning | Workflows |
 |---|---|---|
-| **A — portable as-is** | no repo knowledge beyond `GITHUB_TOKEN` | `ci-retry.yml`, `pipeline-build-retry.yml`, `branch-janitor.yml` |
+| **A — portable as-is** | no repo knowledge beyond `GITHUB_TOKEN` | ~~`ci-retry.yml`, `pipeline-build-retry.yml`, `branch-janitor.yml`~~ — **extracted**: now `reusable-rerun-failed-run.yml` + `reusable-branch-janitor.yml`, called by those three |
 | **B — portable with inputs** | logic is generic; label names, identities and thresholds are the only couplings | `pipeline-groundskeeper.yml`, `pipeline-pr-automerge.yml`, `pipeline-outcomes.yml`, `setup-labels.yml`, `changelog-coverage.yml` |
 | **C — portable with inputs + a project-supplied gate** | as B, plus each needs to know how to run *this project's* checks and services | `pipeline-build.yml`, `pipeline-pr-review.yml`, `pipeline-pr-autofix.yml`, `pipeline-pr-revise.yml`, `pipeline-pr-conflict.yml`, `changelog-autofill.yml` |
 | **D — project-specific by nature** | the definition of green for one codebase | `ci.yml`, `scripts/check-*.mjs` |
@@ -622,9 +629,38 @@ settle too:
 The cost/job-summary step was left alone: it appears in only two workflows
 (build and review) and they format different things.
 
-**2 · Reusable workflows (`workflow_call`) for Tiers A and B.** The
-deterministic loops carry no prompts and no project gate, so they parameterise
-cleanly:
+**2 · Reusable workflows (`workflow_call`) for Tiers A and B — Tier A DONE.**
+The deterministic loops carry no prompts and no project gate, so they
+parameterise cleanly. Tier A now lives in two `workflow_call` workflows:
+
+```
+.github/workflows/reusable-rerun-failed-run.yml  ← ci-retry, pipeline-build-retry
+.github/workflows/reusable-branch-janitor.yml    ← branch-janitor
+```
+
+Two things that extraction settled:
+
+- **`on:` triggers cannot be parameterised**, so the split is not "move the
+  whole workflow". Each caller keeps its trigger, its event-payload `if:` gate
+  and its cap, and passes the payload facts as inputs; the reusable workflow
+  owns the mechanism. That is why the attempt cap is written twice — once in
+  the caller's `if:` (the cheap gate that claims no runner) and once as
+  `max-attempts` (the backstop, for a caller whose `if:` is wrong). Both
+  `SECURITY:` tests in `tests/reusableWorkflows.test.ts` exist because that
+  duplication is structural and drifts silently.
+- **The two retry loops were the same mechanism**, differing only in cap, in
+  `--failed`, and in whether a branch-staleness guard applies. Collapsing them
+  was real deduplication rather than packaging: a fix to the staleness guard or
+  the rerun call now lands once. `branch-janitor` is the pure-packaging case —
+  its body already knew nothing about this repo.
+
+A reusable workflow rejects an undeclared input at run time (unlike a composite
+action, which ignores unknown `with:` keys silently), so that class of mistake
+fails loudly — but only once the loop next fires, which for a retry loop means
+the next red CI. The wiring test catches it at merge time instead.
+
+For a consuming repo the shape is the same, with the local path swapped for a
+pinned remote one:
 
 ```yaml
 uses: <org>/agent-pipeline/.github/workflows/automerge.yml@v1
@@ -684,7 +720,8 @@ a consumer weaken them has extracted the shape and lost the substance:
 ### 8.5 Suggested extraction order
 
 1. ~~The composite action (§8.3.1)~~ — **done**; see above.
-2. Tier A workflows — trivially portable, prove the packaging.
+2. ~~Tier A workflows~~ — **done**; see §8.3. The retry pair deduplicated;
+   the janitor proved the packaging.
 3. Tier B, starting with the groundskeeper and outcomes loops (read-mostly, low
    blast radius) and ending with auto-merge (highest stakes).
 4. Tier C, once the prompt-as-file seam exists.

--- a/docs/PIPELINE-PLAYBOOK.md
+++ b/docs/PIPELINE-PLAYBOOK.md
@@ -1,0 +1,493 @@
+# Agent pipeline adoption playbook
+
+**A specification for automating development, review and PR repair on a
+repository — written to be handed to an AI session pointed at that repository.**
+
+This is not a copy-paste kit. It is the design, the decision rules, the staged
+rollout and the hard-won failure modes, so a session can assess a specific repo,
+recommend what fits *there*, and propose a rollout the maintainer can approve one
+stage at a time.
+
+It is derived from a pipeline that has been running in production on
+`swampratnz/community-agent` — every "why" below traces to something that
+actually broke. Where a claim comes from a specific incident, the issue or PR
+number is cited so it can be checked rather than believed.
+
+---
+
+## How to use this document
+
+Point a session at the target repository with roughly this instruction:
+
+> Read `PIPELINE-PLAYBOOK.md`. Assess this repository against §2, then produce
+> the recommendation described in §9. **Do not create any workflow files yet** —
+> I want the assessment and the staged plan first.
+
+The session's job in that first pass is *diagnosis, not installation*. A rollout
+that starts before §3's prerequisites hold produces automation that fails in ways
+nobody can see, which is worse than no automation.
+
+Once a stage is approved, the same document drives implementation: §5 says what
+each component is, §6 what order to install in, §7 what to parameterise, §8 what
+must never be weakened.
+
+---
+
+## 1 · What this automates, and what it does not
+
+**The loop being automated.** An issue is approved for work → an agent implements
+it on a branch and opens a PR → an agent reviews that PR → when CI fails, or the
+review requests changes, or `main` moves under it and it conflicts, an agent
+repairs it → a human merges. Deterministic sweeps catch anything that falls
+between those steps.
+
+| It does | It does not |
+|---|---|
+| Turn an approved issue into a reviewed PR without a human present | Decide *what* is worth building (unless you add the optional discovery loops) |
+| Review every PR for correctness and security, with a written verdict | Replace human review on anything consequential |
+| Fix its own red CI, resolve its own merge conflicts, respond to review feedback | Fix things it doesn't understand — it escalates instead |
+| Recover work an agent committed but failed to push | Make an unreliable test suite reliable |
+| Escalate to a human, visibly, whenever it is out of its depth | Merge (unless you deliberately enable that at the last stage) |
+
+**The honest cost.** Every agent loop spends model tokens on a shared budget. A
+build can run 30–180 minutes of wall clock. The pipeline is worth it when the
+bottleneck is *implementation throughput on well-specified work*. It is not worth
+it when the bottleneck is deciding what to build, or when the codebase can't tell
+you whether a change is correct.
+
+**The prerequisite that decides everything.** All of this rests on a CI gate that
+genuinely distinguishes working from broken. Agents cannot tell whether their work
+is correct; the gate tells them. A repo whose tests are flaky, slow, or shallow
+will produce agents that confidently ship broken changes and repair loops that
+thrash. *Fixing the gate is stage 0, and it is not optional.*
+
+---
+
+## 2 · Assessing the target repository
+
+Work through these before recommending anything. Each finding maps to a
+consequence, not just a checkbox.
+
+### 2.1 The gate
+
+| Check | How | If absent or weak |
+|---|---|---|
+| CI runs on every PR | `.github/workflows/`, branch protection | **Blocker.** Nothing downstream is safe. Stage 0. |
+| Tests exist and mean something | coverage of the critical paths; do they catch a deliberate bug? | **Blocker for the build loop.** Review-only automation is still viable. |
+| CI is reliable | look at the last ~30 runs: what % failed for non-code reasons? | >10% flake ⇒ install the retry loop *first*, and expect repair loops to chase ghosts until it's fixed. |
+| CI is reasonably fast | median duration | >30 min makes repair loops slow and expensive; consider a fast subset for agent use. |
+| The gate is one command list | a documented "run this before pushing" | If absent, define it in stage 0 — agents and CI must run the *same* checks, or "green locally" is a lie. |
+| External services needed | DB, queues, browsers | Every agent workflow that runs the gate needs the same service containers as CI. |
+
+### 2.2 Governance
+
+| Check | If absent |
+|---|---|
+| Branch protection on the default branch | **Blocker.** This is the enforceable backstop behind every guardrail; tool allowlists are defence in depth, not a substitute. |
+| Required status checks | Add them. Without this, "green" is advisory. |
+| Who may merge | Decide before any loop can push. |
+| `CODEOWNERS` for sensitive paths | Recommended before the build loop — routes review on the parts you care most about. |
+| A conventions doc (`CLAUDE.md`, `CONTRIBUTING.md`) | **Required for the build loop.** A cold agent with no written conventions invents its own. |
+
+### 2.3 Workflow and culture
+
+| Question | Why it matters |
+|---|---|
+| Are issues actually used to track work? | The pipeline coordinates through issues + labels. No issue hygiene ⇒ no build loop; review automation still works. |
+| Is there a `Closes #N` convention? | This is how repair loops distinguish "a PR the pipeline owns" from a Dependabot bump. If absent, adopt one — it is the cheapest possible ownership signal. |
+| How many people review? | A solo maintainer gets the most from review automation. A team with fast review gets more from the build and repair loops. |
+| Fork contributions? | Fork PRs must never receive secrets or run agent code. If the repo takes external PRs, every loop needs a same-repo check — non-negotiable. |
+| Other bots active? | Dependabot etc. produce same-repo bot PRs that must be *excluded* by the ownership signal, or loops will try to "fix" them. |
+| Monorepo? | Affects concurrency grouping and whether the gate can be scoped per package. |
+
+### 2.4 Capacity and cost
+
+| Question | Consequence |
+|---|---|
+| Which model access — subscription or metered API? | Subscription: a shared pool the loops contend for; watch usage. Metered: a per-run cost you can bound. |
+| Is a production service on the same account? | Pipeline runs can starve it. Separate accounts if so. |
+| Expected PR volume | Drives cadence and caps. |
+| Tolerance for an unattended agent pushing to a branch | Determines whether stage 4 is acceptable at all. |
+
+### 2.5 Codebase shape
+
+- **Size and layout.** A large repo needs a committed orientation map (which
+  module owns which behaviour), or every cold agent session re-derives it.
+- **Test-to-code ratio.** Low ⇒ the build loop will produce plausible, unverified
+  changes.
+- **Change coupling.** If a typical change touches many files across layers, note
+  which gate catches a missed one; agents systematically forget the same files.
+- **Generated files, lockfiles, manifests.** These are the classic merge-conflict
+  hotspots and want a deterministic regeneration path rather than hand-merging.
+
+---
+
+## 3 · Non-negotiable prerequisites
+
+If any of these is false, the recommendation is stage 0 work, not automation:
+
+1. **A CI gate that fails on broken code**, running on every PR.
+2. **Branch protection on the default branch**, with required checks.
+3. **A written conventions document** an agent reads before changing code.
+4. **A same-repo ownership signal** (`Closes #N` or equivalent) so loops know
+   which PRs are theirs.
+5. **A model credential stored as a repository secret**, and — for pushes and
+   comments to appear as a distinct identity — a GitHub App installed.
+
+---
+
+## 4 · The architecture in one page
+
+```
+      ISSUE  ──labelled ready──▶  BUILD AGENT  ──▶  branch + PR "Closes #N"
+                                       │
+                                       ▼
+                                 REVIEW AGENT  ──▶  verdict comment (typed token)
+                                       │
+             ┌─────────────────────────┼─────────────────────────┐
+             ▼                         ▼                         ▼
+        CI failed              changes requested            conflicts
+             │                         │                         │
+        retry (free)              REVISE AGENT           CONFLICT AGENT
+             │                         │                         │
+        AUTOFIX AGENT ───────── all capped at N attempts ─────────┘
+             │
+             ▼
+        needs-human  ◀── every loop's terminal state ──▶  HUMAN MERGES
+```
+
+Four structural properties make it safe. They are the point of the design, not
+incidental:
+
+1. **All state lives in the forge.** Issues, labels, PR fields and marker
+   comments. No loop remembers anything; a dead run costs only its tokens.
+2. **Deterministic wherever possible.** Every decision expressible as a shell
+   condition is one. Only implementation, review and repair need a model.
+3. **The workflow owns state transitions, not the agent.** Agents are granted
+   no ability to relabel arbitrary issues; the workflow claims and releases lanes
+   around them.
+4. **Every loop has a bounded number of attempts and one terminal state**
+   (`needs-human`) that takes the item out of automation entirely.
+
+---
+
+## 5 · Component catalogue
+
+Each entry: what it does, what triggers it, the permissions it needs, what it
+depends on, and how it fails. Install order is §6.
+
+### 5.1 Deterministic components (no model, no token cost)
+
+**CI retry** — re-runs a failed CI run once, blindly, before any agent engages.
+Trigger: CI run completed with failure, attempt < 2. Permissions: `actions:write`,
+`contents:read`. *Why blind rather than a log classifier: a classifier is another
+thing to maintain and another way to be wrong; a single retry costs one bounded
+run.* Include a **staleness guard** — if the branch has moved past the failed
+commit, don't re-run, or you cancel the newer commit's in-flight CI and the branch
+ends with no verdict at all.
+
+**Build retry** — re-runs a failed build-agent run, capped (3 attempts total).
+Same shape. Exists so transient infrastructure failures don't consume human
+attention. *Note the gap it cannot cover: a run that hits its timeout reports
+`cancelled`, not `failure`, and is invisible to failure-keyed retries — that's the
+groundskeeper's job.*
+
+**Groundskeeper** — hourly sweep for zombie state: an issue marked in-progress
+with no open PR and no activity for N hours gets escalated to a human, both status
+labels cleared. Permissions: `issues:write`, `pull-requests:read`. This is what
+enforces "in-progress means a build is actually running". Without it, a timed-out
+build wedges its lane forever and starves the queue.
+
+**Branch janitor** — weekly deletion of branches whose work has landed. Deletes
+only when ancestry-merged *or* every PR with that head is merged. *Squash merges
+leave no ancestry trail — the PR ledger, not git ancestry, is the reliable signal.*
+Ship it dry-run-by-default; a scheduled run supplies no inputs, so map the dry-run
+flag to an explicit literal rather than relying on a dispatch default.
+
+**Changelog coverage / outcome ledger** — read-only reporting. The outcome ledger
+is the one that earns its place fastest: it reconstructs per-loop success,
+recovery and escalation counts from marker comments the loops already post, so
+"is this loop earning its tokens?" has an answer. Watch the **recovered** count —
+every one is a prompt or harness defect, not a code defect.
+
+### 5.2 Agent components
+
+**Review agent** — reviews each PR's diff and posts one verdict comment.
+Trigger: `pull_request` opened/synchronize/reopened/ready_for_review.
+Permissions: `contents:read`, `pull-requests:write`. **Run it read-only**: give
+the agent no write tools, capture its final message, and have a deterministic step
+post the comment. That avoids permission-denial thrash and guarantees a comment on
+every run, including clean ones.
+
+*The verdict must be a typed artifact, not prose.* Have the model emit a hidden
+token (`<!-- verdict:LGTM -->` / `CHANGES_REQUESTED` / `NEEDS_HUMAN`), and have the
+one workflow that composes the comment stamp exactly one authoritative token.
+Every consumer reads that token. Free-prose parsing across multiple consumers
+drifts, and the drift is silent: a fix landing in two of three consumers left
+approved PRs sitting unmerged forever with no error anywhere.
+
+**Build agent** — implements an approved issue on a branch and opens a PR.
+Trigger: issue labelled ready. Permissions: `contents`/`issues`/`pull-requests`
+write. The heaviest component and the one with the most machinery around it:
+
+- The **workflow**, not the agent, claims the lane before the run and marks it
+  built after. The agent gets no ability to edit issue labels — a matcher can't
+  pin an issue number, so that grant would let an injected agent mark an arbitrary
+  issue ready and spawn an unreviewed build.
+- **Push incrementally.** The agent's credential can expire mid-run (~1h) while
+  the job budget is much longer; an unpushed tree dies with the runner.
+- A **deterministic checkpoint** after the agent exits pushes anything it
+  committed but never pushed. Prompt-only compliance is provably unreliable —
+  agents have finished entire builds and ended their turn without pushing.
+- A **verify-else-escalate** step asserts the outcome (does a PR closing this
+  issue exist?) and fails loudly otherwise. An agent that narrates work it didn't
+  do must never produce a green run.
+- Escalate on the **final** attempt only, and clear *both* status labels so the
+  item leaves the automated lanes entirely.
+
+**Autofix agent** — repairs a build-agent PR whose CI failed. Trigger: CI run
+failed, same-repo, ownership signal present, attempt ≥ 2 (after the free retry).
+Capped at 2 attempts, then escalate. Must skip PRs already escalated.
+
+**Conflict resolver** — merges the default branch into a conflicting PR and
+resolves. Triggers: push to default branch, PR opened, plus a slow sweep — the
+forge emits no webhook for the conflicting transition, and a PR can be *born*
+conflicted. One attempt per conflict, then escalate.
+
+**Revise agent** — responds to a changes-requested review on a green PR. Without
+it, that edge has no responder: the build agent is one-shot and autofix only reacts
+to CI failure. Capped at 2 attempts (the push re-triggers review, so uncapped it
+becomes a reviewer-vs-reviser loop).
+
+**Auto-merge** (optional, last) — merges fully-vetted PRs one at a time. Keep it
+**deterministic — no model at all**: it reads PR fields as data and runs no
+PR-controlled code, so it has none of the repair loops' injection surface.
+Requires: exact author identity match, ownership signal, all checks green,
+mergeable, a fresh approving verdict *newer than the head commit*, no stop labels,
+and **no change to any governance path** (CI config, the check scripts, the
+workflows themselves, the conventions docs). Ship it inert behind a mode variable:
+unset → does nothing, `dry-run` → logs what it would merge, `live` → merges.
+
+---
+
+## 6 · Staged rollout
+
+Each stage has entry criteria, a verification step, and a rollback. **Do not skip
+ahead**: each stage's failure mode is cheap to see only when the earlier stages
+are already trustworthy.
+
+### Stage 0 — Foundations *(no automation)*
+- **Install:** nothing. Fix the gate, turn on branch protection with required
+  checks, write the conventions doc, adopt the ownership signal, create the labels.
+- **Verify:** the gate command list passes locally and in CI, and it fails when you
+  deliberately break something.
+- **Exit:** all five prerequisites in §3 hold.
+
+### Stage 1 — Deterministic loops *(zero token cost)*
+- **Install:** CI retry, branch janitor (dry-run), changelog/outcome reporting.
+  Groundskeeper only once lane labels exist.
+- **Verify:** deliberately fail a CI run and watch the retry fire once, and only
+  once. Run the janitor dry and read what it *would* delete.
+- **Exit:** a week of clean runs. Rollback: disable the workflow.
+- **Why first:** it proves the plumbing — permissions, triggers, concurrency — with
+  no model and no risk, and the CI retry is a *prerequisite* for autofix (without
+  it, fix agents spend tokens chasing flakes).
+
+### Stage 2 — Review agent *(read-only)*
+- **Install:** the review workflow with the read-only pattern and the typed verdict.
+- **Verify:** open a PR with a deliberate flaw and check the verdict catches it;
+  open a clean one and check it still comments.
+- **Exit:** verdicts are useful on ~10 real PRs. Rollback: remove the workflow;
+  nothing else depends on it yet.
+- **Why second:** highest value per unit risk. It cannot write code, cannot merge,
+  and gives an immediate read on whether the model understands this codebase — which
+  is exactly the question stage 3 depends on.
+
+### Stage 3 — Build agent
+- **Entry:** stage 2 verdicts have been consistently sensible.
+- **Install:** the build workflow with all four safeguards (workflow-owned lane
+  labels, incremental push, checkpoint, verify-else-escalate) plus build retry.
+- **Verify:** label **one** issue and watch the whole run. Read the PR as if a new
+  contributor wrote it.
+- **Exit:** three consecutive builds that produce a mergeable PR.
+- **Rollback:** remove the trigger label from the queue; the loop goes idle.
+- **Caution:** there is no dry-run for this. The moment the secret exists and an
+  issue is labelled, it builds and opens a PR for real. Roll out by labelling one
+  issue and watching, not by flipping a config flag.
+
+### Stage 4 — Repair loops
+- **Entry:** stage 3 produces PRs that are usually right, and CI retry has been
+  running long enough to know the flake rate.
+- **Install:** autofix first (it has the clearest success signal), then conflict
+  resolver, then revise.
+- **Verify:** each on a real instance — a genuinely red PR, a genuinely conflicted
+  one. Confirm the attempt cap by watching one escalate.
+- **Exit:** the outcome ledger shows more repairs than escalations, and few or no
+  "recovered" events.
+- **Rollback:** per-loop workflow disable.
+
+### Stage 5 — Auto-merge *(optional, and reversible)*
+- **Entry:** everything above is boring. Several weeks of it.
+- **Install:** inert. Then `dry-run` for a week — read every "would merge" line and
+  confirm you agree. Only then `live`.
+- **Exit:** never fully; keep watching. Rollback: unset the mode variable.
+- **Do not enable** if a human merge is your only backstop against a
+  prompt-injected review verdict.
+
+### Optional — Discovery loops
+Research and adversarial-review agents that *propose* and *vet* work rather than
+implement it. Add only when the pipeline is starved of well-specified issues, not
+before: they increase the queue, and a queue of vague issues makes the build agent
+worse, not busier.
+
+---
+
+## 7 · What to parameterise per repository
+
+The session should produce a filled-in table like this for the target repo:
+
+| Parameter | Example | Notes |
+|---|---|---|
+| Lane labels | `status:approved` → `status:building` → `status:built` | Must not collide with existing labels |
+| Stop label | `needs-human` | One label, every loop honours it |
+| Pin-out labels | `no-auto-merge`, `no-auto-resolve` | Per-loop manual override |
+| Ownership signal | `Closes #N` in the PR body | How loops identify their own PRs |
+| Agent identity | the App's bot login | Auto-merge must match this **exactly**, not "any bot" |
+| Deterministic identity | the Actions bot | Must differ from the agent identity — see §8 |
+| Gate commands | `npm ci && npm test && …` | Identical in CI and in every agent workflow |
+| Service containers | Postgres, etc. | Mirror CI exactly |
+| Required env | timezone, locale, dummy credentials | Anything the app refuses to boot without |
+| Governance paths | `.github/**`, CI config, conventions docs | Never auto-merged |
+| Attempt caps | 2 agent attempts, 3 build retries, 1 CI retry | Write once per loop; if duplicated, test the agreement |
+| Staleness threshold | 4h | Must exceed the build timeout |
+| Timeouts | build 180m, repair 45m, review 20m | Generous: a throttled run should finish slowly, not be killed |
+| Model + turn budget | per loop | Match cognitive demand × frequency |
+| Schedules | hourly sweep, weekly janitor | Offset from the top of the hour |
+
+---
+
+## 8 · Invariants that must never be weakened
+
+These are the properties that make the difference between automation and an
+unattended write credential. A rollout that trades any of them away has kept the
+shape and lost the substance.
+
+1. **Fork PRs never receive secrets and never run agent code.** Workflows
+   triggered by a completed run carry secrets even for fork PRs — those need an
+   explicit same-repo check in the job condition.
+2. **The agent identity and the deterministic identity are different.** The agent
+   must not be able to write into channels the deterministic steps read — verdict
+   comments, lane labels, handoff notes. If both are the same account, an injected
+   agent can forge its own approval.
+3. **Verify-else-escalate fails loudly.** A run that produced nothing must never be
+   green.
+4. **Every self-retriggering loop has an attempt cap** and a terminal escalation.
+5. **Governance paths always require a human merge.** A pipeline that can
+   auto-merge a change to its own gates has no gates. The list is configurable;
+   having a non-empty list is not.
+6. **Branch protection is the enforceable backstop.** Tool allowlists raise the
+   bar — the agents have code execution, so they are defence in depth, never a
+   guarantee.
+7. **Untrusted content is data, never instructions.** Issue text, PR bodies, review
+   comments, CI logs. Where such content flows into a later agent's prompt, bound
+   it, quote it, strip control tokens, and tell the reader it may only *add*
+   scrutiny, never remove it.
+8. **The stop label is a hard stop for every loop.** No loop re-claims an escalated
+   item.
+
+---
+
+## 9 · The recommendation the session should produce
+
+Not a plan to execute — a proposal for the maintainer to approve.
+
+1. **Fit summary** (short): what this repo would gain, what it would not, and the
+   single biggest obstacle.
+2. **Prerequisite gaps** — each of §3's five, with current state and the concrete
+   work to close it.
+3. **Per-component recommendation** — for each component in §5: *adopt now / adopt
+   later / skip*, with a repo-specific reason. Skipping is a legitimate and common
+   answer.
+4. **The staged plan**, mapped onto §6 with this repo's specifics: what gets
+   installed at each stage, how to verify it *here*, and what would trigger a
+   rollback.
+5. **The filled-in parameter table** (§7).
+6. **Repo-specific risks** — flaky tests, fork traffic, a slow gate, existing bot
+   noise, a monorepo layout, a production service sharing the model budget.
+7. **Estimated cost**, in runs per week and rough token spend, at the first stage
+   that spends anything.
+
+Then stop, and let a human choose the stage to start.
+
+---
+
+## 10 · Failure modes worth knowing before you design
+
+Every one of these looks correct on paper and is wrong in practice. They are the
+most valuable part of this document.
+
+**Forge mechanics**
+
+- **Events created with the default token never trigger workflows.** A comment or
+  label written by a workflow will not start another one. Anywhere you need
+  workflow-to-workflow handoff, use an explicit dispatch — that is one of the few
+  exceptions. (This also means a default-token push does not re-run CI, which is
+  what makes checkpoint pushes free of side effects.)
+- **A shared concurrency group silently cancels queued runs.** A group holds one
+  pending run; a third arrival evicts the second. And a *cancelled* run is not a
+  *failure*, so failure-keyed retries never see it. Use per-item groups.
+- **A job-level timeout kills even always-run steps**, so checkpoint and escalate
+  machinery never runs on a timed-out job. The timeout must be a genuine outlier,
+  and a separate sweep must catch what it leaves behind.
+- **Composite actions ignore unknown inputs silently.** A renamed input degrades to
+  its default with no error. Reusable workflows reject them — but only at run time.
+- **A locally-referenced action resolves from the workspace**, which on a PR-repair
+  workflow is the pull request's own head. Reference shared actions by a ref pinned
+  to the default branch, or PR content defines the step that judges it.
+- **CLI tools print error bodies to stdout.** A failed API lookup can yield a
+  plausible-looking string that flows into a comparison. Validate the *shape* of
+  anything you branch on.
+
+**Agent behaviour**
+
+- **Agents end their turn waiting for work that will never resume.** In a one-shot
+  job there is no async resume — the process exits. State it plainly in the prompt
+  *and* add a deterministic post-step, because the prompt alone provably does not
+  hold: two loops ended their turns waiting on background tasks with completed work
+  committed, and both escalated with nothing to show.
+- **Agents narrate work they did not do.** A run can finish "successfully" having
+  produced nothing. Assert outcomes, never self-reports.
+- **Agent credentials expire mid-run.** Push incrementally; recover with the job's
+  own token afterwards.
+
+**Process**
+
+- **A blind retry beats a failure classifier.** Cheaper, and one fewer thing to be
+  wrong about.
+- **Free-prose parsing across multiple consumers drifts silently.** Make
+  cross-workflow contracts typed, stamp them in exactly one place, and test that
+  the copies agree.
+- **Duplicated constants drift.** Where a cap must appear twice (a cheap gate plus
+  a backstop), test the agreement rather than commenting "keep in sync".
+- **Squash merges break ancestry-based cleanup.** Use the PR ledger.
+- **A stale orientation map is worse than none** — it sends a cold session
+  confidently to a path that moved. Gate it, or don't keep one.
+- **Shared append points cause pairwise conflicts.** A single counter or changelog
+  section that every PR edits will make every concurrent PR conflict. Prefer
+  per-file entries and sorted manifests so unrelated changes land in different
+  hunks.
+
+---
+
+## 11 · Operating it
+
+- **One kill switch.** Removing the model credential should make every agent loop
+  inert. Verify that early.
+- **Watch the recovered count.** Work that had to be rescued by a checkpoint is a
+  harness defect, and it is the failure mode that costs the most.
+- **Watch escalation rate per loop.** A loop that mostly escalates is mis-scoped or
+  being handed work it can't do.
+- **Watch the budget.** Parallel agent runs contend; bursts throttle each other
+  into timeouts. Stagger approvals rather than releasing a queue at once.
+- **Re-read the invariants (§8) whenever you change a workflow.** They are the part
+  a well-meaning refactor quietly erodes.

--- a/tests/reusableWorkflows.test.ts
+++ b/tests/reusableWorkflows.test.ts
@@ -1,0 +1,203 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The reusable workflows (.github/workflows/reusable-*.yml) and their callers.
+ *
+ * `ci-retry.yml` and `pipeline-build-retry.yml` were the same mechanism with
+ * different caps, and `branch-janitor.yml` carried a sweep whose body knew
+ * nothing about this repo; all three now call a `workflow_call` workflow and
+ * keep only their trigger, gating and parameters. That split is worth pinning
+ * because two of its invariants are silent when broken:
+ *
+ *   1. THE ATTEMPT CAP IS WRITTEN TWICE — once in the caller's job `if:`
+ *      (`run_attempt < N`, the cheap gate that claims no runner) and once as
+ *      `max-attempts: N` (the backstop inside the reusable workflow). GitHub
+ *      cannot express the `if:` inside a reusable workflow, because triggers
+ *      and their payload conditions belong to the caller, so the duplication
+ *      is structural. If the two drift, the loop either retries past its cap
+ *      or refuses a retry it should make — neither fails loudly.
+ *   2. THE DRY-RUN MAPPING deletes branches when it is wrong, and the failure
+ *      is invisible until refs are gone. The weekly cron supplies no inputs,
+ *      so `inputs.dry_run` renders empty on that path and the caller must map
+ *      it to an explicit literal.
+ */
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const workflow = (name: string) => readFileSync(path.join(repoRoot, '.github/workflows', name), 'utf8');
+
+const RERUN = './.github/workflows/reusable-rerun-failed-run.yml';
+const JANITOR = './.github/workflows/reusable-branch-janitor.yml';
+
+/** Declared `workflow_call` input names of a reusable workflow. */
+function declaredInputs(source: string): Set<string> {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line.trim() === 'inputs:');
+  assert.notEqual(start, -1, 'no `inputs:` block');
+  const names = new Set<string>();
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    const match = /^ {6}([a-z0-9-]+):\s*$/.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+/** Required input names of a reusable workflow. */
+function requiredInputs(source: string): Set<string> {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line.trim() === 'inputs:');
+  const names = new Set<string>();
+  let current = '';
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    const head = /^ {6}([a-z0-9-]+):\s*$/.exec(line);
+    if (head) current = head[1];
+    else if (/^ {8}required:\s*true\s*$/.test(line) && current) names.add(current);
+  }
+  return names;
+}
+
+/** The `with:` keys a caller passes at its `uses:` of a reusable workflow. */
+function withKeys(source: string, usesRef: string): string[] {
+  const lines = source.split('\n');
+  const at = lines.findIndex((line) => line.trim() === `uses: ${usesRef}`);
+  assert.notEqual(at, -1, `no caller job uses ${usesRef}`);
+  const keys: string[] = [];
+  let seenWith = false;
+  for (const line of lines.slice(at + 1)) {
+    if (line.trim() === 'with:') {
+      seenWith = true;
+      continue;
+    }
+    if (!seenWith) continue;
+    if (/^\s{0,4}\S/.test(line)) break;
+    const match = /^\s{6}([a-z0-9-]+):/.exec(line);
+    if (match) keys.push(match[1]);
+  }
+  return keys;
+}
+
+/** The numeric bound in a caller's `run_attempt < N` gate. */
+function attemptGate(source: string): number {
+  const match = /run_attempt\s*<\s*(\d+)/.exec(source);
+  assert.ok(match, 'no `run_attempt < N` gate found in the caller');
+  return Number(match[1]);
+}
+
+/** The `max-attempts:` literal the caller passes. */
+function maxAttempts(source: string): number {
+  const match = /max-attempts:\s*(\d+)/.exec(source);
+  assert.ok(match, 'no `max-attempts:` passed by the caller');
+  return Number(match[1]);
+}
+
+const CALLERS = [
+  { name: 'ci-retry.yml', ref: RERUN, reusable: 'reusable-rerun-failed-run.yml' },
+  { name: 'pipeline-build-retry.yml', ref: RERUN, reusable: 'reusable-rerun-failed-run.yml' },
+  { name: 'branch-janitor.yml', ref: JANITOR, reusable: 'reusable-branch-janitor.yml' },
+] as const;
+
+test('each caller delegates to its reusable workflow and keeps no inline implementation', () => {
+  for (const { name, ref } of CALLERS) {
+    const source = workflow(name);
+    assert.ok(source.includes(`uses: ${ref}`), `${name} does not call ${ref}`);
+    assert.equal(
+      /^\s+run: \|/m.test(source),
+      false,
+      `${name} still carries an inline run block — the implementation belongs to the reusable workflow`,
+    );
+  }
+});
+
+test('every `with:` key a caller passes is a declared input of the reusable workflow', () => {
+  // Unlike a composite action (which ignores unknown keys silently), a
+  // reusable workflow REJECTS an undeclared input at run time — which for
+  // these loops means discovering it only when CI has already gone red.
+  for (const { name, ref, reusable } of CALLERS) {
+    const declared = declaredInputs(workflow(reusable));
+    for (const key of withKeys(workflow(name), ref)) {
+      assert.ok(declared.has(key), `${name} passes \`${key}\`, which ${reusable} does not declare`);
+    }
+  }
+});
+
+test('every required input of a reusable workflow is passed by its callers', () => {
+  for (const { name, ref, reusable } of CALLERS) {
+    const required = requiredInputs(workflow(reusable));
+    const passed = withKeys(workflow(name), ref);
+    for (const key of required) {
+      assert.ok(passed.includes(key), `${name} omits required input \`${key}\` of ${reusable}`);
+    }
+  }
+});
+
+test("SECURITY: the attempt cap in a caller's gate equals the max-attempts it passes", () => {
+  // The cap is deliberately written twice (see the file header). Drift is
+  // silent: too high and a loop retries past its bound, burning runs and — for
+  // the build worker — delaying the needs-human escalation that a human is
+  // waiting on; too low and a retry that should happen never does.
+  for (const name of ['ci-retry.yml', 'pipeline-build-retry.yml']) {
+    const source = workflow(name);
+    assert.equal(
+      attemptGate(source),
+      maxAttempts(source),
+      `${name}: the \`run_attempt < N\` gate and \`max-attempts\` disagree`,
+    );
+  }
+});
+
+test('the build-retry cap stays in sync with the build worker it re-runs', () => {
+  // pipeline-build.yml escalates `needs-human` on its FINAL attempt, keyed to
+  // the same number. If the retry loop's cap exceeds it, the issue is
+  // escalated while retries are still running.
+  const build = workflow('pipeline-build.yml');
+  const cap = maxAttempts(workflow('pipeline-build-retry.yml'));
+  assert.ok(
+    new RegExp(`>=\\s*${cap}\\b`).test(build),
+    `pipeline-build.yml has no \`>= ${cap}\` final-attempt check matching the retry cap`,
+  );
+});
+
+test('SECURITY: the branch janitor never hands its sweep an ambiguous dry-run value', () => {
+  // The weekly cron supplies NO inputs, so `inputs.dry_run` renders empty on
+  // that path — the dispatch default does not apply. Passed bare, the reusable
+  // workflow's "anything but 'true' is live" rule would read that empty string
+  // as a live sweep: right today, but by accident. The caller must map every
+  // path to an explicit literal.
+  const caller = workflow('branch-janitor.yml');
+  assert.match(
+    caller,
+    /dry-run:\s*\$\{\{\s*inputs\.dry_run\s*\|\|\s*'false'\s*\}\}/,
+    'branch-janitor.yml must map dry_run to an explicit literal for the scheduled path',
+  );
+  // And the reusable workflow's own default must be the SAFE one, so an
+  // omitted input can never delete.
+  const reusable = workflow('reusable-branch-janitor.yml');
+  const block = reusable.slice(reusable.indexOf('dry-run:'));
+  assert.match(
+    block.slice(0, block.indexOf('extra-branches:')),
+    /default:\s*'true'/,
+    "reusable-branch-janitor.yml's dry-run default must be 'true' (dry) so an omitted input never deletes",
+  );
+});
+
+test('the reusable workflows carry no reference to this repository', () => {
+  // The point of tier A: the bodies are portable. `github.repository` resolves
+  // to whichever repo calls them, so a hardcoded owner/repo would be a bug.
+  for (const name of ['reusable-rerun-failed-run.yml', 'reusable-branch-janitor.yml']) {
+    const source = workflow(name);
+    const body = source
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .join('\n');
+    assert.equal(
+      /swampratnz|community-agent/.test(body),
+      false,
+      `${name} names this repository outside a comment — it must stay repo-agnostic`,
+    );
+  }
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -124,6 +124,7 @@
   "repeatQuestionShortcutRouter.test.ts": 4,
   "replyRetractionDisabled.test.ts": 2,
   "replyRetractionRouter.test.ts": 1,
+  "reusableWorkflows.test.ts": 2,
   "reviewVerdict.test.ts": 5,
   "router.test.ts": 9,
   "routerInterceptChain.test.ts": 4,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -39,6 +39,7 @@
     "tests/platformRegistry.test.ts",
     "tests/projectScope.test.ts",
     "tests/repeatQuestionShortcutRouter.test.ts",
+    "tests/reusableWorkflows.test.ts",
     "tests/routerInterceptChain.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
     "tests/toolTierMap.test.ts",


### PR DESCRIPTION
Two related changes: step 2 of the extraction plan in `docs/CICD.md` §8.5, and the portable playbook that plan was ultimately for.

The second commit is docs-only and independent — happy to split it out if you'd rather review them separately.

---

# 1 · Tier A extracted into reusable workflows

Tier A is the three deterministic loops whose bodies carry no repo knowledge beyond `GITHUB_TOKEN`: `ci-retry`, `pipeline-build-retry`, `branch-janitor`. They now delegate to two `workflow_call` workflows:

```
.github/workflows/reusable-rerun-failed-run.yml  ← ci-retry, pipeline-build-retry
.github/workflows/reusable-branch-janitor.yml    ← branch-janitor
```

**The retry pair turned out not to be merely portable — it was duplicated.** Both re-run a failed run under an attempt cap via `gh run rerun`, differing only in the cap (2 vs 3), in `--failed`, and in whether the branch-staleness guard applies. Collapsing them is real deduplication. `branch-janitor` is the pure-packaging case the plan described.

### What the split looks like, and why

**`on:` triggers cannot be parameterised**, so this is not "move the whole workflow into a reusable one". Each caller keeps its trigger, its event-payload `if:` gate and its cap, and passes the payload facts as inputs; the reusable workflow reads nothing from the event context. That is what makes the bodies portable — `github.repository` resolves to whichever repo calls them, and a test asserts neither file names this one outside a comment.

One consequence deserves attention: **the attempt cap is now written twice** — in the caller's `if:` (the cheap gate, which claims no runner) and as `max-attempts` (a backstop *inside* the reusable workflow, so a caller with a broken `if:` cannot rerun without bound). Structural duplication that drifts silently, so a `SECURITY:` test pins the two together, and a second pins the build-retry cap to `pipeline-build.yml`'s final-attempt escalation — the "MUST stay in sync" comment that previously relied on someone reading it.

### The branch-janitor dry-run mapping

Worth reading closely, since this workflow deletes refs. The weekly cron supplies **no inputs**, so `inputs.dry_run` renders *empty* there — a `workflow_dispatch` default does not apply to a scheduled run. The old inline code read that empty value through `[ "$DRY_RUN" = 'true' ]` and swept live: correct, but by accident.

The caller now maps every path to an explicit literal (`inputs.dry_run || 'false'`), and the reusable workflow's own default is the safe one, so an **omitted** input can never delete. Behaviour unchanged on both paths.

---

# 2 · The adoption playbook

`docs/CICD.md` documents this repo's pipeline, and its §8 sketches a reusable version. What was missing is what a maintainer actually needs to automate a *different* repo: not files to copy, but the assessment, the decision rules and the rollout order.

`docs/PIPELINE-PLAYBOOK.md` is written to be handed to an AI session pointed at a target repository, and it insists on diagnosis before installation — assess the repo (§2), check five non-negotiable prerequisites (§3), then produce a recommendation and staged plan (§9) for a human to approve one stage at a time.

The staging is ordered by risk and dependency rather than ambition:

| Stage | Why here |
|---|---|
| 0 · Foundations | A gate that fails on broken code, branch protection, conventions doc. Everything else is unsafe without it |
| 1 · Deterministic loops | Zero token cost, proves the plumbing — and CI retry is a *prerequisite* for autofix, or fix agents spend tokens chasing flakes |
| 2 · Review agent | Read-only: highest value per unit risk, and the cheapest read on whether a model understands this codebase — which is the question stage 3 depends on |
| 3 · Build agent | The heavy one. No dry-run exists: label one issue and watch |
| 4 · Repair loops | Autofix first (clearest success signal), then conflict, then revise |
| 5 · Auto-merge | Last, inert → dry-run → live, and only when everything above is boring |

The most portable content is §10, the failure modes — default-token events never triggering workflows, a shared concurrency group silently cancelling queued runs, a job timeout killing the very always-run steps meant to recover from it, composite actions ignoring unknown inputs, locally-referenced actions resolving from a PR-controlled workspace, agents ending their turn waiting for work that will never resume, free-prose contracts drifting between consumers. Each looks correct on paper; each cost this repo real incidents.

And §8, the invariants a rollout must not trade away: fork isolation, identity separation between the agent and the deterministic steps, loud verify-else-escalate, attempt caps, governance paths always human-merged, and branch protection as the enforceable backstop *behind* tool allowlists rather than a substitute for them.

---

## Security / privacy impact

**Part 1** — no new capability. Permission grants are unchanged and declared on the calling job, so a reusable workflow cannot exceed its caller: `actions:write` (+`contents:read` for the staleness lookup) for the retry loops, `contents:write`/`pull-requests:read` for the janitor. Both reusable workflows read inputs via `env:` rather than interpolating into a `run:` body, execute no repo- or PR-controlled code, and the janitor still never checks out the branches it judges. Two safety backstops added (the second cap check, the safe-by-default dry-run), none removed. The `-ckpt-` exemption is unchanged and still emergent from "rule 2 requires ≥1 PR", now documented as such so a consumer doesn't mistake it for a name pattern.

`./`-relative reusable-workflow references resolve from the **calling workflow's own ref**, not a checked-out workspace, so the `@main`-pinning concern from #992 does not apply — no workspace is involved and no checkout precedes the call.

**Part 2** — documentation only, no code. It describes existing guardrails and adds none. Worth noting it deliberately *hardens* the security framing for any future adopter: §8 lists the invariants as non-negotiable, and §10 explains why tool allowlists are defence in depth rather than a guarantee.

## How verified

Full gate green locally:

- `npm run typecheck` (incl. `typecheck:tests`) · `npm run lint` · `npm run format:check` · `npm run build` — clean.
- `npm test` — 2878 tests, **0 failures** (538 DB-gated skipped: no local Postgres; CI runs them).
- `npm run test:security` — 1122 `SECURITY:` tests across 154 files, manifest matches (`test:security:fix`, +2).
- `npm run context:check` · `npm run imports:check` — clean. All 19 workflow/action YAML files parse.
- `tests/reusableWorkflows.test.ts` (new, 7 tests, 2 `SECURITY:`): each caller delegates and keeps no inline `run:` block; every `with:` key is a declared input; every required input is passed; cap-vs-`max-attempts` agreement; build-retry cap vs the build worker's escalation; the dry-run mapping and safe default; and no repo name in either reusable body.
- **Both `SECURITY:` tests were mutation-checked** — introducing cap drift (`max-attempts: 2` → `4`) and reverting the dry-run mapping to a bare passthrough each turn their test red, then green again on restore. A drift test that cannot fail is worse than none.

**What local verification cannot cover:** these workflows only run from `main`, so the first real exercise is the next red CI (`ci-retry`), the next failed build (`pipeline-build-retry`), or Monday 03:00 UTC (`branch-janitor`). A malformed `uses:` or an undeclared input fails loudly rather than skipping silently. The janitor is the one to watch since it is the only Tier A loop that deletes anything — a manual dispatch with the default `dry_run=true` exercises it at zero risk.

**Unrelated observation, left alone:** `tsconfig.tests.json`'s include list has one pre-existing out-of-order entry (`tests/stringsCatalogue.test.ts`, present on `main` before this branch). Nothing gates the ordering and moving it would touch an unrelated line, so I left it; the new entry is correctly placed.
