### PR TITLE
Update @swampratnz/agent-base to 0.6.4 (bearer token for bosun's agent API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "^0.6.3",
+        "@swampratnz/agent-base": "^0.6.4",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -1755,9 +1755,9 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.3.tgz",
-      "integrity": "sha512-/l/DykBpXsTYydYY07FuZiSoHjuvG+JiWw6SuMJsHXYfX/DvMiRClzzWcbtN7vlDkKxoiqhyaWth2rx1C0q7GQ==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.4.tgz",
+      "integrity": "sha512-RXwsBt7y7GZ6u+9jujAEsH88qDTFdxmQ9ykooIjP6N1EwmVq94TGfEcByo0KQ/IsxnfU3ffSKUfVp3f9+oY9mA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.240",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "^0.6.3",
+    "@swampratnz/agent-base": "^0.6.4",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

`0.6.4` is the release that lets the fleet reporter **authenticate**: it reads `FLEET_SUPERVISOR_TOKEN` and presents it as a bearer header, which bosun's agent API (swampratnz/bosun#13) requires for any cross-box report — and it logs a refused report instead of swallowing it. Against `0.6.3`, a wrong or missing token would be a **silent zero**: the agent runs perfectly, the daily spend reads nothing, and no log line says why. That is the exact failure this chain of releases exists to remove.

Same two-file shape as the `0.6.2 → 0.6.3` bump (#1122), and load-bearing for the same reason: `redeploy.sh` installs with `npm ci`, which pins the lockfile exactly, so without this the box stays on `0.6.3` — reporter present, token absent, 401s swallowed — through any number of deploys.

```
package.json      "@swampratnz/agent-base": "^0.6.3" → "^0.6.4"
package-lock.json 0.6.3 → 0.6.4 (version, resolved, integrity)
```

## Security / privacy impact

**No effect on auth tiers, tool gating, outbound filtering, data access scope, or stored data.**

The new behaviour this pulls in is one outbound credential, and it is **inert on this box today**: the reporter is not constructed at all unless `FLEET_AGENT_ID`, `FLEET_AGENT_TYPE` and `FLEET_SUPERVISOR_URL` are set, and none are. When switched on, the token is read from this process's own environment, sent only to the configured supervisor URL, and never logged — the 401 diagnostic names the variable and the supervisor-side config key, never a value.

## How verified

Against `0.6.4` actually installed from the registry (also verified independently that the published tarball's `dist/fleet/heartbeat.js` contains the `FLEET_SUPERVISOR_TOKEN` / `authorization` code):

- `npm run typecheck` — clean, both projects
- `npm run lint` — clean
- `npm run build` — clean, `check-dist-schema` passes
- `npm test` — **3345 tests, 0 fail, 619 skipped** (DB-backed suites; no Postgres in this environment — #1123's skip guard now keeps that honest)

## Context

This is the last repo-side link in the spend-reporting chain: bosun's authenticated agent listener (bosun#13, merged) → agent-base presenting the token (agent-base#52, released as 0.6.4) → this bump so the deploy actually installs it. What remains after merge is box-side only: env vars and tokens on both machines, covered by the deployment runbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fnz8Rx573T8ahLSzwY8PSh)_