### PR TITLE
Escalation comments state the outcome, never a guessed cause

### DIFF
--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -122,8 +122,9 @@ runs:
         # Surface the agent's OWN final message (best-effort) so a maintainer
         # sees the blocker instead of reverse-engineering it from run logs —
         # the transparency the build worker got in #251. A silent stop leaves
-        # no summary, which is itself diagnostic: it usually means a gate the
-        # agent could not make green, or a change it is not allowed to push.
+        # no summary, which is itself worth saying — but only as an absence of
+        # evidence: the caller's `no-summary-note` must not name a cause the
+        # run did not establish (issue #1349).
         summary=""
         exec_file="${EXECUTION_FILE}"
         if [ -z "${exec_file}" ]; then exec_file="${FALLBACK_EXECUTION_FILE}"; fi
@@ -131,12 +132,56 @@ runs:
           summary="$(jq -r '[.. | objects | select(.type? == "result") | .result?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null | head -c 1500 || true)"
         fi
 
-        # printf '%s' throughout: the body and the captured summary are data,
-        # never format strings (the summary is agent-authored text that can
-        # contain % sequences).
+        # --- State what is KNOWN, never a guessed cause (issue #1349) ---
+        # The autofix escalation used to assert "the cause needs a
+        # workflow-file change I can't push, or it was not safely fixable".
+        # On PR #1270 both halves were false: the agent had ended its turn
+        # waiting on a background command, so the flake-vs-defect triage
+        # CLAUDE.md requires of it never ran at all, and the real fix was a
+        # test-file change squarely inside its own push scope. A maintainer
+        # read that sentence, believed it, and the PR sat for 7 days.
+        #
+        # What this step knows is that the tip did not move. Everything past
+        # that is inference, so it is derived from the execution log and
+        # labelled as inference — never asserted in the loop's fixed prose.
+        stop_reason=""
+        turns=""
+        if [ -n "${exec_file}" ] && [ -f "${exec_file}" ]; then
+          stop_reason="$(jq -r '[.. | objects | select(.type? == "result") | .subtype?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null || true)"
+          turns="$(jq -r '[.. | objects | select(.type? == "result") | .num_turns?] | map(select(. != null)) | last // empty' "${exec_file}" 2>/dev/null || true)"
+        fi
+
+        outcome_note=""
+        case "${stop_reason}" in
+          '' | success) ;;
+          error_max_turns)
+            outcome_note="⚠️ The agent **ran out of turns**${turns:+ after ${turns}} rather than finishing (\`${stop_reason}\`). The summary below is a partial state, not a verdict on this PR."
+            ;;
+          *)
+            outcome_note="⚠️ The agent's run **ended in an error** (\`${stop_reason}\`). Draw no conclusion about this PR from the summary below."
+            ;;
+        esac
+
+        # The stall signature (#606, #609, #1270): a clean stop whose last
+        # words are about waiting for something else to finish. Every one of
+        # those agents had already been instructed to run commands
+        # synchronously and never end a turn waiting, so the instruction is
+        # demonstrably not the control — this note is. Reaching this code at
+        # all means nothing was pushed, so a summary about waiting is
+        # suspicious by construction rather than merely unusual.
+        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && printf '%s' "${summary}" | grep -qiE "(wait|waiting|hold off|stand by|check back)[^.]{0,40}\b(for|on|until)\b|once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)"; then
+          outcome_note="⚠️ **This looks like a stall, not a diagnosis.** The agent ended its turn waiting for something to finish (its own words below), so the triage it is instructed to run may never have happened. Read this as \"nobody has looked yet\", NOT as \"the code cannot be fixed\" — re-queue by removing \`${ESCALATION_LABEL}\`."
+        fi
+
+        # printf '%s' throughout: the body, the captured summary and the
+        # derived note are data, never format strings (the summary is
+        # agent-authored text that can contain % sequences).
         {
           printf '%s\n' "${ESCALATE_MARKER}"
           printf '%s\n' "${ESCALATION_BODY}"
+          if [ -n "${outcome_note}" ]; then
+            printf '\n%s\n' "${outcome_note}"
+          fi
           if [ -n "${summary}" ]; then
             printf '\n<details><summary>%s</summary>\n\n' "${SUMMARY_TITLE}"
             printf '%s\n' "${summary}"

--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -155,7 +155,7 @@ runs:
         case "${stop_reason}" in
           '' | success) ;;
           error_max_turns)
-            outcome_note="⚠️ The agent **ran out of turns**${turns:+ after ${turns}} rather than finishing (\`${stop_reason}\`). The summary below is a partial state, not a verdict on this PR."
+            outcome_note="⚠️ The agent **ran out of turns** rather than finishing (\`${stop_reason}\`${turns:+, ${turns} turns}). The summary below is a partial state, not a verdict on this PR."
             ;;
           *)
             outcome_note="⚠️ The agent's run **ended in an error** (\`${stop_reason}\`). Draw no conclusion about this PR from the summary below."
@@ -169,7 +169,13 @@ runs:
         # demonstrably not the control — this note is. Reaching this code at
         # all means nothing was pushed, so a summary about waiting is
         # suspicious by construction rather than merely unusual.
-        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && printf '%s' "${summary}" | grep -qiE "(wait|waiting|hold off|stand by|check back)[^.]{0,40}\b(for|on|until)\b|once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)"; then
+        # Herestring, not `printf … | grep`: under `set -o pipefail` a pipeline
+        # where grep -q exits early and printf takes SIGPIPE reports 141 even
+        # though grep MATCHED, which would silently disable this note. The
+        # summary is capped at 1500 bytes so it would fit the pipe buffer
+        # today, but that is a property of an unrelated `head -c` and not
+        # something this branch should depend on.
+        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by|check back)[^.]{0,40}\b(for|on|until)\b|once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)" <<<"${summary}"; then
           outcome_note="⚠️ **This looks like a stall, not a diagnosis.** The agent ended its turn waiting for something to finish (its own words below), so the triage it is instructed to run may never have happened. Read this as \"nobody has looked yet\", NOT as \"the code cannot be fixed\" — re-queue by removing \`${ESCALATION_LABEL}\`."
         fi
 

--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -169,13 +169,24 @@ runs:
         # demonstrably not the control — this note is. Reaching this code at
         # all means nothing was pushed, so a summary about waiting is
         # suspicious by construction rather than merely unusual.
+        #
+        # Both arms are anchored on the AGENT deferring its own next step, not
+        # merely on the words "once"/"finish" appearing near each other. The
+        # first version's second arm was `once (the|that|this)…(finish|land|…)`
+        # with no word boundary on the pronouns, so it matched "once **the**y
+        # finish" only because "the" is a substring of "they" — and it fired on
+        # ordinary refusals like "I could not finish this once the CI logs
+        # landed". A detector that flags a fully-reasoned stop as "nobody has
+        # looked yet" is the exact harm this whole change exists to remove, so
+        # the arm now keys on an explicit deferral verb (check back, come back,
+        # resume, pick this up) instead of a pronoun.
         # Herestring, not `printf … | grep`: under `set -o pipefail` a pipeline
         # where grep -q exits early and printf takes SIGPIPE reports 141 even
         # though grep MATCHED, which would silently disable this note. The
         # summary is capped at 1500 bytes so it would fit the pipe buffer
         # today, but that is a property of an unrelated `head -c` and not
         # something this branch should depend on.
-        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by|check back)[^.]{0,40}\b(for|on|until)\b|once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)" <<<"${summary}"; then
+        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by)[^.]{0,40}\b(for|on|until)\b|\b(check back|come back|circle back|resume|pick (this|it) up)\b[^.]{0,40}\b(once|when|after|later)\b" <<<"${summary}"; then
           outcome_note="⚠️ **This looks like a stall, not a diagnosis.** The agent ended its turn waiting for something to finish (its own words below), so the triage it is instructed to run may never have happened. Read this as \"nobody has looked yet\", NOT as \"the code cannot be fixed\" — re-queue by removing \`${ESCALATION_LABEL}\`."
         fi
 

--- a/.github/workflows/pipeline-pr-autofix.yml
+++ b/.github/workflows/pipeline-pr-autofix.yml
@@ -344,11 +344,19 @@ jobs:
           escalate-marker: ${{ env.ESCALATE_MARKER }}
           success-message: Autofix pushed a change; CI will re-run on the new commit.
           error-message: Autofix produced no new commit on ${{ env.HEAD_BRANCH }}.
+          # States the OUTCOME only. It used to add "the cause needs a
+          # workflow-file change I can't push, or it was not safely fixable",
+          # which on #1270 was false on both counts — the agent had stalled
+          # and no diagnosis had run — and cost that PR a week because a
+          # maintainer reasonably believed it (issue #1349). Any inference
+          # about WHY is derived from the execution log by the shared action
+          # and labelled as inference.
           escalation-body: >-
-            🤖 Autofix attempt ${{ steps.mark.outputs.attempt }} pushed no fix — the cause needs a
-            workflow-file change I can't push, or it was not safely fixable. Labelled `needs-human`.
-          summary-title: Autofix agent's final summary (what it says blocked it)
+            🤖 Autofix attempt ${{ steps.mark.outputs.attempt }} ended without pushing a fix.
+            Labelled `needs-human`. Run:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.RUN_ID }}
+          summary-title: Autofix agent's final summary (its own last words)
           no-summary-note: >-
-            _No agent summary was captured — it stopped without explaining, which usually means a CI
-            gate it could not make green. Check the run log:
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.RUN_ID }}_
+            _No agent summary was captured, so this escalation says nothing about whether the
+            failure is fixable — only that the agent stopped without pushing and without
+            explaining. Check the run log above._

--- a/.github/workflows/pipeline-pr-conflict.yml
+++ b/.github/workflows/pipeline-pr-conflict.yml
@@ -674,9 +674,14 @@ jobs:
           escalate-marker: ${{ env.ESCALATE_MARKER }}
           success-message: Resolver pushed a merge commit; CI will re-run on the new commit.
           error-message: Conflict resolver produced no new commit on ${{ steps.precheck.outputs.branch }}.
+          # Outcome, not cause (issue #1349). The old wording asserted the
+          # two sides were "semantically incompatible"; #609's supposedly
+          # unresolvable conflict was a clean merge a human finished in
+          # minutes, after the agent had merely stalled waiting on a Monitor
+          # task. The summary below, and the shared action's derived note,
+          # carry whatever the run actually established.
           escalation-body: >-
-            🤖 Could not automatically resolve this PR's conflict with `main` — the two sides are
-            semantically incompatible, or the fix needs a `.github/workflows/` change I can't push.
-            Labelled `needs-human` for a maintainer. Run:
+            🤖 This PR's conflict with `main` was not resolved automatically. Labelled
+            `needs-human` for a maintainer. Run:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           summary-title: Conflict resolver's final summary (what it says blocked it)

--- a/.github/workflows/pipeline-pr-revise.yml
+++ b/.github/workflows/pipeline-pr-revise.yml
@@ -409,7 +409,6 @@ jobs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           summary-title: Revise worker's final summary (what it says stopped it)
           no-summary-note: >-
-            _No agent summary was captured — it ended without pushing **and** without writing
-            `refusal.md`. That usually means a gate it could not make green, a
-            `.github/workflows/` change it cannot push, or a disagreement with the review it did not
-            voice. Check the run log above._
+            _No agent summary was captured, so this escalation says nothing about whether the review
+            can be answered — only that the agent stopped without pushing **and** without writing
+            `refusal.md`. Check the run log above._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,11 @@ ownership rules:
   the PR sat for a week. The conflict resolver made the same shape of claim
   about #609, which a human then merged cleanly in minutes. Any statement about
   WHY is now derived from the execution log by the shared action and labelled
-  as inference: a non-`success` stop reason is reported as the fact it is, and
+  as inference. That covers all three loops: revise's "no summary" note made
+  the same guess as autofix's ("a gate it could not make green, a
+  `.github/workflows/` change it cannot push"), one word away from the phrase
+  the first version of the guard keyed on. A non-`success` stop reason is
+  reported as the fact it is, and
   a clean stop whose last words are about waiting for something to finish is
   flagged as a probable stall — read as "nobody has looked yet", explicitly NOT
   as "the code cannot be fixed". `tests/escalationHonesty.test.ts` pins both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,24 @@ ownership rules:
   genuinely can't fix something, its escalation comment now carries the agent's
   own final summary (the same diagnosability the build worker got in #251) so a
   maintainer isn't reverse-engineering it from run logs.
+- **An escalation comment states the OUTCOME, never a guessed CAUSE** (issue
+  #1349). All three PR-repair loops share
+  `.github/actions/agent-verify-push/action.yml`, which knows exactly one
+  thing: the PR's tip did not move. Autofix used to add "the cause needs a
+  workflow-file change I can't push, or it was not safely fixable" — on #1270
+  both halves were false (the agent had ended its turn waiting on a background
+  command, so its own flake-vs-defect triage never ran, and the fix was a
+  test-file change well inside its push scope), a maintainer believed it, and
+  the PR sat for a week. The conflict resolver made the same shape of claim
+  about #609, which a human then merged cleanly in minutes. Any statement about
+  WHY is now derived from the execution log by the shared action and labelled
+  as inference: a non-`success` stop reason is reported as the fact it is, and
+  a clean stop whose last words are about waiting for something to finish is
+  flagged as a probable stall — read as "nobody has looked yet", explicitly NOT
+  as "the code cannot be fixed". `tests/escalationHonesty.test.ts` pins both
+  halves: the loops' fixed prose must not re-acquire a cause claim, and the
+  detector must fire on the three real stall transcripts without mislabelling a
+  principled refusal.
 - The **conflict-resolver loop** (`pipeline-pr-conflict.yml`) may push a
   `main`-merge to an existing PR branch when that PR is
   CONFLICTING. It is two-hop: a `discover` job (triggered on every push to

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -322,7 +322,11 @@ flagged as a probable stall, explicitly not as a verdict on the code.
 `tests/escalationHonesty.test.ts` extracts the detector's ERE from the action
 and runs it through the real `grep -E` against the three actual stall
 transcripts plus four principled refusals, and separately asserts the loops'
-escalation prose has not re-acquired a cause claim (issue #1349).
+escalation prose has not re-acquired a cause claim (issue #1349). That last
+guard is keyed on `usually means`, not on the longer phrase autofix happened to
+use: its first version required the literal "which usually means" and walked
+straight past revise's "That usually means a gate it could not make green …" —
+the same guess, one word apart, in a loop the test already enumerated.
 
 Note that M7 and M8 stay **separate steps** even though they always run
 together: a checkpoint may legitimately publish work *and* the verify still

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -307,6 +307,23 @@ the build worker keeps its own, because its version asserts a *PR exists* rather
 than a commit landing and additionally owns the lane labels, the resume pointer
 and the recovery-PR path — a different contract that merely shares a name.
 
+The escalation comment it writes states the **outcome only**. The loops' fixed
+prose used to name a cause: autofix's said "the cause needs a workflow-file
+change I can't push, or it was not safely fixable", the conflict resolver's said
+the two sides were "semantically incompatible". Both were false where it
+mattered — #1270's agent had stalled waiting on a background command so no
+diagnosis had run at all, and #609's "unresolvable" conflict was a clean merge a
+human finished in minutes — and a confident wrong sentence is worse than none,
+because a maintainer reads it and deprioritises the PR (#1270 sat seven days).
+Anything about *why* is now derived by the action from the execution log and
+labelled as inference: a non-`success` `subtype` is reported as the fact it is,
+and a clean stop whose final message is about waiting for something to finish is
+flagged as a probable stall, explicitly not as a verdict on the code.
+`tests/escalationHonesty.test.ts` extracts the detector's ERE from the action
+and runs it through the real `grep -E` against the three actual stall
+transcripts plus four principled refusals, and separately asserts the loops'
+escalation prose has not re-acquired a cause claim (issue #1349).
+
 Note that M7 and M8 stay **separate steps** even though they always run
 together: a checkpoint may legitimately publish work *and* the verify still
 escalate, because checkpointed work never cleared the agent's own gate. Folding

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -117,8 +117,13 @@ function extractStallPattern(): string {
   const bodyStart = from + marker.length;
   const to = ACTION.indexOf('"', bodyStart);
   assert.notEqual(to, -1, 'unterminated stall pattern — action restructured?');
-  // The YAML holds the shell source, so `\b` is written `\\b` there.
-  return ACTION.slice(bodyStart, to).replace(/\\\\/g, '\\');
+  // Verbatim. The pattern lives in a double-quoted shell string inside a YAML
+  // block scalar, both of which pass `\b` through untouched, so what is read
+  // here is byte-for-byte what `grep -E` receives on the runner. An earlier
+  // version un-doubled backslashes and said the YAML stored them doubled; it
+  // does not, so that was a no-op guarded by a wrong explanation — which is
+  // the same thing this whole file exists to stop shipping.
+  return ACTION.slice(bodyStart, to);
 }
 
 const STALL_PATTERN = extractStallPattern();

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -50,8 +50,14 @@ const LOOPS: Array<{ file: string; label: string }> = [
  * itself.
  */
 function escalationProse(file: string): string {
+  // `\s{12,}`, not `\s{10,}`: sibling keys in the same `with:` block sit at
+  // exactly 10 spaces, so a 10-space continuation swept straight past this
+  // field's value into `summary-title:` and whatever followed it. Harmless
+  // with today's content, but it made the guard's real scope something other
+  // than what this docstring claims, and a future edit could have tripped it
+  // on a neighbouring field's unrelated wording.
   const bodies = [
-    ...read(file).matchAll(/^\s*(?:escalation-body|no-summary-note):[^\n]*\n((?:\s{10,}[^\n]*\n)+)/gm),
+    ...read(file).matchAll(/^\s*(?:escalation-body|no-summary-note):[^\n]*\n((?:\s{12,}[^\n]*\n)+)/gm),
   ]
     .map((m) => m[1] ?? '')
     .join('\n');
@@ -148,6 +154,21 @@ const STALLS: Array<{ name: string; summary: string }> = [
   },
 ];
 
+/**
+ * Refusals the FIRST version of the detector wrongly flagged. Its second arm
+ * was `once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)` with no
+ * word boundary on the pronouns, so "the" matched as a substring of "they" —
+ * which is also the only reason the check-back fixture above passed. It fired
+ * on all three of these, i.e. it told a maintainer that a fully-reasoned stop
+ * meant "nobody has looked yet". Kept as named cases rather than folded into
+ * REAL_STOPS so a future rewrite of the pattern has to answer for them.
+ */
+const NEAR_MISS_STOPS: string[] = [
+  'I could not finish this once the CI logs landed',
+  'Once these tests land I expect green, but the failure is real and I did not push',
+  'The reviewer asked that this land in a separate PR, so I did not finish here',
+];
+
 test('SECURITY: the escalation flags every known stall shape', { skip }, () => {
   for (const c of STALLS) {
     assert.equal(
@@ -171,7 +192,7 @@ const REAL_STOPS: string[] = [
 ];
 
 test('SECURITY: a principled refusal is never mislabelled as a stall', { skip }, () => {
-  for (const summary of REAL_STOPS) {
+  for (const summary of [...REAL_STOPS, ...NEAR_MISS_STOPS]) {
     assert.equal(matchesStall(summary), false, `wrongly flagged as a stall: ${summary}`);
   }
 });

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -80,10 +80,17 @@ test("SECURITY: no PR-repair loop's escalation prose asserts the conflict is unr
 });
 
 test('SECURITY: no PR-repair loop guesses a cause from the absence of an agent summary', () => {
+  // Deliberately keyed on `usually means` rather than the full phrase autofix
+  // happened to use. The first version of this guard required the literal
+  // "which usually means" and so walked straight past revise.yml's "That
+  // usually means a gate it could not make green, a `.github/workflows/`
+  // change it cannot push, …" — the same cause-guess, one word apart, in a
+  // loop this very LOOPS array already listed. A guard that only catches the
+  // wording you already removed catches nothing.
   for (const loop of LOOPS) {
     assert.doesNotMatch(
       escalationProse(loop.file),
-      /which usually means/i,
+      /\busually means\b/i,
       `${loop.label}: a missing summary is an absence of evidence, not evidence of a cause`,
     );
   }

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -1,0 +1,190 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * What a PR-repair loop's escalation comment is allowed to claim
+ * (.github/actions/agent-verify-push/action.yml, issue #1349).
+ *
+ * The shared verify step knows exactly one fact: the PR's tip did not move.
+ * It used to publish a great deal more than that. Autofix's fixed prose said
+ * "the cause needs a workflow-file change I can't push, or it was not safely
+ * fixable"; on PR #1270 both halves were false — the agent had ended its turn
+ * waiting on a background command, so the flake-vs-defect triage CLAUDE.md
+ * requires of it never ran, and the real fix was a test-file change squarely
+ * inside its own push scope. A maintainer read that sentence, believed it, and
+ * the PR sat for seven days. The conflict resolver made the same shape of
+ * claim ("the two sides are semantically incompatible") about #609, which a
+ * human then merged cleanly in minutes.
+ *
+ * So there are two things to pin, and neither is cosmetic:
+ *
+ *   1. The loops' fixed prose states an OUTCOME and never a CAUSE. Any wording
+ *      that survives here is what a human reads before deciding whether to
+ *      look at a PR at all.
+ *   2. The stall detector fires on the real stall transcripts and not on an
+ *      ordinary refusal. Its regex is EXTRACTED FROM THE ACTION and run
+ *      through the real `grep -E` with the same flags the action uses — a
+ *      string assertion would pass on a pattern that compiles and matches the
+ *      wrong set, which is the only failure that matters.
+ */
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const read = (rel: string): string => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+const ACTION = read('.github/actions/agent-verify-push/action.yml');
+
+/** The loops whose fixed escalation prose a maintainer reads on a red PR. */
+const LOOPS: Array<{ file: string; label: string }> = [
+  { file: '.github/workflows/pipeline-pr-autofix.yml', label: 'autofix' },
+  { file: '.github/workflows/pipeline-pr-revise.yml', label: 'revise' },
+  { file: '.github/workflows/pipeline-pr-conflict.yml', label: 'conflict resolver' },
+];
+
+/**
+ * The prose a loop hands the shared action, scoped to those values rather than
+ * the whole file: the surrounding comments must stay free to *explain* the
+ * claims this guard removed, or documenting the fix would trip the guard on
+ * itself.
+ */
+function escalationProse(file: string): string {
+  const bodies = [
+    ...read(file).matchAll(/^\s*(?:escalation-body|no-summary-note):[^\n]*\n((?:\s{10,}[^\n]*\n)+)/gm),
+  ]
+    .map((m) => m[1] ?? '')
+    .join('\n');
+  assert.notEqual(bodies.length, 0, `no escalation prose found in ${file} — restructured?`);
+  return bodies;
+}
+
+test("SECURITY: no PR-repair loop's escalation prose asserts the code is unfixable", () => {
+  for (const loop of LOOPS) {
+    assert.doesNotMatch(
+      escalationProse(loop.file),
+      /not safely fixable/i,
+      `${loop.label}: this claim was false on #1270 and cost the PR seven days`,
+    );
+  }
+});
+
+test("SECURITY: no PR-repair loop's escalation prose asserts the conflict is unresolvable", () => {
+  for (const loop of LOOPS) {
+    assert.doesNotMatch(
+      escalationProse(loop.file),
+      /semantically incompatible/i,
+      `${loop.label}: this claim was false on #609, which a human merged cleanly in minutes`,
+    );
+  }
+});
+
+test('SECURITY: no PR-repair loop guesses a cause from the absence of an agent summary', () => {
+  for (const loop of LOOPS) {
+    assert.doesNotMatch(
+      escalationProse(loop.file),
+      /which usually means/i,
+      `${loop.label}: a missing summary is an absence of evidence, not evidence of a cause`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The stall detector.
+// ---------------------------------------------------------------------------
+
+const grepAvailable = spawnSync('grep', ['--version'], { encoding: 'utf8' }).status === 0;
+const skip = grepAvailable ? false : 'grep not installed — the action itself requires it on the runner';
+
+/** Slice the double-quoted ERE out of the action's `grep -qiE "..."` call. */
+function extractStallPattern(): string {
+  const marker = 'grep -qiE "';
+  const from = ACTION.indexOf(marker);
+  assert.notEqual(from, -1, 'stall detector not found — action restructured?');
+  const bodyStart = from + marker.length;
+  const to = ACTION.indexOf('"', bodyStart);
+  assert.notEqual(to, -1, 'unterminated stall pattern — action restructured?');
+  // The YAML holds the shell source, so `\b` is written `\\b` there.
+  return ACTION.slice(bodyStart, to).replace(/\\\\/g, '\\');
+}
+
+const STALL_PATTERN = extractStallPattern();
+
+function matchesStall(summary: string): boolean {
+  const res = spawnSync('grep', ['-qiE', STALL_PATTERN], { input: summary, encoding: 'utf8' });
+  assert.ok(res.status === 0 || res.status === 1, `grep errored: ${res.stderr}`);
+  return res.status === 0;
+}
+
+/**
+ * The first three are the agents' ACTUAL final messages from the three runs
+ * that produced this failure mode. If a pattern change stops matching these,
+ * the detector no longer detects the thing it was written for.
+ */
+const STALLS: Array<{ name: string; summary: string }> = [
+  {
+    name: 'autofix on #1270',
+    summary: "I'll stop issuing further calls and wait for the background test run to complete.",
+  },
+  {
+    name: 'revise on #606',
+    summary:
+      "I'll wait for the monitor notification before continuing with the security test suite, build, and push.",
+  },
+  {
+    name: 'conflict resolver on #609 (Monitor task)',
+    summary: 'The merge is staged. Waiting on the Monitor task before I commit and push.',
+  },
+  {
+    name: 'a deferral phrased as a check-back',
+    summary: 'Tests are running in the background; I will check back once they finish.',
+  },
+];
+
+test('SECURITY: the escalation flags every known stall shape', { skip }, () => {
+  for (const c of STALLS) {
+    assert.equal(
+      matchesStall(c.summary),
+      true,
+      `${c.name}: a stall that reads as a diagnosis is what cost #1270 seven days`,
+    );
+  }
+});
+
+/**
+ * The other half of the contract. A principled stop is a real verdict from a
+ * run that did the work, and burying it under "this looks like a stall" would
+ * be the same disservice in the opposite direction.
+ */
+const REAL_STOPS: string[] = [
+  'The fix requires editing .github/workflows/ci.yml, which my token cannot push. Escalating.',
+  'I ran the failing tests in isolation and they fail there too: the PR genuinely breaks the tier map. I did not push a change that would paper over it.',
+  'Reproduced the failure, but the correct fix changes the public tool schema, which is beyond what this PR asked for.',
+  'security-floor.json disagreed with the true counts; regenerating it did not make CI green, so the failure is real.',
+];
+
+test('SECURITY: a principled refusal is never mislabelled as a stall', { skip }, () => {
+  for (const summary of REAL_STOPS) {
+    assert.equal(matchesStall(summary), false, `wrongly flagged as a stall: ${summary}`);
+  }
+});
+
+test('the stall note tells the reader what it does NOT mean, not just what it might', () => {
+  // The whole failure was a maintainer believing a confident wrong sentence.
+  // The replacement has to be explicit about its own uncertainty and about the
+  // conclusion it must not be read as supporting.
+  const note = ACTION.slice(ACTION.indexOf('looks like a stall'));
+  assert.match(note, /nobody has looked yet/i);
+  assert.match(note, /NOT as/);
+  assert.match(note, /re-queue/i);
+});
+
+test('a non-success stop reason is reported instead of the stall guess', () => {
+  // error_max_turns and error_during_execution are facts the execution log
+  // states outright; guessing past them would be the original bug again.
+  assert.match(ACTION, /error_max_turns\)/);
+  assert.match(ACTION, /ran out of turns/i);
+  assert.match(ACTION, /ended in an error/i);
+  // The stall heuristic must not overwrite a stop reason the log already knows.
+  assert.match(ACTION, /if \[ -z "\$\{outcome_note\}" \] && \[ -n "\$\{summary\}" \]/);
+});

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -83,6 +83,7 @@
   "docsIngest.test.ts": 2,
   "embeddingHealthCheck.test.ts": 2,
   "engagementAlert.test.ts": 2,
+  "escalationHonesty.test.ts": 5,
   "escalationRouter.test.ts": 9,
   "evalAnswersOffCi.test.ts": 2,
   "evalAnswersScopeSafety.test.ts": 2,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -34,6 +34,7 @@
     "tests/dependencyPins.test.ts",
     "tests/deployHardening.test.ts",
     "tests/displayTime.test.ts",
+    "tests/escalationHonesty.test.ts",
     "tests/evalAnswersImportFreshness.test.ts",
     "tests/evalAnswersScopeSafety.test.ts",
     "tests/fetchPageTool.test.ts",


### PR DESCRIPTION
Closes #1349

## Summary

The shared verify step knows exactly one thing: the PR's tip did not move. It was publishing considerably more than that.

Autofix's fixed prose said *"the cause needs a workflow-file change I can't push, or it was not safely fixable"*. On #1270 both halves were false. The agent had ended its turn waiting on a background command, so the flake-vs-defect triage `CLAUDE.md` requires of it **never ran at all**; and the real cause was a genuine defect in the PR — a defaulted 5th parameter left 9 pre-existing test call sites falling through to the real repository function and hitting live Postgres — fixable with a test-file change squarely inside autofix's own push scope. A maintainer read that sentence, reasonably believed it, and the PR sat for seven days. The conflict resolver made the same shape of claim about #609 (*"the two sides are semantically incompatible"*), which a human then merged cleanly in minutes.

A confident wrong sentence is worse than no sentence, because it is acted on.

So the loops' fixed prose now states the outcome only, and anything about **why** is derived by the shared action from the execution log and labelled as inference:

- a non-`success` stop reason (`error_max_turns`, `error_during_execution`) is reported as the fact the log states, with the summary marked as a partial state rather than a verdict;
- a clean stop whose final message is about waiting for something to finish is flagged as a probable stall — explicitly to be read as *"nobody has looked yet"*, **not** as *"the code cannot be fixed"*, with the re-queue step spelled out.

That heuristic is the control the prompt-level instruction never was. All three loops already tell their agent to run commands synchronously and never end a turn waiting; #606, #609 and #1270 each did it anyway. `CLAUDE.md` itself already says this class of instruction is "demonstrably not enough".

Remediation 2 in #1349 — making the `security-floor.json` regeneration and the isolation re-run deterministic workflow steps rather than agent instructions — is deliberately **not** in this diff. It needs CI-log parsing to know which tests failed and is a substantially larger change; worth its own issue.

## Review rounds — three findings, all mine, all the same shape as the bug being fixed

1. **The revise loop still guessed a cause**, and my own guard walked past it. Its `no-summary-note` read *"That usually means a gate it could not make green, a `.github/workflows/` change it cannot push, …"* — the same unverified claim from the same silent stop. It survived because the guard was keyed on the literal `which usually means`, the phrase autofix happened to use, while revise's says `That usually means`. One word apart, in a loop the test's own `LOOPS` array already listed. A guard that only catches the wording you already removed catches nothing; it is now keyed on `\busually means\b`.

2. **The stall detector matched by accident, not by rule.** Its second arm was `once (the|that|this)[^.]{0,40}\b(finish|complet|return|land)` with no word boundary on the pronouns. It fired on ordinary refusals — *"I could not finish this once the CI logs landed"*, *"Once these tests land I expect green, but the failure is real and I did not push"* — i.e. it would have told a maintainer that a fully-reasoned stop meant "nobody has looked yet". And the one fixture exercising that arm (*"check back once they finish"*) passed **only because "the" is a substring of "they"**, which is exactly the matches-the-wrong-set failure the test file's own docstring warns about. Both arms are now anchored on the agent deferring its own next step; the three near-misses are kept as named fixtures so a future rewrite has to answer for them.

3. **A comment described a transform that was not happening.** The extraction said the YAML stores backslashes doubled and un-doubled them; it does not, so the replace was a no-op behind an explanation of why it was needed. Now verbatim, with a comment saying why verbatim is right.

## Security / privacy impact

None. No `src/` changes, no permission changes, no new secrets, no change to what any loop is allowed to push or merge. This only alters the prose of a comment the verify step posts and adds a read-only derivation from the execution log it already parses. The summary is still emitted with `printf '%s'` as data, never as a format string.

## How verified

Against a real Postgres 16, after merging `main` (which brought #1356's dependency updates) and `npm ci`:

- `npm run typecheck` (incl. `typecheck:tests`), `npm run lint`, `npm run format:check`, `npm run build`, `npm run context:check`, `npm run imports:check` — clean
- `npm run migrate` then `npm test` — **4062 passed, 0 failed**
- `bash -n` on the extracted composite-action script — parses
- **End-to-end**: extracted the changed block and ran it against synthetic execution logs for all three shapes (stall, principled refusal, `error_max_turns`). Each renders the correct note, with no leading whitespace and the bold and backticks intact.
- `tests/escalationHonesty.test.ts` — 7 tests, 5 `SECURITY:`, passing

### Every guard verified by breaking it

- reintroduce `not safely fixable` → the unfixable-claim test goes red
- restore revise's original `That usually means …` → the cause-guess test goes red (it did **not** with the narrow regex — that is how the bug was found)
- restore the old pronoun-based detector arm → the principled-refusal test goes red

### One correctness fix found by re-reading my own diff

The check was originally `printf '%s' "$summary" | grep -qiE …`, which under `set -o pipefail` can report 141: `grep -q` exits on the first match, `printf` takes SIGPIPE, and pipefail returns the rightmost non-zero status **even though grep matched**, silently disabling the note. It is now a herestring.

This PR touches `.github/`, a governance path, so it routes to human merge rather than auto-merge — expected, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119M8ULkEJmSXUcagEVhU7L