### PR TITLE
Update @swampratnz/agent-base to 0.6.3 (the lockfile is the operative change)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "^0.6.2",
+        "@swampratnz/agent-base": "^0.6.3",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -1755,9 +1755,9 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.2.tgz",
-      "integrity": "sha512-quLsZQzRtACwyyck3NXJG7OrLb31sjDGLoXV+797O12FA47GE9PygMSRtWqZzSkNFqr0izKA1gxo91HnnKUY5g==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.3.tgz",
+      "integrity": "sha512-/l/DykBpXsTYydYY07FuZiSoHjuvG+JiWw6SuMJsHXYfX/DvMiRClzzWcbtN7vlDkKxoiqhyaWth2rx1C0q7GQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.240",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "^0.6.2",
+    "@swampratnz/agent-base": "^0.6.3",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

`0.6.3` is the first agent-base release that carries the bosun fleet reporter **at all**. The module merged in agent-base #50, but no published tarball contained `dist/fleet` until now — I pulled the `0.6.2` tarball and listed it: 403 entries, zero matching `fleet`. agent-base #51 then added the caller that starts it from `createAgent`'s `start()`. Without this bump the reporter cannot reach this box.

**The version range was never the blocker.** `^0.6.2` already permits `0.6.3`. But `scripts/redeploy.sh` installs with `npm ci`, which installs `package-lock.json` *exactly* and ignores the range — so the box would have stayed on `0.6.2` through any number of deploys. Refreshing the lock is the change that matters. The floor moves to `^0.6.3` alongside it to record that this deployment now depends on a *behaviour*, so a fresh resolve cannot silently land on a version without the reporter.

Two files, nothing else moved:

```
package.json      "@swampratnz/agent-base": "^0.6.2" → "^0.6.3"
package-lock.json 0.6.2 → 0.6.3 (version, resolved, integrity)
```

**No code change is needed here.** Base starts the reporter; the module does not have to call anything.

## Security / privacy impact

**No effect on auth, tool gating, outbound filtering, data access scope, or stored data.**

The one new behaviour this pulls in is the fleet reporter, and it is **inert on this box**. It is not constructed at all unless `FLEET_AGENT_ID`, `FLEET_AGENT_TYPE` and `FLEET_SUPERVISOR_URL` are all present in the process environment. None are set here, and deliberately so for now: bosun's HTTP API binds `127.0.0.1` only (`http.ts` → `server.listen(port, '127.0.0.1')`), so a cross-box heartbeat could not reach the supervisor even if they were. Installing the reporter ahead of that transport is free; wiring it before the transport exists would not be.

For when it is switched on: it is one-directional. It posts liveness and per-model USD to a supervisor URL read from this process's own environment, executes nothing that comes back, and its payload carries no message content, user id or credential.

## How verified

Against `0.6.3` actually installed from the registry, not just resolved:

- `npm run typecheck` — clean (both `tsconfig.json` and `tsconfig.tests.json`)
- `npm run lint` — clean
- `npm run build` — clean, `check-dist-schema` passes
- `npm test` — **3306 tests, 2696 pass, 609 skipped, 1 fail**

**That one failure is pre-existing and environmental, not caused by this bump.** It is `community_info/formatCommunityInfoText: … (issue #1116 acceptance criterion 3)` in `tests/tools.test.ts`, failing with `ECONNREFUSED 127.0.0.1:5432` — a real Postgres write via `setLanguagePreference` in a test that does not skip without a database. This sandbox has no Postgres.

I confirmed it rather than assuming: reinstalled `0.6.2` from `main`'s lockfile (`npm ci`), re-ran `tests/tools.test.ts`, and got the identical test failing identically. It is unrelated to this diff, though it is worth someone's attention on its own — 609 other tests skip cleanly without a database, so this one is missing the guard the rest have.

**Also verified by hand:** the published `0.6.3` tarball contains `dist/fleet/heartbeat.js`, `.js.map` and `.d.ts` — the files `0.6.2` was missing.

## Follow-on, not in this PR

This box is currently **151 commits behind `main`** and `.deployed-commit` reads `a4582cb`, so `0.6.3` arrives with the catch-up deploy whenever that is run — a separate decision that wants the full deploy procedure (CI green on the target commit, DB and code backup, config validated against the new dist before the restart).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fnz8Rx573T8ahLSzwY8PSh)_