### PR TITLE
Two pipeline signals that outlived their claim

### DIFF
--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -180,13 +180,24 @@ runs:
         # looked yet" is the exact harm this whole change exists to remove, so
         # the arm now keys on an explicit deferral verb (check back, come back,
         # resume, pick this up) instead of a pronoun.
+        #
+        # The third arm was added after a live miss on PR #1390: the autofix
+        # agent stopped with "Here's a summary while the security test suite
+        # finishes running in the background", which contains no wait word and
+        # no deferral verb, so neither of the first two arms fired. Its work
+        # was never committed and a human had to read the truncated summary to
+        # notice. The arm keys on the agent describing something as CURRENTLY
+        # in flight at the moment it stopped — deliberately "running in the
+        # background" and not the bare "in the background", so a past-tense
+        # report ("I ran the suite in the background and it failed for a real
+        # reason") stays a refusal.
         # Herestring, not `printf … | grep`: under `set -o pipefail` a pipeline
         # where grep -q exits early and printf takes SIGPIPE reports 141 even
         # though grep MATCHED, which would silently disable this note. The
         # summary is capped at 1500 bytes so it would fit the pipe buffer
         # today, but that is a property of an unrelated `head -c` and not
         # something this branch should depend on.
-        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by)[^.]{0,40}\b(for|on|until)\b|\b(check back|come back|circle back|resume|pick (this|it) up)\b[^.]{0,40}\b(once|when|after|later)\b" <<<"${summary}"; then
+        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by)[^.]{0,40}\b(for|on|until)\b|\b(check back|come back|circle back|resume|pick (this|it) up)\b[^.]{0,40}\b(once|when|after|later)\b|\b(still running|running in the background|finishes running|running now)\b" <<<"${summary}"; then
           outcome_note="⚠️ **This looks like a stall, not a diagnosis.** The agent ended its turn waiting for something to finish (its own words below), so the triage it is instructed to run may never have happened. Read this as \"nobody has looked yet\", NOT as \"the code cannot be fixed\" — re-queue by removing \`${ESCALATION_LABEL}\`."
         fi
 

--- a/.github/actions/agent-verify-push/action.yml
+++ b/.github/actions/agent-verify-push/action.yml
@@ -187,17 +187,21 @@ runs:
         # no deferral verb, so neither of the first two arms fired. Its work
         # was never committed and a human had to read the truncated summary to
         # notice. The arm keys on the agent describing something as CURRENTLY
-        # in flight at the moment it stopped — deliberately "running in the
-        # background" and not the bare "in the background", so a past-tense
-        # report ("I ran the suite in the background and it failed for a real
-        # reason") stays a refusal.
+        # in flight at the moment it stopped. TENSE has to carry that, because
+        # the phrase alone does not: an earlier draft of this arm matched the
+        # bare "running in the background", which also occurs in "the suite
+        # FINISHED running in the background and reported two real failures I
+        # could not fix" — a completed diagnosis, flagged as a stall, i.e. the
+        # precise harm this whole mechanism exists to prevent. So it keys only
+        # on present-tense forms. Every real stall transcript still matches one
+        # of them; "finished running" no longer matches anything.
         # Herestring, not `printf … | grep`: under `set -o pipefail` a pipeline
         # where grep -q exits early and printf takes SIGPIPE reports 141 even
         # though grep MATCHED, which would silently disable this note. The
         # summary is capped at 1500 bytes so it would fit the pipe buffer
         # today, but that is a property of an unrelated `head -c` and not
         # something this branch should depend on.
-        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by)[^.]{0,40}\b(for|on|until)\b|\b(check back|come back|circle back|resume|pick (this|it) up)\b[^.]{0,40}\b(once|when|after|later)\b|\b(still running|running in the background|finishes running|running now)\b" <<<"${summary}"; then
+        if [ -z "${outcome_note}" ] && [ -n "${summary}" ] && grep -qiE "(wait|waiting|hold off|stand by)[^.]{0,40}\b(for|on|until)\b|\b(check back|come back|circle back|resume|pick (this|it) up)\b[^.]{0,40}\b(once|when|after|later)\b|\b(still running|finishes running|running now)\b" <<<"${summary}"; then
           outcome_note="⚠️ **This looks like a stall, not a diagnosis.** The agent ended its turn waiting for something to finish (its own words below), so the triage it is instructed to run may never have happened. Read this as \"nobody has looked yet\", NOT as \"the code cannot be fixed\" — re-queue by removing \`${ESCALATION_LABEL}\`."
         fi
 

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -173,6 +173,33 @@ jobs:
               echo "::endgroup::"; continue
             fi
 
+            # --- `human-merge-ready` must not outlive the claim it makes -------
+            # The label's comment tells a maintainer "a maintainer just needs to
+            # press merge". That is a statement about the PR's CURRENT state,
+            # and every input to it can flip back: main advances and the PR goes
+            # CONFLICTING, a push turns CI red, a new commit staledates the
+            # LGTM. PR #1382 sat labelled `human-merge-ready` for 22 hours while
+            # actually CONFLICTING — the button it promised did not exist, and
+            # the conflict resolver's own failed attempt left no mark on the
+            # label. A signal that was true once and is never re-checked is the
+            # same class of defect as the CI wedge in #1348.
+            #
+            # So the label is now revoked the moment this loop sees the PR fail
+            # any gate it had previously passed. The one-per-PR explanatory
+            # comment is NOT re-posted on re-qualification (it would be noise);
+            # only the label tracks live state.
+            has_ready="$(jq -r '[.labels[].name] | index("human-merge-ready") != null' <<<"$struct")"
+            revoke_ready() {
+              [ "$has_ready" = 'true' ] || return 0
+              if [ "$MODE" != 'live' ]; then
+                echo "PR #$n: DRY RUN (AUTOMERGE_MODE=$MODE) — would revoke human-merge-ready ($1)."
+                return 0
+              fi
+              echo "PR #$n: revoking human-merge-ready — $1."
+              gh pr edit "$n" --repo "$REPO" --remove-label human-merge-ready \
+                || echo "::warning::Could not remove human-merge-ready from PR #$n."
+            }
+
             # --- Governance / CI / config paths are ALWAYS human-merged --------
             # A PR that changes CI or any workflow (including THIS loop's own
             # gates), the check machinery (npm scripts, the security-gate script,
@@ -295,6 +322,7 @@ jobs:
             # --- Mergeable (no conflict) ---------------------------------------
             if [ "$mergeable" != 'MERGEABLE' ]; then
               echo "PR #$n: mergeable=$mergeable (conflicting or still unknown) — skip; the conflict resolver handles CONFLICTING."
+              revoke_ready "mergeable=$mergeable, so there is no merge button to press"
               echo "::endgroup::"; continue
             fi
 
@@ -314,6 +342,7 @@ jobs:
             ' <<<"$info")"
             if [ "$checks_green" != 'true' ]; then
               echo "PR #$n: not all checks are green yet — skip."
+              revoke_ready "a check is no longer green"
               echo "::endgroup::"; continue
             fi
 
@@ -340,6 +369,7 @@ jobs:
               --jq '[.comments[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and (.body | test("^PR review \\(automated\\):")))] | last // empty')"
             if [ -z "$latest_review" ]; then
               echo "PR #$n: no automated review verdict yet — skip."
+              revoke_ready "the automated review verdict is gone"
               echo "::endgroup::"; continue
             fi
             review_body="$(jq -r '.body' <<<"$latest_review")"
@@ -368,6 +398,7 @@ jobs:
             if [ -n "$token" ]; then
               if [ "$token" != "LGTM" ]; then
                 echo "PR #$n: latest review verdict is $token, not an LGTM approval — skip."
+                revoke_ready "the latest review verdict is $token, not an LGTM"
                 echo "::endgroup::"; continue
               fi
             else
@@ -378,6 +409,7 @@ jobs:
               if printf '%s' "$verdict" | grep -qiE 'changes requested|needs a human decision' \
                  || ! printf '%s' "$verdict" | grep -qiE 'lgtm|ready for a human to merge'; then
                 echo "PR #$n: latest review verdict is not an LGTM approval — skip."
+                revoke_ready "the latest review verdict is not an LGTM"
                 echo "::endgroup::"; continue
               fi
             fi
@@ -389,6 +421,7 @@ jobs:
             head_at="$(gh api "repos/$REPO/commits/$head_sha" --jq '.commit.committer.date')"
             if [ "$(date -d "$review_at" +%s)" -lt "$(date -d "$head_at" +%s)" ]; then
               echo "PR #$n: the LGTM review predates the current head commit — awaiting re-review, skip."
+              revoke_ready "a later push staledated the LGTM; the PR is awaiting re-review"
               echo "::endgroup::"; continue
             fi
 
@@ -403,6 +436,7 @@ jobs:
               --jq '[.labels[].name] | any(. == "needs-human" or . == "no-auto-merge")')"
             if [ "$has_stop" = 'true' ]; then
               echo "PR #$n: a stop label (needs-human/no-auto-merge) appeared during evaluation — aborting before merge."
+              revoke_ready "a stop label was added"
               echo "::endgroup::"; continue
             fi
 
@@ -410,9 +444,13 @@ jobs:
             # human's. Escalate LOUDLY (label + one marker-guarded comment)
             # instead of the old silent skip, then keep scanning so a
             # non-governance PR later in the queue can still merge this run.
-            # The label/comment are idempotent and posted at most once per PR;
-            # they persist across later pushes deliberately — the label means
-            # "auto-merge will never take this one", which stays true.
+            # The explanatory comment is posted at most once per PR. The LABEL
+            # is re-asserted on every qualifying tick and revoked the moment the
+            # PR stops qualifying (see revoke_ready above), so it always tracks
+            # live state. These are deliberately split: after a revocation the
+            # marker comment still exists, so gating the label add on that
+            # marker — as this block used to — would mean the label could never
+            # come back once removed.
             if [ "$governance_hit" = 'true' ]; then
               if [ "$MODE" != 'live' ]; then
                 echo "PR #$n: DRY RUN (AUTOMERGE_MODE=$MODE) — fully vetted but governance-path; would label human-merge-ready."
@@ -426,15 +464,18 @@ jobs:
               # latest_review identity note above).
               already_flagged="$(gh pr view "$n" --repo "$REPO" --json comments \
                 | jq -r --arg m "$READY_MARKER" '[.comments[] | select(.author.login == "github-actions" or .author.login == "github-actions[bot]") | .body] | any(startswith($m))')"
+              # The label, unconditionally — this is the live-state signal, so
+              # it is re-asserted every qualifying tick whether or not the
+              # explanatory comment has already been posted.
+              # --force makes create idempotent (updates if it exists); the
+              # label also lives in scripts/setup-labels.sh with the rest.
+              gh label create human-merge-ready --repo "$REPO" \
+                --color '8250DF' --description 'Fully vetted by auto-merge but touches a governance path; a human must merge' --force \
+                || echo "::warning::Could not ensure the human-merge-ready label exists."
+              gh pr edit "$n" --repo "$REPO" --add-label human-merge-ready \
+                || echo "::warning::Could not add the human-merge-ready label to PR #$n."
               if [ "$already_flagged" != 'true' ]; then
                 echo "PR #$n: fully vetted (green + mergeable + fresh LGTM) but governance-path — flagging human-merge-ready."
-                # --force makes create idempotent (updates if it exists); the
-                # label also lives in scripts/setup-labels.sh with the rest.
-                gh label create human-merge-ready --repo "$REPO" \
-                  --color '8250DF' --description 'Fully vetted by auto-merge but touches a governance path; a human must merge' --force \
-                  || echo "::warning::Could not ensure the human-merge-ready label exists."
-                gh pr edit "$n" --repo "$REPO" --add-label human-merge-ready \
-                  || echo "::warning::Could not add the human-merge-ready label to PR #$n."
                 gh pr comment "$n" --repo "$REPO" --body "${READY_MARKER}
           🤖 Auto-merge evaluated this PR as **fully vetted** — every check green, \`MERGEABLE\`, and a fresh automated \`LGTM\` — but it touches a governance/CI/config path (\`.github/\`, \`scripts/\`, \`package.json\`, check config, or the \`CLAUDE.md\`/\`docs/PIPELINE.md\`/\`docs/VISION.md\` governance docs), which always requires a **human merge** (see docs/PIPELINE.md, auto-merge loop). Labelled \`human-merge-ready\` — a maintainer just needs to press merge." \
                   || echo "::warning::Could not post the human-merge-ready comment on PR #$n."

--- a/.github/workflows/pipeline-pr-automerge.yml
+++ b/.github/workflows/pipeline-pr-automerge.yml
@@ -168,11 +168,6 @@ jobs:
               and ((.body // "") | test("[Cc]loses #[0-9]+"))
               and ([.labels[].name] | (index("needs-human") | not) and (index("no-auto-merge") | not))
             ' <<<"$struct")"
-            if [ "$eligible" != 'true' ]; then
-              echo "PR #$n: not an eligible build-worker PR (draft/fork/not claude[bot]/no Closes #/stop-labelled) — skip."
-              echo "::endgroup::"; continue
-            fi
-
             # --- `human-merge-ready` must not outlive the claim it makes -------
             # The label's comment tells a maintainer "a maintainer just needs to
             # press merge". That is a statement about the PR's CURRENT state,
@@ -188,6 +183,14 @@ jobs:
             # any gate it had previously passed. The one-per-PR explanatory
             # comment is NOT re-posted on re-qualification (it would be noise);
             # only the label tracks live state.
+            # Computed BEFORE the eligibility gate on purpose. The first draft
+            # defined this after it, which left the loop exiting at that gate
+            # without ever reaching a revocation — so a maintainer pinning a
+            # labelled PR out with `no-auto-merge` (the mechanism
+            # docs/PIPELINE.md tells them to use) or converting it back to
+            # draft would leave `human-merge-ready` sitting next to the label
+            # that contradicts it, forever. That is the same defect this whole
+            # block fixes, one gate earlier.
             has_ready="$(jq -r '[.labels[].name] | index("human-merge-ready") != null' <<<"$struct")"
             revoke_ready() {
               [ "$has_ready" = 'true' ] || return 0
@@ -199,6 +202,23 @@ jobs:
               gh pr edit "$n" --repo "$REPO" --remove-label human-merge-ready \
                 || echo "::warning::Could not remove human-merge-ready from PR #$n."
             }
+
+            if [ "$eligible" != 'true' ]; then
+              echo "PR #$n: not an eligible build-worker PR (draft/fork/not claude[bot]/no Closes #/stop-labelled) — skip."
+              # Revoke ONLY for the two reasons that mean "was eligible, now
+              # isn't". A fork / non-claude[bot] / no-`Closes #` PR could never
+              # have been labelled by this loop in the first place, so a label
+              # on one of those was put there by a human and is not ours to
+              # remove.
+              is_stopped="$(jq -r '[.labels[].name] | (index("needs-human") != null) or (index("no-auto-merge") != null)' <<<"$struct")"
+              is_draft="$(jq -r '.isDraft' <<<"$struct")"
+              if [ "$is_stopped" = 'true' ]; then
+                revoke_ready "a stop label was added"
+              elif [ "$is_draft" = 'true' ]; then
+                revoke_ready "the PR went back to draft"
+              fi
+              echo "::endgroup::"; continue
+            fi
 
             # --- Governance / CI / config paths are ALWAYS human-merged --------
             # A PR that changes CI or any workflow (including THIS loop's own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,7 +406,15 @@ ownership rules:
   it gets a `human-merge-ready` label plus one marker-guarded comment asking
   a maintainer to merge (pipeline work routinely edits `.github/` or
   `scripts/` to fix the machinery itself, so this stays a well-trodden path
-  even with `docs/SECURITY.md` off the list).
+  even with `docs/SECURITY.md` off the list). That label tracks LIVE state,
+  not a verdict once reached: the loop revokes it the moment the PR fails any
+  gate it had passed (goes CONFLICTING, CI turns red, the LGTM staledates, a
+  stop label appears) and re-asserts it when the PR qualifies again. #1382
+  carried it for 22 hours while actually CONFLICTING — its comment says "a
+  maintainer just needs to press merge", and there was no button to press.
+  The one-per-PR comment stays marker-gated, so only the label moves; the
+  label add is deliberately OUTSIDE that marker gate, since after a revocation
+  the marker comment still exists and a gated add could never restore it.
   Never one labelled `needs-human`/`no-auto-merge`. Exactly ONE merge per run:
   afterwards `main` has advanced, so it dispatches the conflict resolver to
   rebase the rest, and the next PR only re-qualifies once it is green against

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -422,6 +422,7 @@ What happens when each thing fails, in order of who gets there first:
 | Review says "Changes requested" | `pipeline-pr-revise.yml`, ≤2 attempts | `needs-human` | human |
 | Review says "Needs a human decision" | review labels `needs-human` directly | — | human |
 | PR green + LGTM but touches a governance path | automerge labels `human-merge-ready` + one comment | keeps scanning for other PRs | human merges |
+| A `human-merge-ready` PR stops qualifying (CONFLICTING, CI red, LGTM staledated, stop label) | automerge revokes the label on its next tick | re-asserted when it qualifies again; the comment is not re-posted | the label never outlives its claim (#1382) |
 | Merged PR has no changelog entry | `changelog-coverage.yml` opens/refreshes one self-closing tracking issue | `changelog-autofill.yml` drafts a PR 30 min later | human merges the autofill PR |
 | Merged branch left behind | `branch-janitor.yml` weekly, ancestry- or all-PRs-merged only | never touches never-PR'd or `-ckpt-` refs | `extra` dispatch input |
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -187,7 +187,12 @@ Create them once: **Actions → "Setup pipeline labels" → Run workflow**, or
   LGTM, no stop labels) is labelled `human-merge-ready` and gets one
   marker-guarded comment asking a maintainer to press merge — the loop still
   never merges it itself, and it keeps scanning so a non-governance PR later
-  in the queue can still merge that run. It merges **exactly one
+  in the queue can still merge that run. The label is revoked again the
+  moment any of those gates stops holding, because its comment promises a
+  merge button and that promise expires: #1382 wore it for 22 hours while
+  CONFLICTING, with the conflict resolver's own failed attempt leaving no
+  mark on it. The explanatory comment is still posted at most once per PR;
+  only the label tracks live state. It merges **exactly one
   PR per run**: afterwards `main` has advanced, so it dispatches the conflict
   resolver to rebase whatever now conflicts, and the next PR only re-qualifies
   once it is green against the new `main` — so a PR is never merged except

--- a/tests/autoMergeReadyLabel.test.ts
+++ b/tests/autoMergeReadyLabel.test.ts
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `human-merge-ready` must not outlive the claim it makes
+ * (.github/workflows/pipeline-pr-automerge.yml).
+ *
+ * The label ships with a comment reading "a maintainer just needs to press
+ * merge". That is a statement about the PR's CURRENT state, and every input to
+ * it can flip back: main advances and the PR goes CONFLICTING, a push turns CI
+ * red, a new commit staledates the LGTM. PR #1382 carried the label for 22
+ * hours while actually CONFLICTING — the button it promised did not exist. A
+ * signal that was true once and is never re-checked is the same class of defect
+ * as the CI wedge in #1348, which is the whole reason this repo now has a
+ * groundskeeper sweep.
+ *
+ * The guard here is the `has_ready` jq (which decides whether there is anything
+ * to revoke) EXTRACTED FROM THE WORKFLOW and run through real `jq`, plus two
+ * structural properties of the escalation block that a string match alone would
+ * not establish:
+ *
+ *   1. every gate that can invalidate readiness revokes before it `continue`s;
+ *   2. the label add is NOT inside the marker-gated branch — after a revocation
+ *      the marker comment still exists, so a marker-gated add could never
+ *      restore the label, which would turn this fix into a one-way delete.
+ */
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const WORKFLOW = path.join(repoRoot, '.github/workflows/pipeline-pr-automerge.yml');
+const yaml = readFileSync(WORKFLOW, 'utf8');
+
+const jqAvailable = spawnSync('jq', ['--version'], { encoding: 'utf8' }).status === 0;
+const skip = jqAvailable ? false : 'jq not installed — the workflow itself requires it on the runner';
+
+/** Slice a single-quoted jq program out of the workflow's shell. */
+function extractJq(startMarker: string, endMarker: string): string {
+  const from = yaml.indexOf(startMarker);
+  assert.notEqual(from, -1, `start marker not found — workflow restructured?\n  ${startMarker}`);
+  const bodyStart = from + startMarker.length;
+  const to = yaml.indexOf(endMarker, bodyStart);
+  assert.notEqual(to, -1, `end marker not found after start — workflow restructured?\n  ${endMarker}`);
+  return yaml.slice(bodyStart, to);
+}
+
+const HAS_READY_JQ = extractJq(`has_ready="$(jq -r '`, `' <<<"$struct")"`);
+
+function runJq(program: string, input: unknown): string {
+  const res = spawnSync('jq', ['-r', program], { input: JSON.stringify(input), encoding: 'utf8' });
+  assert.equal(res.status, 0, `jq failed: ${res.stderr}`);
+  return res.stdout.trim();
+}
+
+const labelled = (...names: string[]) => ({ labels: names.map((name) => ({ name })) });
+
+test(
+  'SECURITY: the auto-merge loop detects an existing human-merge-ready label, so it has something to revoke',
+  { skip },
+  () => {
+    assert.equal(runJq(HAS_READY_JQ, labelled('human-merge-ready')), 'true');
+    assert.equal(runJq(HAS_READY_JQ, labelled('dependencies', 'human-merge-ready')), 'true');
+    // No label, nothing to revoke — revoke_ready must be a no-op so an ordinary
+    // PR never eats a pointless `gh pr edit` call on every gate it fails.
+    assert.equal(runJq(HAS_READY_JQ, labelled()), 'false');
+    assert.equal(runJq(HAS_READY_JQ, labelled('dependencies')), 'false');
+    // Must not be satisfied by a merely similar label.
+    assert.equal(runJq(HAS_READY_JQ, labelled('human-merge-ready-soon')), 'false');
+    assert.equal(runJq(HAS_READY_JQ, labelled('needs-human')), 'false');
+  },
+);
+
+/**
+ * Every gate that can flip from pass to fail after the label was applied. If a
+ * new gate is added to the loop without a revocation, the label can once again
+ * outlive its claim — which is exactly what #1382 did.
+ */
+const INVALIDATING_GATES: Array<{ skipLine: string; why: string }> = [
+  {
+    skipLine: 'mergeable=$mergeable (conflicting or still unknown)',
+    why: 'the PR went CONFLICTING (this is #1382)',
+  },
+  { skipLine: 'not all checks are green yet', why: 'a push turned CI red' },
+  { skipLine: 'no automated review verdict yet', why: 'the verdict disappeared' },
+  { skipLine: 'not an LGTM approval — skip', why: 'the verdict flipped to CHANGES_REQUESTED' },
+  { skipLine: 'predates the current head commit', why: 'a later push staledated the LGTM' },
+  { skipLine: 'a stop label (needs-human/no-auto-merge) appeared', why: 'a human pinned it out' },
+];
+
+test('SECURITY: every gate that can invalidate readiness revokes the label before skipping', () => {
+  for (const gate of INVALIDATING_GATES) {
+    const at = yaml.indexOf(gate.skipLine);
+    assert.notEqual(at, -1, `gate not found — workflow restructured?\n  ${gate.skipLine}`);
+    // The revoke must sit between this gate's own log line and the `continue`
+    // that leaves the PR behind, not merely somewhere in the file.
+    const tail = yaml.slice(at);
+    const untilContinue = tail.slice(0, tail.indexOf('continue'));
+    assert.match(
+      untilContinue,
+      /revoke_ready /,
+      `the "${gate.why}" gate skips without revoking human-merge-ready — the label would keep promising a merge button that is not there`,
+    );
+  }
+});
+
+test('the label add is re-asserted every qualifying tick, not gated on the one-per-PR comment marker', () => {
+  // After a revocation the marker comment still exists. If the add stayed
+  // inside the `already_flagged` branch the label could never come back, and
+  // revoking would silently become a one-way delete.
+  const block = yaml.slice(yaml.indexOf('already_flagged="$('));
+  const addAt = block.indexOf('--add-label human-merge-ready');
+  const gateAt = block.indexOf(`if [ "$already_flagged" != 'true' ]`);
+  assert.notEqual(addAt, -1, 'the label add was not found in the escalation block');
+  assert.notEqual(gateAt, -1, 'the already_flagged gate was not found');
+  assert.ok(
+    addAt < gateAt,
+    'the human-merge-ready add must come BEFORE the already_flagged gate, or a revoked label can never be restored',
+  );
+  // The comment, by contrast, must stay inside the gate — one per PR.
+  const commentAt = block.indexOf('gh pr comment');
+  assert.ok(
+    commentAt > gateAt,
+    'the explanatory comment must stay marker-gated so it is posted at most once',
+  );
+});

--- a/tests/autoMergeReadyLabel.test.ts
+++ b/tests/autoMergeReadyLabel.test.ts
@@ -86,7 +86,32 @@ const INVALIDATING_GATES: Array<{ skipLine: string; why: string }> = [
   { skipLine: 'not an LGTM approval — skip', why: 'the verdict flipped to CHANGES_REQUESTED' },
   { skipLine: 'predates the current head commit', why: 'a later push staledated the LGTM' },
   { skipLine: 'a stop label (needs-human/no-auto-merge) appeared', why: 'a human pinned it out' },
+  // The gate the first draft missed. It sits ABOVE the others and `continue`s
+  // for draft / fork / not-claude[bot] / no-`Closes #` / stop-labelled, so a
+  // maintainer pinning a labelled PR out with `no-auto-merge` — the mechanism
+  // docs/PIPELINE.md tells them to use — or converting it back to draft would
+  // exit here and never reach any of the six revocations below it.
+  {
+    skipLine: 'not an eligible build-worker PR',
+    why: 'a labelled PR was pinned out or sent back to draft (found in review of this PR)',
+  },
 ];
+
+test('the eligibility gate revokes only for reasons a loop-applied label could have, not for PRs it never labelled', () => {
+  // A fork / non-claude[bot] / no-`Closes #` PR could never have been labelled
+  // by this loop, so a `human-merge-ready` on one of those was applied by a
+  // human and is not this loop's to remove. Only the two transitions that mean
+  // "was eligible, now isn't" revoke.
+  const block = yaml.slice(yaml.indexOf(`if [ "$eligible" != 'true' ]`));
+  const gate = block.slice(0, block.indexOf('continue'));
+  assert.match(gate, /is_stopped=/, 'the stop-label transition must be distinguished');
+  assert.match(gate, /is_draft=/, 'the draft transition must be distinguished');
+  assert.doesNotMatch(
+    gate.replace(/if \[ "\$is_(stopped|draft)" = 'true' \][\s\S]*/, ''),
+    /revoke_ready /,
+    'the eligibility gate must not revoke unconditionally — that would strip a human-applied label off a PR this loop never labelled',
+  );
+});
 
 test('SECURITY: every gate that can invalidate readiness revokes the label before skipping', () => {
   for (const gate of INVALIDATING_GATES) {

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -190,6 +190,13 @@ const NEAR_MISS_STOPS: string[] = [
   // a finished diagnosis, not a stall. This is why that arm keys on "running
   // in the background" rather than the bare "in the background".
   'I ran the suite in the background and it failed for a real reason, so I stopped.',
+  // The tense-ambiguity control, from the review of the PR that added the
+  // third arm. This one uses the LITERAL phrase the first draft matched
+  // ("running in the background") in a completed report — which is why that
+  // draft would have flagged it, and why the arm now keys on present-tense
+  // forms only. The control above sidesteps the phrase entirely and so never
+  // exercised this.
+  'The suite finished running in the background and reported two real failures I could not fix, so I stopped.',
 ];
 
 test('SECURITY: the escalation flags every known stall shape', { skip }, () => {

--- a/tests/escalationHonesty.test.ts
+++ b/tests/escalationHonesty.test.ts
@@ -157,6 +157,20 @@ const STALLS: Array<{ name: string; summary: string }> = [
     name: 'a deferral phrased as a check-back',
     summary: 'Tests are running in the background; I will check back once they finish.',
   },
+  {
+    // The live miss that added the third arm (autofix on PR #1390). It
+    // contains no wait word and no deferral verb — it simply reports work as
+    // in flight — so the first two arms both walked past it. The agent's
+    // fix was never committed and a human had to read the truncated summary
+    // to notice it had stalled at all.
+    name: 'autofix on #1390 (work described as in flight, no wait word)',
+    summary:
+      "I've identified the CI failure and applied a fix. Here's a summary while the security test suite finishes running in the background:",
+  },
+  {
+    name: 'autofix on #1390, as actually truncated at the 1500-byte cap',
+    summary: '- `test:security` — running now in the',
+  },
 ];
 
 /**
@@ -172,6 +186,10 @@ const NEAR_MISS_STOPS: string[] = [
   'I could not finish this once the CI logs landed',
   'Once these tests land I expect green, but the failure is real and I did not push',
   'The reviewer asked that this land in a separate PR, so I did not finish here',
+  // The control for the third arm: a PAST-TENSE report of background work is
+  // a finished diagnosis, not a stall. This is why that arm keys on "running
+  // in the background" rather than the bare "in the background".
+  'I ran the suite in the background and it failed for a real reason, so I stopped.',
 ];
 
 test('SECURITY: the escalation flags every known stall shape', { skip }, () => {

--- a/tests/security-floor.json
+++ b/tests/security-floor.json
@@ -44,6 +44,7 @@
   "autoAnswerRouter.test.ts": 4,
   "autoAnswerThreadFollowupRouter.test.ts": 8,
   "autoAnswerUsageRouter.test.ts": 1,
+  "autoMergeReadyLabel.test.ts": 2,
   "backgroundJobCost.test.ts": 3,
   "backgroundJobCostAlert.test.ts": 2,
   "backgroundJobs.test.ts": 16,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -28,6 +28,7 @@
     "src/**/*.ts",
     "tests/agentModule.test.ts",
     "tests/agentRunActions.test.ts",
+    "tests/autoMergeReadyLabel.test.ts",
     "tests/backgroundJobCostAlert.test.ts",
     "tests/conflictResolverEligibility.test.ts",
     "tests/dbCoverageCheck.test.ts",


### PR DESCRIPTION
Both found by live cases in the two days since #1357 landed, and both are the same defect: **a signal that was true once and is never re-checked** — the class the groundskeeper sweep (#1348) exists for.

## 1. The stall detector missed a real stall (#1390)

The autofix agent on #1390 stopped with:

> Here's a summary **while the security test suite finishes running in the background**:

No wait word, no deferral verb — so neither existing arm of the detector fired. Its fix was never committed, so the checkpoint step had nothing to rescue, and a human had to read the truncated summary (`- test:security — running now in the`) to notice it had *stalled* rather than *decided*.

The honest-outcome half of #1349 worked exactly as intended here: the escalation said only *"ended without pushing a fix"* rather than the old false *"not safely fixable"*, which is what made the PR quick to pick up. But the inference half stayed silent when it had something true to say.

A third arm now keys on the agent describing work as **currently in flight at the moment it stopped**, and — after the first review round — on **present tense only**: `still running`, `finishes running`, `running now`.

Tense is doing the work, because the phrase alone cannot. The first draft of this arm also matched the bare `running in the background`, which occurs just as happily in *"the suite **finished** running in the background and reported two real failures I could not fix"* — a completed diagnosis, flagged as a stall, i.e. the precise harm this whole mechanism exists to prevent. Dropping that alternative kills the false positive while keeping every true positive: `finishes running in the background` still matches via `finishes running`.

Pinned fixtures now include both real #1390 transcripts (the full sentence and its actually-truncated form) and, in `NEAR_MISS_STOPS`, the reviewer's exact finished-running sentence — using the literal phrase, so the tense ambiguity is genuinely exercised rather than sidestepped.

## 2. `human-merge-ready` outlived its own promise (#1382)

The label ships with a comment reading *"a maintainer just needs to press merge"*. #1382 wore it for **22 hours while `mergeable_state: dirty`** — there was no button to press, and the conflict resolver's own failed attempt left no mark on the label.

The workflow justified the stickiness inline: *"the label means 'auto-merge will never take this one', which stays true"*. That is true of the governance-path fact, but it is not what the label's **name** or its **comment** tell a human.

The label is now revoked whenever the loop sees the PR fail a gate it had previously passed, and re-asserted when it qualifies again.

**The first draft of this fix had the defect it was fixing, one gate earlier.** `revoke_ready` was defined *below* the top-of-loop eligibility filter, which `continue`s for draft / fork / not-`claude[bot]` / no-`Closes #` / stop-labelled. So a maintainer pinning a labelled PR out with `no-auto-merge` — the mechanism `docs/PIPELINE.md` tells them to use — or converting it back to draft would exit there and never reach any revocation. My own `INVALIDATING_GATES` list did not cover that path either. The review round caught it; the helper now sits above that gate.

That eligibility-gate revocation is deliberately **narrow**: only `is_stopped` and `is_draft`, the two transitions that mean *"was eligible, now isn't"*. A fork / non-bot / no-`Closes #` PR could never have been labelled by this loop, so a label on one was applied by a human and is not this loop's to remove. That distinction has its own test.

Re-assertion also required splitting the label add out of the marker-gated branch: the marker comment survives a revocation, so leaving the add gated on it would have made revoking a **one-way delete**. The comment stays marker-gated and one-per-PR; only the label tracks live state.

## Security / privacy impact

No `src/` changes; no RBAC, tool-gating, outbound-filtering or SQL-scoping surface touched. No permission changes — the loop already holds `pull-requests: write` for the label add it has always done, and `--remove-label` needs nothing further. It remains deterministic, no-LLM, reading PR fields only as `jq` data.

Worth stating plainly: the label is **advisory**. The merge decision is gated independently by `governance_hit`, so no label state — stale, revoked, or hand-applied — can cause an unintended auto-merge. Revoking is also a narrowing action: it can only ever make a PR merge less readily, never more. The failure mode being fixed is a human being misled, not a gate being bypassed.

## How verified

- `npm run typecheck` (incl. `typecheck:tests`), `lint`, `format:check`, `build`, `context:check`, `imports:check` — clean
- `bash -n` on the extracted auto-merge step — parses
- `tests/autoMergeReadyLabel.test.ts` (4 tests, 2 `SECURITY:`) and `tests/escalationHonesty.test.ts` (7 tests, 5 `SECURITY:`) — 11/11 passing
- New test added to `tsconfig.tests.json`'s ratchet and to `security-floor.json`, both in alphabetical position

### Every guard verified by breaking it

| mutation | result |
|---|---|
| drop the revoke at the mergeable gate | gate test reddens, naming the #1382 case |
| move `revoke_ready` back below the eligibility gate | two tests redden |
| move the label add back inside the marker gate | restoration test reddens |
| remove the third detector arm | the #1390 fixture reddens |
| restore the bare `running in the background` alternative | refusal test reddens, naming the finished-running sentence |

The gate test asserts the revoke sits **between each gate's own log line and its `continue`**, not merely somewhere in the file — so a future gate added without a revocation fails it, which is how both #1382 and the eligibility-gate miss happened in the first place.

This PR touches `.github/`, a governance path, so it routes to human merge rather than auto-merge — expected, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119M8ULkEJmSXUcagEVhU7L