### PR TITLE
Take agent-base 0.6.2 and Claude Agent SDK 0.3.240

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "community-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.240",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "^0.6.0",
+        "@swampratnz/agent-base": "^0.6.2",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -41,22 +41,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
-      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.240.tgz",
+      "integrity": "sha512-rt/n4rr/Iqem0JtDdL7DdzDnMEei652sS00wVwZ3/0btFt9ah5/iKPKZi8udJ2fjiBwJk6spz9vUQrm6LeyXsA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.240",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.240"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
-      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.240.tgz",
+      "integrity": "sha512-iCGku/IOMvvwSfdFQXnkX2Txzo6nNzz/JoJ2tvmPSnA2NvEEKbSL2P7/WCGSo8asKe1m/6S6EDhYbiagyhc5VQ==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
-      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.240.tgz",
+      "integrity": "sha512-rA5uZtNGbpxe2+ghzBCZvB30Q4tcFduxkP1qMjI4jOFNq5M4b0O173MaQj+g8D9o0clKbAIEx3tq8pSrtEXotA==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
-      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.240.tgz",
+      "integrity": "sha512-cvfxos8HdvVlHO9vKpt8i5cC87a5EuLFBtzjtr+ycczipp4+af+A15J3y2+PEHIvEoLWXxbGKEsX4c81rALn1w==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
-      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.240.tgz",
+      "integrity": "sha512-EsshHPGUtkuw4SAIFnj0zUDfb3Kvp/wPPtVyF0i+rjvekY99ZiQmLZeAmNWf1qTdktYlNiQZE2D77qUW+kaOYA==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
-      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.240.tgz",
+      "integrity": "sha512-pp3VLi/AuZhYn4SY0cMXRHdJam3B7US423OhrV90qlJzNdJ389urxgfQSbuc38wh4nRpbo3xD1uz83qFD/MSag==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
-      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.240.tgz",
+      "integrity": "sha512-wcuLoslY5vepqOALUKhQ/7mTaMqqPD/iCqZ74BwSRjgaylMoNKIkrdKMIcJwewgrcPuiAdJOYEdYGUaWYX9a2Q==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
-      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.240.tgz",
+      "integrity": "sha512-HbXGvQFCB7DTdlTq/JRlpgQBtTjTnMirg28LdLvvXaZL492cZPAvk8CjhzgvRlwQaHv4qpUvkR33R2xlyiBGkg==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +156,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
-      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "version": "0.3.240",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.240.tgz",
+      "integrity": "sha512-XSM+BTBmYi6a06h/ERReyn+oLRrF2JvkbB/BLC1H0GcRwdsiv4r3bzwy0rLcR2OXNzPL8aZ5C5hOG6mqUFiazg==",
       "cpu": [
         "x64"
       ],
@@ -1755,12 +1755,12 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.0.tgz",
-      "integrity": "sha512-uzfbOlSPG1pin0iWAPLIQqvLzUE3Ot+6EYlZFaJg+tw2qOhK63jX9092MkOCaWRUR/mbJzm/peU7TdI1FfSfgw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.2.tgz",
+      "integrity": "sha512-quLsZQzRtACwyyck3NXJG7OrLb31sjDGLoXV+797O12FA47GE9PygMSRtWqZzSkNFqr0izKA1gxo91HnnKUY5g==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.240",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
         "discord.js": "^14.27.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.240",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "^0.6.0",
+    "@swampratnz/agent-base": "^0.6.2",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

Completes the paired SDK bump you asked for:

| | from | to |
|---|---|---|
| `@swampratnz/agent-base` | `^0.6.0` | `^0.6.2` |
| `@anthropic-ai/claude-agent-sdk` | `^0.3.220` | `^0.3.240` |

**Both sides have to move together.** agent-base 0.6.2 carries the same SDK at `^0.3.240` (agent-base #47), and this repo pins that SDK *directly* as well — so bumping only the framework would leave a single deployment resolving two different SDK versions.

Both applied with `npm install` so `package-lock.json` moves with `package.json`.

### Why 0.6.2 and not 0.6.1

agent-base #47 bumped the SDK dependency but not agent-base's own `version` field, so the `v0.6.1` tag landed on a tree whose `package.json` still read `0.6.0` and the publish preflight rejected it (`Tag 'v0.6.1' does not match package.json version '0.6.0'`). Nothing was published; the number was skipped rather than re-tagged, keeping that release history append-only — the same call made for `v0.5.0` and `v0.5.2`. agent-base #48 then released 0.6.2 properly.

`0.6.2` carries **no framework source change** beyond 0.6.0 — the SDK bump is the entire diff between them.

## Security / privacy impact

**No change to this repo's security spine** — no `src/` file is touched at all. No tool, tier, table, permission, SQL scope, or outbound filter is modified. The diff is two dependency ranges and their lockfile entries.

The SDK sits under the agent kernel's `query()` and the tool-execution path, so it is worth being explicit about what did *not* change with it: tool gating, role resolution from env + `community_users`, the CONFIRM flow, secret redaction and code policy on the adapter send paths, and admin SQL scoping all live in this repo and in agent-base's `src/agent/` and `src/platforms/`, none of which this bump alters. The `typecheck` pass below is the check that would surface an SDK API-surface change; agent-base's own `test:consumption` (packing the real tarball and booting a complete composition) already covered the framework side on #47.

Nothing here re-opens the welcome-path filtering question from 0.6.0 — that narrowing shipped in 0.6.0, which this repo already consumes on `main`.

## How verified

Run against the **published** packages from the registry, not packed tarballs:

- **Both resolve, checked in the installed tree rather than by reading the ranges**: `node_modules/@swampratnz/agent-base` → `0.6.2`, `node_modules/@anthropic-ai/claude-agent-sdk` → `0.3.240`.
- **The #559 anti-drift flag pin passes unchanged (2/2)**. It scans the *installed* config for `*_ENABLED` vars and asserts an exact count, so this is a real check that 0.6.2 introduced no new feature flag needing a `FEATURE_FLAG_MAP` entry. The count stays 49; no `tests/tools.test.ts` edit was needed.
- **`npm test` — 3131/3131 pass, 0 failed, 0 skipped** against a real Postgres 16 + pgvector with `DATABASE_URL` set. Zero-skipped is the point: with it unset the DB-gated tests skip and the run proves little.
- `npm run test:security` — 0 fail; gate reports 1228 `SECURITY:`-prefixed tests against a manifest total of 1228 across 159 files. No floor change; this adds no test.
- `npm run typecheck` (incl. `typecheck:tests`), `lint`, `format:check`, `context:check`, `imports:check`, `build` (incl. `check-dist-schema`) — all clean.
- `npm run migrate` — clean.

## Merge note

This touches `package.json`, a governance path, so the auto-merge loop will route it to `human-merge-ready` rather than merging it. Green CI and an automated LGTM are deliberately not sufficient — it needs a human press.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_