### PR TITLE
Let the conflict resolver un-stick changelog-autofill PRs

### DIFF
--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -29,8 +29,9 @@ name: Pipeline PR conflict resolver
 # and pushes code, so they matter):
 #   * Same-repo PRs only (never a fork — workflow-triggered secrets + a push
 #     tool must never run against fork-controlled branches; the discover filter
-#     hard-requires !isCrossRepository). Author must be EITHER the build-worker
-#     bot (with a `Closes #` body) OR a trusted maintainer in MAINTAINER_LOGINS
+#     hard-requires !isCrossRepository). Author must be the build-worker
+#     bot (with a `Closes #` body), the changelog-autofill loop (bot-authored
+#     on its one fixed branch), OR a trusted maintainer in MAINTAINER_LOGINS
 #     (the repo owner's own human PRs — main churn otherwise leaves them stuck
 #     CONFLICTING with no responder). Fork/external-human PRs stay excluded.
 #   * PRs labelled `needs-human` OR `no-auto-resolve` are SKIPPED — the former
@@ -159,7 +160,18 @@ jobs:
           #   (a) a BUILD-WORKER PR — bot-authored with a `Closes #<issue>` body
           #       (the build worker's contract; the `Closes #` test keeps an
           #       unrelated bot PR like a Dependabot bump out), OR
-          #   (b) a MAINTAINER PR — authored by a login in MAINTAINER_LOGINS
+          #   (b) a CHANGELOG-AUTOFILL PR — bot-authored on that loop's ONE
+          #       fixed branch (changelog-autofill.yml's AUTOFILL_BRANCH). It
+          #       is drafted from the daily coverage check, not from an issue,
+          #       so it can never carry a `Closes #` and (a) can never match
+          #       it — while it conflicts constantly, because it edits the one
+          #       file (CHANGELOG.md) that almost every merge to main also
+          #       edits. Keyed on the branch rather than the label because
+          #       that branch is pinned in the autofill workflow's own push
+          #       grant (checkout/branch/switch are withheld from its agent),
+          #       so it is as unspoofable as the `Closes #` test; a label is
+          #       editable by anyone. OR
+          #   (c) a MAINTAINER PR — authored by a login in MAINTAINER_LOGINS
           #       (the repo owner's own human PRs, which main churn otherwise
           #       leaves stuck CONFLICTING with no responder).
           maint="$(jq -cn --arg s "$MAINTAINER_LOGINS" '$s | split(" ") | map(select(length > 0))')"
@@ -170,6 +182,7 @@ jobs:
                 and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-resolve") | not))
                 and (
                   ((.author.is_bot == true) and ((.body // "") | test("[Cc]loses #[0-9]+")))
+                  or ((.author.is_bot == true) and (.headRefName == "chore/changelog-autofill"))
                   or (.author.login as $l | ($maint | index($l)) != null)
                 )
               )]')"
@@ -268,7 +281,9 @@ jobs:
       #     write access can `workflow_dispatch` this file with an arbitrary
       #     matrix), so the payload carries PR NUMBERS ONLY and this step
       #     re-checks the full discover contract for that number — same-repo,
-      #     bot-authored, `Closes #` body, not `needs-human` — and re-derives
+      #     not `needs-human`, and one of the three author arms (build-worker
+      #     bot with `Closes #`, changelog-autofill bot on its fixed branch,
+      #     or a MAINTAINER_LOGINS human) — and re-derives
       #     the branch from the PR itself. A hand-crafted dispatch therefore
       #     cannot aim the agent (and its push) at a human PR's branch or any
       #     branch the eligibility rules wouldn't have selected.
@@ -304,6 +319,7 @@ jobs:
             and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-resolve") | not))
             and (
               ((.author.is_bot == true) and ((.body // "") | test("[Cc]loses #[0-9]+")))
+              or ((.author.is_bot == true) and (.headRefName == "chore/changelog-autofill"))
               or (.author.login as $l | ($maint | index($l)) != null)
             )
           ' <<<"$info")"

--- a/tests/conflictResolverEligibility.test.ts
+++ b/tests/conflictResolverEligibility.test.ts
@@ -1,0 +1,203 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The conflict resolver's eligibility filter
+ * (.github/workflows/pipeline-pr-conflict.yml).
+ *
+ * This filter decides which PR branches an agent may be pointed at and PUSH
+ * to, so a mistake here is a security bug rather than a bug: loosening it
+ * hands an automated pusher a branch nobody vetted. It is also written twice
+ * on purpose — once in `discover` to select candidates, once in `resolve` to
+ * re-verify before checkout, because the dispatch payload carries PR numbers
+ * only and is attacker-shapeable by anyone with write access. Two copies of
+ * one rule is exactly the shape that drifts (the same failure mode
+ * tests/agentRunActions.test.ts exists for), so both are pinned here.
+ *
+ * The jq programs are EXTRACTED FROM THE WORKFLOW and executed against the
+ * real `jq`, rather than asserted as strings: a string match would pass on a
+ * filter that parses but selects the wrong set. Fixtures below are the actual
+ * PR shapes `gh pr list --json` returns.
+ */
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const WORKFLOW = path.join(repoRoot, '.github/workflows/pipeline-pr-conflict.yml');
+const yaml = readFileSync(WORKFLOW, 'utf8');
+
+const jqAvailable = spawnSync('jq', ['--version'], { encoding: 'utf8' }).status === 0;
+const skip = jqAvailable ? false : 'jq not installed — the workflow itself requires it on the runner';
+
+/** Slice a single-quoted jq program out of the workflow's shell. */
+function extractJq(startMarker: string, endMarker: string): string {
+  const from = yaml.indexOf(startMarker);
+  assert.notEqual(from, -1, `start marker not found — workflow restructured?\n  ${startMarker}`);
+  const bodyStart = from + startMarker.length;
+  const to = yaml.indexOf(endMarker, bodyStart);
+  assert.notEqual(to, -1, `end marker not found after start — workflow restructured?\n  ${endMarker}`);
+  return yaml.slice(bodyStart, to);
+}
+
+const DISCOVER_JQ = extractJq(`| jq -c --argjson maint "$maint" '`, `')"`);
+const RESOLVE_JQ = extractJq(`eligible="$(jq -r --argjson maint "$maint" '`, `' <<<"$info")"`);
+
+const MAINT = JSON.stringify(['swampratnz']);
+
+function runJq(program: string, input: unknown, args: string[]): string {
+  const res = spawnSync('jq', [...args, '--argjson', 'maint', MAINT, program], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+  });
+  assert.equal(res.status, 0, `jq failed: ${res.stderr}`);
+  return res.stdout.trim();
+}
+
+interface PrShape {
+  number: number;
+  author: { is_bot: boolean; login: string };
+  isCrossRepository: boolean;
+  labels: Array<{ name: string }>;
+  body: string;
+  headRefName: string;
+  state?: string;
+  mergeable?: string;
+}
+
+function pr(number: number, over: Partial<PrShape> = {}): PrShape {
+  return {
+    number,
+    author: { is_bot: true, login: 'claude[bot]' },
+    isCrossRepository: false,
+    labels: [],
+    body: 'Closes #42',
+    headRefName: 'feature/x',
+    state: 'OPEN',
+    mergeable: 'CONFLICTING',
+    ...over,
+  };
+}
+
+const AUTOFILL_BRANCH = 'chore/changelog-autofill';
+
+/** Every case, with the verdict the filter must reach. */
+const CASES: Array<{ name: string; pr: PrShape; eligible: boolean }> = [
+  { name: 'build-worker bot with a `Closes #` body', pr: pr(1), eligible: true },
+  {
+    name: 'changelog-autofill bot on its fixed branch, no `Closes #`',
+    pr: pr(2, { body: 'auto-drafted', headRefName: AUTOFILL_BRANCH }),
+    eligible: true,
+  },
+  {
+    name: 'maintainer human',
+    pr: pr(3, { author: { is_bot: false, login: 'swampratnz' }, body: 'no closes' }),
+    eligible: true,
+  },
+  // --- everything below must stay OUT ---
+  {
+    name: 'an unrelated bot PR (Dependabot bump): bot, but no `Closes #` and not the autofill branch',
+    pr: pr(4, {
+      author: { is_bot: true, login: 'dependabot[bot]' },
+      body: 'Bumps foo from 1 to 2',
+      headRefName: 'dependabot/npm_and_yarn/foo-2',
+    }),
+    eligible: false,
+  },
+  {
+    name: 'a FORK claiming the autofill branch name',
+    pr: pr(5, { isCrossRepository: true, body: 'x', headRefName: AUTOFILL_BRANCH }),
+    eligible: false,
+  },
+  {
+    name: 'a non-bot non-maintainer on the autofill branch name',
+    pr: pr(6, {
+      author: { is_bot: false, login: 'randomuser' },
+      body: 'x',
+      headRefName: AUTOFILL_BRANCH,
+    }),
+    eligible: false,
+  },
+  {
+    name: 'autofill bot already labelled needs-human (the failed-attempt stop)',
+    pr: pr(7, { body: 'x', headRefName: AUTOFILL_BRANCH, labels: [{ name: 'needs-human' }] }),
+    eligible: false,
+  },
+  {
+    name: 'autofill bot pinned out with no-auto-resolve',
+    pr: pr(8, { body: 'x', headRefName: AUTOFILL_BRANCH, labels: [{ name: 'no-auto-resolve' }] }),
+    eligible: false,
+  },
+];
+
+test(
+  'SECURITY: the discover filter selects exactly the three trusted author arms and nothing else',
+  { skip },
+  () => {
+    const selected = JSON.parse(
+      runJq(
+        `${DISCOVER_JQ} | map(.number)`,
+        CASES.map((c) => c.pr),
+        ['-c'],
+      ),
+    ) as number[];
+    const expected = CASES.filter((c) => c.eligible).map((c) => c.pr.number);
+    assert.deepEqual(
+      selected,
+      expected,
+      `discover selected the wrong set.\n` +
+        CASES.map(
+          (c) => `  #${c.pr.number} ${c.eligible ? 'MUST include' : 'MUST EXCLUDE'} — ${c.name}`,
+        ).join('\n'),
+    );
+  },
+);
+
+test(
+  'SECURITY: the resolve re-verification agrees with discover on every case — the two copies must not drift',
+  { skip },
+  () => {
+    // Compared against DISCOVER'S OWN OUTPUT, not against the expected table:
+    // the table already pins each copy's absolute verdict (test 1 for
+    // discover, and every case here transitively), so what is left to catch
+    // is the two rules diverging from EACH OTHER — the failure this
+    // duplication invites, and the one a table-vs-table check would miss if
+    // both copies happened to drift the same way.
+    const selected = new Set(
+      JSON.parse(
+        runJq(
+          `${DISCOVER_JQ} | map(.number)`,
+          CASES.map((c) => c.pr),
+          ['-c'],
+        ),
+      ) as number[],
+    );
+    for (const c of CASES) {
+      const verdict = runJq(RESOLVE_JQ, c.pr, ['-r']);
+      assert.equal(
+        verdict,
+        String(selected.has(c.pr.number)),
+        `resolve and discover disagree on #${c.pr.number} (${c.name}) — discover ` +
+          `${selected.has(c.pr.number) ? 'selects' : 'skips'} it but resolve says ${verdict}`,
+      );
+    }
+  },
+);
+
+test(
+  'SECURITY: resolve additionally refuses a PR that is closed or no longer conflicting, which discover does not check',
+  { skip },
+  () => {
+    // discover reads mergeability separately (a bounded poll below the filter);
+    // resolve folds state/mergeable INTO the same expression, and that is what
+    // makes a superseded duplicate dispatch a no-op instead of a mislabel.
+    const merged = pr(9, { state: 'MERGED' });
+    const resolved = pr(10, { mergeable: 'MERGEABLE' });
+    assert.equal(runJq(RESOLVE_JQ, merged, ['-r']), 'false', 'a non-OPEN PR must never be resolved');
+    assert.equal(
+      runJq(RESOLVE_JQ, resolved, ['-r']),
+      'false',
+      'an already-unconflicted PR must never be resolved',
+    );
+  },
+);

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -54,6 +54,7 @@
   "classifierModelTieringSet.test.ts": 1,
   "config.test.ts": 19,
   "confirmCancelMi.router.test.ts": 11,
+  "conflictResolverEligibility.test.ts": 3,
   "contextBuilder.test.ts": 2,
   "contextBuilderStructuredOutput.test.ts": 3,
   "contextExport.test.ts": 4,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -29,6 +29,7 @@
     "tests/agentModule.test.ts",
     "tests/agentRunActions.test.ts",
     "tests/backgroundJobCostAlert.test.ts",
+    "tests/conflictResolverEligibility.test.ts",
     "tests/dbCoverageCheck.test.ts",
     "tests/displayTime.test.ts",
     "tests/fetchPageTool.test.ts",


### PR DESCRIPTION
## Summary

The conflict resolver silently skipped #1011, and would skip every changelog-autofill PR. Its eligibility filter admits a bot PR only when the body carries `Closes #<issue>`:

```jq
((.author.is_bot == true) and ((.body // "") | test("[Cc]loses #[0-9]+")))
or (.author.login as $l | ($maint | index($l)) != null)
```

That test is a proxy for "this is a build-worker PR" — the workflow's own comment says it "keeps an unrelated bot PR like a Dependabot bump out". The taxonomy it encodes is *bot PRs are either build-worker or foreign*. **The changelog-autofill loop is a third category nobody accounted for**: our own bot, but drafted from the daily coverage check rather than from an issue, so it can never carry a `Closes #`, and `claude[bot]` is obviously not in `MAINTAINER_LOGINS`. It fails both arms.

That combination is unlucky rather than harmless: this is the loop whose PRs conflict *most*, because they edit `CHANGELOG.md` — the one file nearly every merge to `main` also edits. So the pipeline reliably produces conflicting PRs that the resolver is structurally unable to touch.

This adds a third named arm, in **both** places the contract is written — `discover`, which selects candidates, and `resolve`, which re-verifies before checkout because the dispatch payload carries PR numbers only and is attacker-shapeable by anyone with write access:

```jq
or ((.author.is_bot == true) and (.headRefName == "chore/changelog-autofill"))
```

### Why the branch and not the label

`changelog-autofill.yml` pins `AUTOFILL_BRANCH: chore/changelog-autofill` as one standing branch, and withholds `git checkout`/`branch`/`switch` from its agent while pinning the push form — so only that loop can produce a PR on it. Keying on the branch is therefore as unspoofable as the `Closes #` test.

The PR also carries a `changelog-autofill` **label**, which would have been the easier key and is the wrong one: labels are editable by anyone with write access, so keying on one would be a real loosening rather than a restatement of the same guarantee.

## Security / privacy impact

This widens what an automated pusher may be pointed at, so it is a security-relevant change and I treated it as one. It admits exactly one new class — bot-authored PRs on one fixed branch — and nothing else.

Verified by running the extracted filter against a fixture table rather than by reading it. Still excluded:

| Case | Verdict |
|---|---|
| Dependabot bump (bot, no `Closes #`, other branch) | excluded |
| a **fork** claiming the `chore/changelog-autofill` branch name | excluded (`isCrossRepository`) |
| a non-bot, non-maintainer login on that branch name | excluded |
| autofill bot labelled `needs-human` (the failed-attempt stop) | excluded |
| autofill bot labelled `no-auto-resolve` | excluded |

All the pre-existing guardrails are untouched: same-repo only, the `needs-human`/`no-auto-resolve` skips, one attempt per conflict, and `resolve`'s independent re-verification of state/mergeability.

`tests/security-floor.json` gains `conflictResolverEligibility.test.ts: 3` for the three new `SECURITY:` tests.

## How verified

New `tests/conflictResolverEligibility.test.ts` **extracts both jq programs from the workflow and executes them against real `jq`**, rather than asserting on the file's text — a string match would happily pass a filter that parses but selects the wrong set. It follows `tests/agentRunActions.test.ts`'s approach of running extracted shell rather than trusting it.

I confirmed the pin actually bites by breaking it deliberately, in both directions:

- delete `discover`'s arm → test 1 fails, test 2 passes
- delete `resolve`'s arm alone → test 2 fails, test 1 passes (the drift case)

Two things that changed during that work, worth stating because they'd otherwise be invisible:

- My first break-it experiment was **invalid**. Removing the 14-space `resolve` line by string match also matched as a substring inside the 18-space `discover` line, so it mangled `discover` instead and I briefly mis-read the result as the drift test failing to fire. Redone line-exact.
- Test 2's original form **overclaimed**: its name said it compared `resolve` against `discover`, but it compared `resolve` against the expected table, so two copies drifting *the same way* would have slipped through. It now cross-checks `resolve`'s verdict against `discover`'s actual output.

Full local gate against a real Postgres 16 + pgvector: `typecheck` (incl. `typecheck:tests`, with the new file added to the ratchet — it was already type-clean), `lint`, `format:check`, `migrate`, `build`, `context:check`, `imports:check` all clean; `npm test` and `npm run test:security` results follow in a comment, and this stays in draft until then.

Note this touches `.github/`, a governance path the auto-merge loop never takes, so it needs a human merge either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_