### PR TITLE
Build the exactly-at-threshold alert fixture before the job reads its clock

### DIFF
--- a/tests/accessRequestStaleAlert.test.ts
+++ b/tests/accessRequestStaleAlert.test.ts
@@ -210,9 +210,20 @@ test('makeDefaultAccessRequestStaleAlertRun: a pending-access-request set with n
 
 test('makeDefaultAccessRequestStaleAlertRun: an access request exactly at the threshold DOES trigger the alert', async () => {
   const { adapter, dms } = makeAdapter();
-  const listPendingAccessRequests = async () => [
-    accessRequest({ ageHours: ACCESS_REQUEST_STALE_ALERT_THRESHOLD_HOURS }),
-  ];
+  // Built EAGERLY, before runOnce() captures its clock — the same ordering fix
+  // as the stale set above, but load-bearing for a sharper reason: this
+  // fixture sits EXACTLY on the `>=` boundary, so it has no slack at all. The
+  // job reads `Date.now()` first and only then awaits
+  // listPendingAccessRequests(), so a fixture dated inside that lazy callback
+  // is stamped a hair LATER than `now`, making the measured age
+  // `THRESHOLD - delta` — just under the threshold, so the request is not
+  // stale and no DM is sent. The other alert tests carry 30h+ of margin and
+  // only misrender the hour count; this one inverts the very behaviour it
+  // asserts. Building first makes the age `THRESHOLD + delta`, which is
+  // >= threshold on every run. Padding the age instead would destroy the
+  // point of the test, which is the boundary itself.
+  const atThreshold = [accessRequest({ ageHours: ACCESS_REQUEST_STALE_ALERT_THRESHOLD_HOURS })];
+  const listPendingAccessRequests = async () => atThreshold;
   const listAdminIdentities = async () => admins([{}]);
   const runOnce = makeDefaultAccessRequestStaleAlertRun(
     [adapter],


### PR DESCRIPTION
Closes #1231

## Summary

`tests/accessRequestStaleAlert.test.ts` — *"an access request exactly at the threshold DOES trigger the alert"* — dated its fixture **inside** the lazy `listPendingAccessRequests` callback. The job (`src/module/accessRequestStaleAlert.ts:98`) captures `const now = Date.now()` **first** and only then awaits that callback, so the row was stamped at `now + δ` and its measured age was `THRESHOLD − δ`. The comparison is `>=`, so any millisecond of clock advance made the request not stale: no DM, and the test's `assert.equal(dms.length, 1)` failed.

Same root cause as the `appealStaleAlert` fix in #1071 and the `rosterStaleAlert` multi-platform fix in #1229, but **sharper**. Those fixtures carry 30h+ of margin, so the race only ever misrendered the hour count (`100h` → `99h`). This one sits exactly on the `>=` boundary with no slack at all, so it inverts the behaviour the test asserts.

Padding the age was not available as a fix — the boundary *is* the point of the test. Building the fixture eagerly makes the age `THRESHOLD + δ`, which satisfies `>=` on every run.

### Sweep

Every `const now = Date.now()`-then-`await` job in `src/module/` was enumerated: six, all in the stale-alert family (`accessRequest`, `appeal`, `knowledgeCandidate`, `report`, `roster`, `suggestion`). This is the **only** exactly-at-threshold fixture among them. The other five test `THRESHOLD - 1` only, which is safe in the failing direction — a later stamp makes the row *younger*, so it stays under the threshold and the "no alert" assertion still holds. Every exact-hour-string assertion in those files already builds eagerly.

Worth flagging, deliberately **not** done here: five of those six siblings have no exactly-at-threshold test at all, so the `>=` boundary is pinned in only one of six jobs sharing an identical threshold/latch shape. That is a coverage gap, not a flake, and adding five tests is outside a flake repair.

## Security / privacy impact

**None.** Test-only, one file. No change to `src/`, tool gating, RBAC, outbound filtering, data-access scope, schema, config, or stored data. No `SECURITY:` test added or removed, so `tests/security-floor.json` is untouched.

This does *increase* assurance on one security-adjacent behaviour: the corrected test now reliably pins that a request sitting exactly on the staleness threshold **does** alert, rather than passing or failing on clock luck.

## How verified

Full gate on the merged tree against a **freshly created** Postgres 16 + pgvector database:

- `npm test` — **3741 pass, 0 fail, 0 skipped**
- `npm run test:security` — **1506 pass, 0 fail**, manifest exact-match
- `npm run typecheck` (incl. `typecheck:tests`), `lint`, `format:check`, `context:check`, `imports:check`, `migrate`, `build` — all clean

The fix is demonstrated rather than asserted. Injecting a 2 ms gap into the fixture clock, standing in for a loaded runner:

| fixture form | result |
|---|---|
| lazy (before) | `not ok 5 — exactly-at-threshold counts as stale (>= comparison)` — 14 pass / 1 fail |
| eager (after) | 15 pass / 0 fail |

It passes on an idle machine because both `Date.now()` calls land in the same millisecond, which is why it has survived unnoticed.

No CHANGELOG entry: test-only, so this is internal under the changelog-coverage skip-ledger convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgYZcxN4CTBbCeLVTGu8aH)_