### PR TITLE
test(spine): pin arm-shell in the consumer spine-order assertion (needs agent-base 0.7.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.260",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "0.6.6",
+        "@swampratnz/agent-base": "0.7.0",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -1755,9 +1755,9 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.6.6.tgz",
-      "integrity": "sha512-nHy3cSs+IaqZEm8jEo7QnRWx0fAInQ/ePmW1l5lynWG86yHzPsK3Av97LOPj8+0iM9FYnLja4P60yk2ThTkhYQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.7.0.tgz",
+      "integrity": "sha512-AfYfhmULvrEKVLwPl+GbleIBN6UY1PiBSfK0eBJdVAVVJffZzQZuUGzb5Pa8FNnKrI6uedrd8H3PcjkukDHSCw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.260",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "0.6.6",
+    "@swampratnz/agent-base": "0.7.0",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",

--- a/tests/routerInterceptChain.test.ts
+++ b/tests/routerInterceptChain.test.ts
@@ -48,6 +48,7 @@ test('SECURITY: PRE_TURN_SPINE is frozen and lists the security-ordered pre-turn
       'gated-guest',
       'record-inbound',
       'confirm-intercept',
+      'arm-shell',
       'escalation-confirm',
       'addressed-gate',
       'pause',


### PR DESCRIPTION
> **`@swampratnz/agent-base` 0.7.0 is published and pinned here** (swampratnz/agent-base#58, merge `1775ab9`; npm `gitHead` verified to match, `latest = 0.7.0`). Pinned exact (`--save-exact`) because `dependencyPins` rejects a caret range.

## Why

agent-base 0.7.0 adds a new pre-turn spine step, `arm-shell` — a deterministic, super-admin-only router intercept that opens the arming window for the full Agent SDK built-in tool surface (shell, file write/edit, read, fetch, sub-agents). This repo deliberately keeps **its own** copy of the spine order, so a reorder or insertion in base surfaces here as a security regression rather than passing silently.

That pin did its job: it was the **only** failure in agent-base#58's canary run (4209 pass, 1 fail).

## What changes

Two commits, both small:

1. `'arm-shell'` inserted after `'confirm-intercept'` in the exact-order assertion in `tests/routerInterceptChain.test.ts` — its audited position, since both are deterministic actor-keyed intercepts that must run *before* the addressed gate so a bare phrase works in a group conversation. The file's other two assertions derive from `PRE_TURN_SPINE.length` and needed no change.
2. The dependency bump to 0.7.0 (package.json + lockfile).

## Verification

- Typecheck clean; `routerInterceptChain` + `dependencyPins` 7/7; Prettier clean.
- Full suite: **4210 tests, 3294 pass, 911 skipped (DB-gated), 5 fail** — the 5 being the known Windows `importDirection` path artifacts, which fail identically on untouched `main`.
- Before the bump, the updated pin was also checked against a locally packed 0.7.0 (with `dist` rebuilt first, since `npm pack` does not rebuild): 4/4.

**Two flakes seen once, recorded rather than dropped.** An earlier full run also failed `agentWebSearchDedup` AC-1 and `agentWebSearchRateLimit` AC-0/AC-1. Both pass in isolation (4/4, and 13/13 with both files together) and in a clean rerun. Both select their hook by `matcher === 'WebSearch'`, not by array position, so prepending 0.7.0's arming gate to `PreToolUse` cannot shift them — and AC-1 flaked once before on a branch that touched no hooks at all. They look like load-order flakes in the parallel runner; if CI disagrees, that changes the diagnosis and I'll say so.

## What this does NOT do

It does not enable anything on Dave. Dave stays on agent-base 0.6.6 until a deploy is separately approved, and even on 0.7.0 the super-admin tool surface is inert unless a super admin arms it with an explicit message ("arm shell", 5 minutes). An unarmed super-admin turn is byte-identical to an admin turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULGfkzvZLCXrDRiz9CsMH7
