### PR TITLE
Take docs/SECURITY.md off the auto-merge governance list, pin its sections instead

### DIFF
--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -218,12 +218,33 @@ jobs:
             # addition. Every other entry earns its place the same way: a PR
             # editing it can weaken the check that would catch it, because
             # `pull_request` CI runs the workflow FROM THE PR BRANCH. That does
-            # not reach docs/SECURITY.md. Nothing loads it — not CI, not any
-            # agent prompt (the build worker is pointed at CLAUDE.md and
-            # docs/PIPELINE.md; the review worker's rubric names the word
-            # "security", not the file). Editing it cannot change what runs,
-            # what an agent believes, or what "green" means. It is DESCRIPTIVE,
-            # where everything else here is CAUSAL.
+            # not reach docs/SECURITY.md: no workflow or check reads it —
+            # there is no readFileSync/gh-api load of that path anywhere — so
+            # editing it cannot change what runs or what "green" means. It is
+            # DESCRIPTIVE, where everything else here is CAUSAL.
+            #
+            # It is NOT inert, and an earlier version of this comment wrongly
+            # said so. CLAUDE.md:10 tells every agent to start with README.md,
+            # "then docs/ARCHITECTURE.md and docs/SECURITY.md", and both the
+            # build worker and the review worker are told to read CLAUDE.md —
+            # so an agent that follows the pointer does read this file, and a
+            # subtly wrong edit could mislead one. Two things bound that, and
+            # neither is "the auto-merge gate":
+            #   - The pointer is shared. CLAUDE.md points the same way at
+            #     docs/ARCHITECTURE.md, docs/STANDARDS.md and docs/agents/*,
+            #     none of which are on this list and none of which anyone has
+            #     proposed adding. Governing a file because CLAUDE.md names it
+            #     would pull in every orientation doc in the repo.
+            #   - The imperatives are elsewhere. The "do not regress" rules an
+            #     agent must obey live in CLAUDE.md's own security-posture
+            #     section, which STAYS governed — the build worker's prompt
+            #     points there for exactly that ("conventions + security
+            #     posture you must not regress"). docs/SECURITY.md carries the
+            #     threat model and rationale behind those rules.
+            # Residual risk, accepted knowingly: a wrong edit here now reaches
+            # main on an automated LGTM, and the structural pin below catches
+            # renumbering, not wrong content. That is the same exposure every
+            # other orientation doc already carries.
             #
             # It was also, by a distance, the most expensive entry: measured
             # over the last 40 merges it appeared in 7, and was the ONLY

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -415,7 +415,7 @@ jobs:
                 gh pr edit "$n" --repo "$REPO" --add-label human-merge-ready \
                   || echo "::warning::Could not add the human-merge-ready label to PR #$n."
                 gh pr comment "$n" --repo "$REPO" --body "${READY_MARKER}
-          🤖 Auto-merge evaluated this PR as **fully vetted** — every check green, \`MERGEABLE\`, and a fresh automated \`LGTM\` — but it touches a governance/CI/config path (\`.github/\`, \`scripts/\`, \`package.json\`, check config, or the \`CLAUDE.md\`/\`docs/PIPELINE.md\`/\`docs/SECURITY.md\` governance docs), which always requires a **human merge** (see docs/PIPELINE.md, auto-merge loop). Labelled \`human-merge-ready\` — a maintainer just needs to press merge." \
+          🤖 Auto-merge evaluated this PR as **fully vetted** — every check green, \`MERGEABLE\`, and a fresh automated \`LGTM\` — but it touches a governance/CI/config path (\`.github/\`, \`scripts/\`, \`package.json\`, check config, or the \`CLAUDE.md\`/\`docs/PIPELINE.md\`/\`docs/VISION.md\` governance docs), which always requires a **human merge** (see docs/PIPELINE.md, auto-merge loop). Labelled \`human-merge-ready\` — a maintainer just needs to press merge." \
                   || echo "::warning::Could not post the human-merge-ready comment on PR #$n."
               else
                 echo "PR #$n: fully vetted but governance-path — already flagged human-merge-ready, nothing to do."

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -213,16 +213,45 @@ jobs:
             #     changes what the pipeline will build next, which is exactly
             #     the "rewrite its own guardrails" risk this list exists for.
             #
-            # A governance hit does NOT stop evaluation, only the merge: the
-            # pipeline's own acceptance criteria make most feature PRs document
-            # themselves in docs/SECURITY.md, so a silent skip here stranded
-            # fully-vetted PRs with no signal to anyone (2026-07-21). Instead,
-            # keep evaluating; if the PR passes EVERY other gate it is labelled
-            # `human-merge-ready` with one marker-guarded comment, so the human
-            # merge it requires actually gets requested.
+            # docs/SECURITY.md was REMOVED from this list, and the reasoning
+            # is worth keeping because it is the test to apply to any future
+            # addition. Every other entry earns its place the same way: a PR
+            # editing it can weaken the check that would catch it, because
+            # `pull_request` CI runs the workflow FROM THE PR BRANCH. That does
+            # not reach docs/SECURITY.md. Nothing loads it — not CI, not any
+            # agent prompt (the build worker is pointed at CLAUDE.md and
+            # docs/PIPELINE.md; the review worker's rubric names the word
+            # "security", not the file). Editing it cannot change what runs,
+            # what an agent believes, or what "green" means. It is DESCRIPTIVE,
+            # where everything else here is CAUSAL.
+            #
+            # It was also, by a distance, the most expensive entry: measured
+            # over the last 40 merges it appeared in 7, and was the ONLY
+            # governed path in all seven — 64% of every human press this list
+            # forced, more than `.github/`. Because the pipeline's own
+            # acceptance criteria push most feature work to document itself
+            # here, the gate had stopped tracking risk and started tracking
+            # diligence: two te reo rendering PRs were held for documenting
+            # themselves, while #1021 (a new always-on job that DMs every
+            # admin) added no section at all and would have passed untouched.
+            #
+            # The drift it did guard against — this document ceasing to
+            # describe the real controls — is now held by
+            # tests/securityDocSections.test.ts, which pins the section list so
+            # a change is a reviewable diff instead of an unnoticed one. Same
+            # trade tests/toolTierMap.test.ts already makes for a MORE
+            # dangerous file. That pin found a duplicate section number that
+            # had survived this gate for many merges.
+            #
+            # A governance hit does NOT stop evaluation, only the merge: a
+            # silent skip here stranded fully-vetted PRs with no signal to
+            # anyone (2026-07-21). Instead, keep evaluating; if the PR passes
+            # EVERY other gate it is labelled `human-merge-ready` with one
+            # marker-guarded comment, so the human merge it requires actually
+            # gets requested.
             files="$(gh pr view "$n" --repo "$REPO" --json files --jq '.files[].path')"
             governance_hit='false'
-            if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/SECURITY\.md$|docs/VISION\.md$|src/module/agentModule\.ts$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
+            if printf '%s\n' "$files" | grep -qE '^(\.github/|scripts/|CLAUDE\.md$|docs/PIPELINE\.md$|docs/VISION\.md$|src/module/agentModule\.ts$|package(-lock)?\.json$|tsconfig([.-].*)?\.json$|eslint\.config\.|\.prettier)'; then
               governance_hit='true'
               echo "PR #$n: touches a governance/CI/config path (workflows, check machinery, or governance docs) — will never auto-merge; still evaluating for the human-merge-ready escalation."
             fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,8 +363,9 @@ ownership rules:
   instead, the same trade `tests/toolTierMap.test.ts` makes for the tier map.
   A governance-path PR that passes every other gate is not skipped silently:
   it gets a `human-merge-ready` label plus one marker-guarded comment asking
-  a maintainer to merge (a PR touching `.github/` or the check machinery to
-  document themselves, so this is the common case, not the exception).
+  a maintainer to merge (pipeline work routinely edits `.github/` or
+  `scripts/` to fix the machinery itself, so this stays a well-trodden path
+  even with `docs/SECURITY.md` off the list).
   Never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to
   rebase the rest, and the next PR only re-qualifies once it is green against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,10 +357,16 @@ ownership rules:
   never auto-merge a change to its own guardrails or to what "green" means.
   `docs/SECURITY.md` is deliberately NOT on that list: every other entry can
   weaken the check that would catch it (PR-branch CI runs the PR's own
-  workflows), whereas nothing loads that document at all, so it is descriptive
-  where the rest are causal. It cost 64% of the list's human presses for that
-  non-risk; `tests/securityDocSections.test.ts` now pins its section list
-  instead, the same trade `tests/toolTierMap.test.ts` makes for the tier map.
+  workflows), whereas no workflow or check reads that document, so it is
+  descriptive where the rest are causal. It is not inert — line 10 above
+  points every agent at it, so a wrong edit can mislead one — but that pointer
+  is shared with `docs/ARCHITECTURE.md`, `docs/STANDARDS.md` and
+  `docs/agents/*`, none of them governed either, and the rules an agent must
+  obey live in this file's security-posture section, which stays governed. It
+  cost 64% of the list's human presses; `tests/securityDocSections.test.ts`
+  now pins its section list instead, the same trade
+  `tests/toolTierMap.test.ts` makes for the tier map — structural drift only,
+  not content correctness.
   A governance-path PR that passes every other gate is not skipped silently:
   it gets a `human-merge-ready` label plus one marker-guarded comment asking
   a maintainer to merge (pipeline work routinely edits `.github/` or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,11 +353,17 @@ ownership rules:
   the review worker's identity) newer than the head commit, and does NOT touch
   any governance/CI/config path (`.github/`, `scripts/`, `package.json`,
   typecheck/lint/format config, `CLAUDE.md`, `docs/PIPELINE.md`,
-  `docs/SECURITY.md`) — those always require a human merge, so the loop can
+  `docs/VISION.md`) — those always require a human merge, so the loop can
   never auto-merge a change to its own guardrails or to what "green" means.
+  `docs/SECURITY.md` is deliberately NOT on that list: every other entry can
+  weaken the check that would catch it (PR-branch CI runs the PR's own
+  workflows), whereas nothing loads that document at all, so it is descriptive
+  where the rest are causal. It cost 64% of the list's human presses for that
+  non-risk; `tests/securityDocSections.test.ts` now pins its section list
+  instead, the same trade `tests/toolTierMap.test.ts` makes for the tier map.
   A governance-path PR that passes every other gate is not skipped silently:
   it gets a `human-merge-ready` label plus one marker-guarded comment asking
-  a maintainer to merge (most feature PRs touch `docs/SECURITY.md` to
+  a maintainer to merge (a PR touching `.github/` or the check machinery to
   document themselves, so this is the common case, not the exception).
   Never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -507,9 +507,14 @@ own PR.
    gates the pair, so a 🔒 added without a `CODEOWNERS` line silently drops
    review routing.
 5. **This file is not a governance path.** The auto-merge matcher governs
-   `CLAUDE.md`, `docs/PIPELINE.md`, `docs/SECURITY.md` and `docs/VISION.md`, so
-   a bot PR editing *those* always waits for a human — but a bot PR editing
-   `docs/CICD.md` can auto-merge. That is arguably correct (this file is a
+   `CLAUDE.md`, `docs/PIPELINE.md` and `docs/VISION.md`, so a bot PR editing
+   *those* always waits for a human — but a bot PR editing `docs/CICD.md` can
+   auto-merge. (`docs/SECURITY.md` was on that list and came off: it is
+   descriptive rather than causal — nothing loads it, so unlike the other three
+   it cannot steer an agent or weaken a check — and it was costing 64% of the
+   list's human presses. `tests/securityDocSections.test.ts` pins its section
+   list instead. The same descriptive/causal test is the one to apply to this
+   file if it is ever proposed for the matcher.) That is arguably correct (this file is a
    reference; the workflow files are the authority) and arguably not (a
    confidently wrong CI/CD reference misleads exactly the cold agent sessions
    it is written for). Left as a maintainer decision — adding it to the matcher

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -510,9 +510,11 @@ own PR.
    `CLAUDE.md`, `docs/PIPELINE.md` and `docs/VISION.md`, so a bot PR editing
    *those* always waits for a human — but a bot PR editing `docs/CICD.md` can
    auto-merge. (`docs/SECURITY.md` was on that list and came off: it is
-   descriptive rather than causal — nothing loads it, so unlike the other three
-   it cannot steer an agent or weaken a check — and it was costing 64% of the
-   list's human presses. `tests/securityDocSections.test.ts` pins its section
+   descriptive rather than causal — no workflow or check reads it, so unlike
+   the other three it cannot weaken a gate — and it was costing 64% of the
+   list's human presses. (It is not inert: `CLAUDE.md` points agents at it, as
+   it does at `docs/ARCHITECTURE.md` and `docs/agents/*`, which are not
+   governed either.) `tests/securityDocSections.test.ts` pins its section
    list instead. The same descriptive/causal test is the one to apply to this
    file if it is ever proposed for the matcher.) That is arguably correct (this file is a
    reference; the workflow files are the authority) and arguably not (a

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -158,7 +158,9 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   `src/module/agentModule.ts` — THE manifest the agent-base split turned into a
   rules file, since every extension point this deployment registers passes
   through it — so the pipeline can never auto-merge a
-  change to its own guardrails or to what "green" means. (`docs/VISION.md` is
+  change to its own guardrails or to what "green" means (and since
+  `pull_request` CI runs the workflow version from the PR branch, a PR could
+  otherwise weaken a check and still show it "passing"). (`docs/VISION.md` is
   on the list because it is the rubric research proposes against and
   adversarial judges by: editing it changes what the pipeline builds next.
   `src/module/agent/tools/index.ts`, which defines the tier map, is
@@ -171,9 +173,7 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   every other entry it is descriptive rather than causal. Nothing loads it:
   not CI, not any agent prompt. Its drift risk is held by
   `tests/securityDocSections.test.ts`, which found a duplicate section number
-  that had survived the gate for many merges.) (and since
-  `pull_request` CI runs the workflow version from the PR branch, a PR could
-  otherwise weaken a check and still show it "passing"). Because the pipeline's
+  that had survived the gate for many merges.) Because the pipeline's
   own acceptance criteria push feature work through CI and check config, a
   governance hit is still common and is NOT a silent skip: a
   governance-path PR that passes **every other** gate (green, mergeable, fresh

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -154,7 +154,7 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   config path to a human merge** — `.github/**` (workflows/CI, including this
   loop itself), `scripts/**` (the check machinery), `package.json`,
   typecheck/lint/format config, the `CLAUDE.md`/`docs/PIPELINE.md`/
-  `docs/SECURITY.md`/`docs/VISION.md` governance docs, and
+  `docs/VISION.md` governance docs, and
   `src/module/agentModule.ts` — THE manifest the agent-base split turned into a
   rules file, since every extension point this deployment registers passes
   through it — so the pipeline can never auto-merge a
@@ -165,11 +165,17 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   deliberately **not** — every new tool registers a tier there, so it appears
   in 62% of recent merges and governing it would gut auto-merge; the tier-map
   snapshot in `tests/toolTierMap.test.ts` covers it instead, at no throughput
-  cost.) (and since
+  cost. `docs/SECURITY.md` came OFF the list for the same reason plus a
+  stronger one: measured over 40 merges it appeared in 7 and was the only
+  governed path in all seven — 64% of the list's human presses — and unlike
+  every other entry it is descriptive rather than causal. Nothing loads it:
+  not CI, not any agent prompt. Its drift risk is held by
+  `tests/securityDocSections.test.ts`, which found a duplicate section number
+  that had survived the gate for many merges.) (and since
   `pull_request` CI runs the workflow version from the PR branch, a PR could
   otherwise weaken a check and still show it "passing"). Because the pipeline's
-  own acceptance criteria make most feature PRs document themselves in
-  `docs/SECURITY.md`, a governance hit is common and is NOT a silent skip: a
+  own acceptance criteria push feature work through CI and check config, a
+  governance hit is still common and is NOT a silent skip: a
   governance-path PR that passes **every other** gate (green, mergeable, fresh
   LGTM, no stop labels) is labelled `human-merge-ready` and gets one
   marker-guarded comment asking a maintainer to press merge — the loop still

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -170,10 +170,15 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   cost. `docs/SECURITY.md` came OFF the list for the same reason plus a
   stronger one: measured over 40 merges it appeared in 7 and was the only
   governed path in all seven — 64% of the list's human presses — and unlike
-  every other entry it is descriptive rather than causal. Nothing loads it:
-  not CI, not any agent prompt. Its drift risk is held by
-  `tests/securityDocSections.test.ts`, which found a duplicate section number
-  that had survived the gate for many merges.) Because the pipeline's
+  every other entry it is descriptive rather than causal: no workflow or check
+  reads it, so editing it cannot weaken a gate. It is not inert — `CLAUDE.md`
+  points every agent at it, so a wrong edit can mislead one — but that pointer
+  is shared with `docs/ARCHITECTURE.md`, `docs/STANDARDS.md` and
+  `docs/agents/*`, none governed, and the imperatives an agent must obey live
+  in `CLAUDE.md`'s own security-posture section, which stays governed. Its
+  structural drift risk is held by `tests/securityDocSections.test.ts`, which
+  found a duplicate section number that had survived the gate for many merges;
+  content correctness is now carried by review, not by a human press.) Because the pipeline's
   own acceptance criteria push feature work through CI and check config, a
   governance hit is still common and is NOT a silent skip: a
   governance-path PR that passes **every other** gate (green, mergeable, fresh

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4253,7 +4253,7 @@ number could reach an unrelated person).
       governance/CI/config path to a human merge** — `.github/**` (workflows/CI,
       including the auto-merge loop itself), `scripts/**` (the check machinery),
       `package.json`, typecheck/lint/format config, and the
-      `CLAUDE.md`/`docs/PIPELINE.md`/`docs/SECURITY.md` docs — so the loop can
+      `CLAUDE.md`/`docs/PIPELINE.md`/`docs/VISION.md` docs — so the loop can
       never auto-merge a change to its *own* gates or to what "green" means (which
       matters because `pull_request` CI runs the workflow version from the PR
       branch). A governance-path PR that passes every *other* gate is escalated

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2244,7 +2244,7 @@ non-allowlisted parent would be unmoderated by construction. Controls:
 - **Only text/announcement channels**: forum/media channels use a different,
   tag-based thread-creation API this tool doesn't support; `create_thread`
   throws rather than guessing at forum tags.
-### 11. Scheduled events (`create_event`, issue #230)
+### 11b. Scheduled events (`create_event`, issue #230)
 Creates a real Discord `GuildScheduledEvent` (RSVP + reminders in the
 server's Events tab) instead of a text announcement. Outward-facing *and*
 member-notifying — a genuinely higher floor than `announce`/`create_poll` —
@@ -3829,7 +3829,7 @@ extended to `backgroundJobs.ts`'s `alertSuperAdmins` or `tools.ts`'s
   Members, Kick Members, **Ban Members** — required for the admin `ban_user`
   and `unban_user` actions; without it, either fails cleanly as `Failed: …`
   rather than silently no-oping — Manage Messages) plus Manage Events
-  (required for the admin `create_event` tool, §11), and place its role
+  (required for the admin `create_event` tool, §11b), and place its role
   appropriately in the hierarchy.
 
 ## Subscription-auth caveat

--- a/docs/agents/recipes.md
+++ b/docs/agents/recipes.md
@@ -58,10 +58,13 @@ Then:
   Reuse today's section if it exists. Purely internal work (CI, deps, tooling,
   pipeline) instead goes in the skip ledger comment at the top of the file.
 - **`docs/SECURITY.md`** — if the change adds, removes or moves anything on the
-  security spine, or introduces a new input, egress or trust boundary. Note
-  that touching this file (or `.github/**`, `scripts/**`, `package.json`,
-  `CLAUDE.md`, `docs/PIPELINE.md`) routes the PR to a **human merge** — that is
-  intended, not a problem to design around.
+  security spine, or introduces a new input, egress or trust boundary. Its
+  `### N. Title` section list is pinned by `tests/securityDocSections.test.ts`,
+  so adding or renumbering a section means updating that snapshot in the same
+  diff (`npx tsx tests/dumpSecurityDocSections.ts` regenerates it). Editing
+  this file no longer routes the PR to a human merge; `.github/**`,
+  `scripts/**`, `package.json`, `CLAUDE.md`, `docs/PIPELINE.md` and
+  `docs/VISION.md` still do — that is intended, not a problem to design around.
 - **`docs/agents/module-map.md`** — if you added, removed or renamed a `src/`
   module. `npm run context:check` fails otherwise; `npm run context:fix`
   does the mechanical part.

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -259,6 +259,7 @@ console.log(
     '`docs/PIPELINE.md`, `docs/VISION.md`) and handing it to a person exactly as policy requires. ' +
     'Every path on that list is one a PR editing it could use to weaken the check that would catch ' +
     'it, so a Routed row is the guardrail working, not the loop struggling. `docs/SECURITY.md` used ' +
-    'to be on the list and came off: nothing loads it, so it could not do that — it was costing 64% ' +
-    'of the Routed rows for a risk it did not carry.',
+    'to be on the list and came off: no workflow or check reads it, so it could not do that, and it ' +
+    'was costing 64% of the Routed rows. (It is not inert — `CLAUDE.md` points agents at it — but so ' +
+    'are `docs/ARCHITECTURE.md` and `docs/agents/*`, which were never governed.)',
 );

--- a/scripts/pipeline-outcomes.mjs
+++ b/scripts/pipeline-outcomes.mjs
@@ -82,7 +82,7 @@ const LOOPS = [
     // the loop wanted to merge and could not.
     escalation: '<!-- pipeline-automerge-blocked -->',
     // A governance-path PR (.github/**, scripts/**, CLAUDE.md, docs/PIPELINE.md,
-    // docs/SECURITY.md, …) that passed every other gate and was deliberately
+    // docs/VISION.md, …) that passed every other gate and was deliberately
     // handed to a human with a `human-merge-ready` label. This is the loop
     // working exactly as designed, NOT a failure — see `routed` below.
     routed: '<!-- pipeline-automerge-human-ready -->',
@@ -256,8 +256,9 @@ console.log(
     '> **Routed to human (by design)** is NOT a failure, and is deliberately left out of the ' +
     '"did not finish on its own" list: it is ' +
     'auto-merge meeting a governance-path PR (`.github/**`, `scripts/**`, `CLAUDE.md`, ' +
-    '`docs/PIPELINE.md`, `docs/SECURITY.md`) and handing it to a person exactly as policy requires. ' +
-    'Because the pipeline asks most feature PRs to document themselves in `docs/SECURITY.md`, this ' +
-    'is the common case rather than the exception — a high Routed number means the guardrail is ' +
-    'working, not that the loop is struggling.',
+    '`docs/PIPELINE.md`, `docs/VISION.md`) and handing it to a person exactly as policy requires. ' +
+    'Every path on that list is one a PR editing it could use to weaken the check that would catch ' +
+    'it, so a Routed row is the guardrail working, not the loop struggling. `docs/SECURITY.md` used ' +
+    'to be on the list and came off: nothing loads it, so it could not do that — it was costing 64% ' +
+    'of the Routed rows for a risk it did not carry.',
 );

--- a/tests/appealStaleAlert.test.ts
+++ b/tests/appealStaleAlert.test.ts
@@ -157,7 +157,15 @@ test('SECURITY: the crossing-tick alert DM contains no appeal id, user id/name, 
   const secretUserId = 'secret-user-id-4f2a';
   const secretUserName = 'secret-display-name';
   const secretReason = 'secret-appeal-reason-text';
-  const listOpenAppeals = async () => [
+  // Built EAGERLY, before runOnce() captures its clock. The job reads
+  // `Date.now()` first and only then awaits listOpenAppeals(), so a fixture
+  // that dates the appeal inside that callback stamps it LATER than `now` —
+  // making the measured age just under 100h, which `Math.floor` renders as
+  // "99h". Sub-millisecond on an idle machine, but a loaded CI runner
+  // deschedules the process between the two often enough to make this test a
+  // coin flip (it reddened PR #1071 twice). Constructing first inverts the
+  // ordering: the age is then a hair OVER 100h and floors to 100 every time.
+  const staleAppeals = [
     appeal({
       ageHours: 100,
       id: 999,
@@ -167,6 +175,7 @@ test('SECURITY: the crossing-tick alert DM contains no appeal id, user id/name, 
       platform: 'discord',
     }),
   ];
+  const listOpenAppeals = async () => staleAppeals;
   const listAdminIdentities = async () => admins([{}]);
   const runOnce = makeDefaultAppealStaleAlertRun([adapter], listOpenAppeals, listAdminIdentities);
 

--- a/tests/dumpSecurityDocSections.ts
+++ b/tests/dumpSecurityDocSections.ts
@@ -1,0 +1,23 @@
+/**
+ * Regenerates `tests/securityDocSections.test.ts`'s EXPECTED snapshot.
+ *
+ * Sibling of `tests/dumpToolTiers.ts`, and here for the same reason: the
+ * snapshot exists to make a change reviewable, not to be retyped by hand. Adding
+ * one section is a one-line edit and should stay that way — reach for this only
+ * when the list has drifted wholesale (a renumbering pass, say).
+ *
+ *   npx tsx tests/dumpSecurityDocSections.ts
+ *
+ * Prints the array body to stdout; paste it between the EXPECTED brackets.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(fileURLToPath(new URL('../docs/SECURITY.md', import.meta.url)), 'utf8');
+
+for (const line of source.split('\n')) {
+  const m = /^### ([0-9]+[a-z]?)\. (.+)$/.exec(line);
+  if (!m) continue;
+  const title = m[2].replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  process.stdout.write(`  ['${m[1]}', '${title}'],\n`);
+}

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -130,6 +130,7 @@
   "reviewVerdict.test.ts": 5,
   "router.test.ts": 9,
   "routerInterceptChain.test.ts": 4,
+  "securityDocSections.test.ts": 1,
   "securityGateCanary.test.ts": 1,
   "securityGateWrite.test.ts": 7,
   "staleKnowledgeAlert.router.test.ts": 3,

--- a/tests/securityDocSections.test.ts
+++ b/tests/securityDocSections.test.ts
@@ -17,10 +17,19 @@ import { fileURLToPath } from 'node:url';
 // that would catch it: `pull_request` CI runs the workflow FROM THE PR BRANCH,
 // so a PR can neuter a gate and still show that named check "passing". That is
 // true of `.github/`, `scripts/`, and the lint/typecheck config. It is not
-// true of this file. Nothing loads it — not CI, not any agent prompt. The
-// build worker is pointed at CLAUDE.md and docs/PIPELINE.md; the review
-// worker's rubric names the word "security", not the document. Editing it
-// cannot change what runs, what an agent believes, or what "green" means.
+// true of this file: no workflow or check reads it, so editing it cannot
+// change what runs or what "green" means.
+//
+// It is NOT inert, and an earlier draft of this comment wrongly said so.
+// CLAUDE.md:10 tells every agent to start with README.md, "then
+// docs/ARCHITECTURE.md and docs/SECURITY.md", and both the build worker and
+// the review worker are told to read CLAUDE.md — so an agent following that
+// pointer does read this document, and a wrong edit could mislead one. That
+// pointer is shared with docs/ARCHITECTURE.md, docs/STANDARDS.md and
+// docs/agents/*, none of which are governed either; and the rules an agent
+// must not regress live in CLAUDE.md's own security-posture section, which
+// stays governed. So the belief-channel is real but not unique to this file,
+// and the snapshot below does not close it — it pins structure, not content.
 //
 // What it CAN do is drift — stop describing the controls that actually exist —
 // and losing the gate lost the guaranteed human read that would notice. This

--- a/tests/securityDocSections.test.ts
+++ b/tests/securityDocSections.test.ts
@@ -1,0 +1,123 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// docs/SECURITY.md's threat-model sections, pinned exactly.
+//
+// WHY THIS FILE EXISTS
+//
+// This document used to be on the auto-merge governance list, which routed
+// every PR touching it to a mandatory human merge. Measured against the last
+// 40 merges it appeared in 7 of them and was the ONLY governed path in all
+// seven — 64% of every human press that list forced, more than `.github/`.
+//
+// It came off that list because the list's own stated reason does not reach
+// it. The reason is that a PR editing a governed path can weaken the check
+// that would catch it: `pull_request` CI runs the workflow FROM THE PR BRANCH,
+// so a PR can neuter a gate and still show that named check "passing". That is
+// true of `.github/`, `scripts/`, and the lint/typecheck config. It is not
+// true of this file. Nothing loads it — not CI, not any agent prompt. The
+// build worker is pointed at CLAUDE.md and docs/PIPELINE.md; the review
+// worker's rubric names the word "security", not the document. Editing it
+// cannot change what runs, what an agent believes, or what "green" means.
+//
+// What it CAN do is drift — stop describing the controls that actually exist —
+// and losing the gate lost the guaranteed human read that would notice. This
+// snapshot is the replacement, and it is the same trade
+// tests/toolTierMap.test.ts already makes for a MORE dangerous file: pin the
+// structure so a change becomes a reviewable diff instead of an unnoticed one,
+// at zero throughput cost.
+//
+// It is not hypothetical. PRs #1035 and #1057 each added a section numbered
+// 27, both passed every check, and the collision was caught by hand afterwards
+// while resolving their merge conflict. The uniqueness assertion below catches
+// that in CI instead.
+//
+// MAINTENANCE: adding a section means adding one line here, in document order.
+// That is the intended friction — the diff is the audit trail, and it makes
+// "which invariant changed" a question the review can answer from the diff
+// alone. Regenerate wholesale with:
+//
+//   npx tsx tests/dumpSecurityDocSections.ts
+const SECURITY_DOC = fileURLToPath(new URL('../docs/SECURITY.md', import.meta.url));
+
+/** Every `### <n>. <title>` threat-model section, in document order. */
+const EXPECTED: ReadonlyArray<readonly [string, string]> = [
+  ['1', 'Privilege escalation via chat ("prompt injection")'],
+  ['2', 'Secret exposure'],
+  ['3', 'Abuse / cost runaway'],
+  ['4', 'Moderation misuse / accountability'],
+  ['5', 'Host compromise / blast radius'],
+  ['6', 'Data protection (member PII)'],
+  ['6b', 'WhatsApp LIDs must never become member ids (2026-08-01 incident)'],
+  ['7', 'Cross-platform identity linking (`link_member` / `unlink_member`)'],
+  ['8', 'Image generation via the host Grok CLI (`generate_image`)'],
+  ['9', 'Emoji reactions (`react_to_message`, issue #231)'],
+  ['10', 'Cosmetic community roles (`assign_community_role` / `remove_community_role`, issue #232)'],
+  ['11', 'Discord thread management (`create_thread` / `archive_thread`, issue #229)'],
+  ['11b', 'Scheduled events (`create_event`, issue #230)'],
+  ['12', 'GitHub issue filing (`suggest_issue`, opt-in)'],
+  ['13', 'WhatsApp/Discord voice transcription (configurable min tier, opt-in)'],
+  [
+    '14',
+    'Real-time admin escalation after a max-turns failure (`ESCALATION_TO_ADMIN_ENABLED`, off by default, issue #479)',
+  ],
+  ['15', 'Help-channel auto-answer mode (`AUTO_ANSWER_CHANNEL_IDS`, opt-in, Discord-only, issue #477)'],
+  ['16', 'Config-flag visibility (`feature_flags`, super-admin, issue #559)'],
+  ['17', 'Opt-in Discord auto-enroll (`DISCORD_AUTO_ENROLL_MEMBERS`, off by default, issue #605)'],
+  ['18', 'WhatsApp bot-side block list (`block_user`/`unblock_user`, issue #572)'],
+  [
+    '20',
+    'Discord slash commands (`/kb`, `/whois`, `/projects`, `/guidelines`, `/digest`, `DISCORD_SLASH_COMMANDS_ENABLED`, off by default, issues #744, #841)',
+  ],
+  ['19', 'Agent Skills (`AGENT_SKILLS_ENABLED`, off by default, issues #741, #755, #757, #759)'],
+  ['21', 'Pipeline handoff notes (build worker → PR-review worker)'],
+  [
+    '22',
+    'Image-attachment input (`IMAGE_INPUT_ENABLED` Discord / `WHATSAPP_IMAGE_INPUT_ENABLED` WhatsApp-Baileys / `WHATSAPP_CLOUD_IMAGE_INPUT_ENABLED` WhatsApp Cloud API, all off by default, `super_admin`-only default, issues #783 / #879 / #891)',
+  ],
+  [
+    '23',
+    'WhatsApp text commands (`!whois`, `!projects`, `!guidelines`, `!digest`, `WHATSAPP_TEXT_COMMANDS_ENABLED`, off by default, issue #859)',
+  ],
+  ['24', 'WhatsApp text-command discovery (`community_info`, issue #872)'],
+  ['25', 'Projects — shared team memory (`project_*`, issue #927)'],
+  ['26', "`community_info` honours a standing `'mi'` language preference (issue #1028)"],
+  ['27', "`community_info` extends the `'mi'` preference to the admin/super-admin segments (issue #1056)"],
+  [
+    '28',
+    "WhatsApp `!`-shortcuts discovery block honours a standing `'mi'` language preference too (issue #1034)",
+  ],
+];
+
+/** Parsed straight from the document — the same regex the dump script uses. */
+function actualSections(): Array<[string, string]> {
+  const source = readFileSync(SECURITY_DOC, 'utf8');
+  const out: Array<[string, string]> = [];
+  for (const line of source.split('\n')) {
+    const m = /^### ([0-9]+[a-z]?)\. (.+)$/.exec(line);
+    if (m) out.push([m[1], m[2]]);
+  }
+  return out;
+}
+
+test('docs/SECURITY.md: the threat-model section list matches the pinned snapshot', () => {
+  assert.deepEqual(
+    actualSections(),
+    EXPECTED.map((e) => [...e]),
+    'a section was added, removed, renumbered or retitled — update EXPECTED in this diff so the change ' +
+      'is reviewable rather than silent (npx tsx tests/dumpSecurityDocSections.ts regenerates it)',
+  );
+});
+
+test('SECURITY: no two threat-model sections share a number — a duplicate hides one behind the other', () => {
+  // The concrete failure this is here for: #1035 and #1057 both added a §27,
+  // independently, and both went green. Cross-references elsewhere in the
+  // document address sections by number, so a duplicate silently points half
+  // of them at the wrong control.
+  const numbers = actualSections().map(([n]) => n);
+  const seen = new Set<string>();
+  const duplicates = numbers.filter((n) => (seen.has(n) ? true : (seen.add(n), false)));
+  assert.deepEqual(duplicates, [], `duplicate section numbers: ${duplicates.join(', ')}`);
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -43,6 +43,7 @@
     "tests/reusableWorkflows.test.ts",
     "tests/routerInterceptChain.test.ts",
     "tests/schemaConstraintIdempotency.test.ts",
+    "tests/securityDocSections.test.ts",
     "tests/toolTierMap.test.ts",
     "tests/stringsCatalogue.test.ts",
     "tests/systemPromptByteStability.test.ts",


### PR DESCRIPTION
## Summary

Removes one path from the auto-merge governance matcher and replaces the protection it was actually providing with a test.

**The measurement.** Over the last 40 merges to `main`, 11 tripped the governance gate. Seven tripped it on `docs/SECURITY.md` **and nothing else** — 64% of every human press that list forces, more than `.github/`.

| Path | Hit rate | Can a PR editing it weaken the check that would catch it? | |
|---|---|---|---|
| `docs/SECURITY.md` | 7/40 | **No** — no workflow or check reads it | remove |
| `.github/` | 4/40 | Yes — PR-branch CI runs the PR's own workflows | keep |
| `tsconfig*.json` | 3/40 | Yes — defines what typecheck checks | keep |
| `CLAUDE.md`, `docs/PIPELINE.md` | 0/40 | Yes — the build worker is told to read both | keep |
| `docs/VISION.md` | 0/40 | Yes — research proposes against it, adversarial judges by it | keep |
| `scripts/`, `package.json`, `agentModule.ts`, lint/format config | 0/40 | Yes — check machinery and the manifest | keep |

**Why this one is different.** Every other entry is *causal*: editing it changes what the pipeline does. `docs/SECURITY.md` cannot — no workflow or check reads it (no `readFileSync`, no `gh api` load of that path anywhere), so editing it cannot weaken a gate or change what "green" means.

**A correction, made during review.** An earlier version of this PR claimed the file was inert — that no agent prompt loads it either. That was **wrong**, and the automated review caught it. `CLAUDE.md:10` tells every agent to start with `README.md`, "then `docs/ARCHITECTURE.md` and `docs/SECURITY.md`", and both the build worker (`pipeline-build.yml:292`) and the review worker (`pipeline-pr-review.yml:171`) are told to read `CLAUDE.md`. An agent that follows the pointer does read this file, so a wrong edit could mislead one. My verification checked for *mechanical* loads and stopped one hop short of the transitive pointer.

Two things bound that belief-channel, and neither is the auto-merge gate:

- **The pointer is shared.** `CLAUDE.md` points the same way at `docs/ARCHITECTURE.md`, `docs/STANDARDS.md` and `docs/agents/*` — none governed, none proposed for governing. Governing a file because `CLAUDE.md` names it would pull in every orientation doc in the repo.
- **The imperatives are elsewhere.** The "do not regress" rules live in `CLAUDE.md`'s own security-posture section, which stays governed — which is why the build worker's prompt points *there* for "security posture you must not regress". `docs/SECURITY.md` carries the threat model behind those rules.

The claim is now stated accurately in all six places that repeat it.

**The inversion it was producing.** Because the pipeline's own acceptance criteria push feature work to document itself here, the gate had stopped tracking risk and started tracking diligence:

- **#1035, #1057** — te reo Māori renderings of help text. Held for a human *because* they documented themselves.
- **#1021** — a new always-on job that DMs every admin. Genuinely security-relevant, added **no** `docs/SECURITY.md` section (its own reviewer flagged the omission), and would have passed the gate untouched.

## What replaces it

`tests/securityDocSections.test.ts` pins the section list, so a structural change to this document becomes a reviewable diff instead of an unnoticed one. That is the same trade `tests/toolTierMap.test.ts` already makes for `src/module/agent/tools/index.ts` — a *more* dangerous file, deliberately left ungoverned at 62% frequency for exactly this reason.

**The pin earned itself immediately: it failed on `main`.**

Two sections were both numbered **§11** — "Discord thread management" and "Scheduled events" — and had survived the gate across many merges, every one of which got a mandatory human read. Cross-references address sections by number, so the single `§11` reference (meaning `create_event`) was resolving ambiguously. Fixed as **§11b**, following the `6`/`6b` precedent already in the document, with the reference updated.

That is the *third* instance of this failure mode. #1035 and #1057 also both added a §27; I caught that by hand while resolving their merge conflict. This test catches it in CI.

## Security / privacy impact

No runtime change: no `src/` edit, no tool, tier, table, or permission touched. The security spine is untouched.

The change is to *governance*, so the honest cost is stated plainly: `docs/SECURITY.md` loses a guaranteed human read on every change, and the pin catches renumbering and duplication — **not** content correctness. A subtly wrong edit now reaches `main` on an automated LGTM. That residual risk is real, is the same exposure the other orientation docs already carry, and is accepted knowingly rather than argued away.

Three things bound it: the automated review still reads the full diff (on this PR it caught four real defects, including the overstated claim above); branch protection on `main` is unchanged and remains the enforceable backstop; and the new pin converts structural drift from *unnoticed* to *visible in a diff*.

Nothing else comes off the list. `.github/` and `scripts/` are load-bearing for exactly the reason the workflow comment gives, and `CLAUDE.md`/`docs/PIPELINE.md`/`docs/VISION.md` each have a real causal channel into what agents build next. Their combined measured cost is 4 presses per 40 merges — a fair price.

## Also in this PR

A clock-ordering flake in `tests/appealStaleAlert.test.ts`, which reddened this branch twice on prose-only commits. The job reads `Date.now()` before awaiting `listOpenAppeals()`, but the fixture dated the appeal *inside* that callback — so the appeal was stamped later than the captured clock, the measured age came out a hair under 100h, and `Math.floor` rendered "99h". Sub-millisecond on an idle machine, a coin flip on a loaded runner. Building the fixture eagerly inverts the ordering. Reproduced with a forced 2 ms gap: 500/500 wrong before, 0/500 after. It is the only test file that dates a fixture against a clock the code under test also reads.

## How verified

- `typecheck` (incl. `typecheck:tests`, with the new file added to the ratchet), `lint`, `format:check`, `context:check`, `imports:check` — all clean.
- New test run directly: 2/2. Confirmed it **fails on unmodified `main`** (the duplicate §11), which is what makes it a pin rather than decoration.
- YAML re-parsed after each workflow edit; the governance regex went from 1 occurrence of `SECURITY\.md` to 0, with every other alternation left byte-identical.
- `security-floor.json` regenerated, +1 for the new `SECURITY:`-prefixed duplicate-number test. The flake fix changes no `SECURITY:` count.
- A mechanical sweep of every tracked file for co-occurring governance-path enumerations, after three review rounds each found a different stale copy by eye.

One assertion I wrote and then removed: that section numbers never go backwards. §20 precedes §19 on `main` today, so it asserted a convention the document does not follow, and physical order carries no meaning when cross-references are by number. Pinning a rule nobody keeps would have made the file noise rather than signal.

## Not in this PR

The third step of the plan — a `changelog-coverage`-shaped check that flags merged PRs touching the security spine with *no* `docs/SECURITY.md` change — is the fix for the #1021 inversion and is deliberately left as follow-up. It adds work rather than removing it, and it should land on its own evidence.

Two non-blocking nits the review raised, also left for follow-up: a tangled nested parenthetical in `docs/CICD.md` point 5, and a pre-existing alphabetical-ordering slip in `tsconfig.tests.json` (`toolTierMap.test.ts` before `stringsCatalogue.test.ts`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_