### PR TITLE
Mark the issue #1116 criterion-3 test DB-backed, like its 385 siblings

### DIFF
--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -4631,37 +4631,46 @@ const agentSkillsFlag = config.agentSkills as MutableAgentSkillsFlag;
 const AGENT_SKILLS_DISCOVERABILITY_TEXT_EN = notice('communityInfoSkillsCapabilities');
 const AGENT_SKILLS_DISCOVERABILITY_TEXT_MI = notice('communityInfoSkillsCapabilities', { language: 'mi' });
 
-test('community_info/formatCommunityInfoText: member-tier caller sees the Agent Skills discoverability line when config.agentSkills.enabled is true, in English by default and te reo Māori for a standing mi preference (issue #1116 acceptance criterion 3)', async () => {
-  const original = agentSkillsFlag.enabled;
-  try {
-    agentSkillsFlag.enabled = true;
+test(
+  'community_info/formatCommunityInfoText: member-tier caller sees the Agent Skills discoverability line when config.agentSkills.enabled is true, in English by default and te reo Māori for a standing mi preference (issue #1116 acceptance criterion 3)',
+  // DB-backed: the 'mi' half sets a standing language preference, which is a
+  // real write. Preference READS degrade to the default on a dead pool (hence
+  // the sibling criterion-4 test passing without a database), but a write
+  // throws — so without this guard the whole file goes red on a machine with
+  // no Postgres, which is the one thing a skip marker exists to prevent.
+  { skip },
+  async () => {
+    const original = agentSkillsFlag.enabled;
+    try {
+      agentSkillsFlag.enabled = true;
 
-    const enUser = `${RUN}-info-skills-member-en`;
-    const enReply = (await communityInfoHandler('member', 'discord', enUser)).content[0]?.text ?? '';
-    assert.match(
-      enReply,
-      new RegExp(AGENT_SKILLS_DISCOVERABILITY_TEXT_EN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
-      'a member-tier caller must see the Agent Skills discoverability line when the flag is on',
-    );
+      const enUser = `${RUN}-info-skills-member-en`;
+      const enReply = (await communityInfoHandler('member', 'discord', enUser)).content[0]?.text ?? '';
+      assert.match(
+        enReply,
+        new RegExp(AGENT_SKILLS_DISCOVERABILITY_TEXT_EN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        'a member-tier caller must see the Agent Skills discoverability line when the flag is on',
+      );
 
-    const miUser = `${RUN}-info-skills-member-mi`;
-    await setLanguagePreferenceHandler({ platform: 'discord', userId: miUser }).handler({ language: 'mi' });
-    const miReply = (await communityInfoHandler('member', 'discord', miUser)).content[0]?.text ?? '';
-    assert.match(
-      miReply,
-      new RegExp(AGENT_SKILLS_DISCOVERABILITY_TEXT_MI.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
-      "a member-tier caller with a standing 'mi' preference must see the te reo Māori variant",
-    );
+      const miUser = `${RUN}-info-skills-member-mi`;
+      await setLanguagePreferenceHandler({ platform: 'discord', userId: miUser }).handler({ language: 'mi' });
+      const miReply = (await communityInfoHandler('member', 'discord', miUser)).content[0]?.text ?? '';
+      assert.match(
+        miReply,
+        new RegExp(AGENT_SKILLS_DISCOVERABILITY_TEXT_MI.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        "a member-tier caller with a standing 'mi' preference must see the te reo Māori variant",
+      );
 
-    assert.equal(
-      await formatCommunityInfoText('member', 'discord', enUser),
-      enReply,
-      "formatCommunityInfoText's own output must match the tool handler's (single source of truth)",
-    );
-  } finally {
-    agentSkillsFlag.enabled = original;
-  }
-});
+      assert.equal(
+        await formatCommunityInfoText('member', 'discord', enUser),
+        enReply,
+        "formatCommunityInfoText's own output must match the tool handler's (single source of truth)",
+      );
+    } finally {
+      agentSkillsFlag.enabled = original;
+    }
+  },
+);
 
 test('community_info/formatCommunityInfoText: admin and super_admin callers also receive the Agent Skills discoverability line exactly once, with the admin/super-admin segments still appended after it in the existing order (issue #1116 acceptance criterion 4)', async () => {
   const original = agentSkillsFlag.enabled;


### PR DESCRIPTION
## Summary

Without a Postgres, `npm test` fails on one test with `ECONNREFUSED 127.0.0.1:5432` — so the whole suite reads red on a fresh checkout, which is precisely the signal a skip marker exists to prevent.

**CI is unaffected either way.** It runs against a `pgvector/pgvector:pg16` service with a real `DATABASE_URL`, so this test ran and passed there before this change and still does. This is a local-development fix, not a correctness one.

**Why this test and not its neighbours.** It writes: the te reo Māori half calls `setLanguagePreferenceHandler`, which is a real `INSERT`. Its three siblings in the same `#1116` block pass without a database because preference *reads* degrade to the default on a dead pool and log a warning — only a *write* throws. That asymmetry is easy to miss when you add a test next to passing ones.

The fix is the file's own idiom, already applied to 385 tests in it: the `skip` const computed from `Boolean(process.env.DATABASE_URL)` at the top of the file — captured deliberately *before* the dummy-URL fallback that would otherwise make every test think a database exists.

The rest of the diff is prettier reindenting the body one level, because the options argument turns a single-line `test()` call into a multi-line one. **`git diff -w` shows the whole semantic change: eight added lines.**

## Security / privacy impact

**None.** A test-only change that adds a skip condition; no source file, no runtime behaviour, no data access, no dependency.

Worth stating explicitly since it touches a test gate: the `test:security` floor is **unchanged at 1294 across 162 files**. This test is not `SECURITY:`-prefixed, so it was never in that count, and the gate still passes with the same number.

## How verified

- `npm test` — **3306 tests, 0 fail, 610 skipped** (was 609 skipped with **1 fail** before this change; the delta is exactly this test moving from failing to skipped)
- `npm run typecheck` — clean, both projects
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run test:security` — 1294 SECURITY: tests ran, matching the manifest

Confirmed the skip actually engages rather than the test silently vanishing — it now reports `# SKIP DATABASE_URL not set — skipping DB-integration tests`, the same marker the other 385 carry.

**Not verified here:** the test's actual assertions against a live database. This sandbox has no Postgres, which is the entire reason the failure appeared. CI will exercise it against the pgvector service exactly as it did before.

## Context

Found while verifying an unrelated dependency bump (#1122) — the failing test was the only red in that run, and this confirms it was neither caused by nor related to that change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fnz8Rx573T8ahLSzwY8PSh)_