### PR TITLE
Pin agent-base 0.8.0 and the shell-arming prompt slot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.260",
         "@hapi/boom": "^10.0.1",
         "@huggingface/transformers": "^4.2.0",
-        "@swampratnz/agent-base": "0.7.0",
+        "@swampratnz/agent-base": "0.8.0",
         "@whiskeysockets/baileys": "6.7.24",
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
@@ -1755,9 +1755,9 @@
       "peer": true
     },
     "node_modules/@swampratnz/agent-base": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.7.0.tgz",
-      "integrity": "sha512-AfYfhmULvrEKVLwPl+GbleIBN6UY1PiBSfK0eBJdVAVVJffZzQZuUGzb5Pa8FNnKrI6uedrd8H3PcjkukDHSCw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@swampratnz/agent-base/-/agent-base-0.8.0.tgz",
+      "integrity": "sha512-T0s/Pu32PlmyAgXAz4V3qj4KKeNNvOpZVVmuRRtguE+FePc20XfEjQO4eEm8J3PNYyZYaFut74J+cNnbSeCz8A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.240",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.260",
     "@hapi/boom": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@swampratnz/agent-base": "0.7.0",
+    "@swampratnz/agent-base": "0.8.0",
     "@whiskeysockets/baileys": "6.7.24",
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",

--- a/tests/systemPromptSlots.test.ts
+++ b/tests/systemPromptSlots.test.ts
@@ -220,6 +220,14 @@ test('the top-level slot order is the frozen base constant (charter → guidelin
       'human-style',
       'context',
       'role-note',
+      // Renders only while a super admin has armed the mutating built-ins in
+      // this conversation (agent-base 0.8.0). Its position is load-bearing in
+      // two ways: the arming statement sits with the RBAC framing rather than
+      // among the late style blocks, and because it changes the prompt bytes,
+      // arming forces a fresh session — which is what makes the armed tool
+      // surface reach the model at all (0.7.0's armed turns resumed the
+      // unarmed session and so ran with no shell).
+      'shell-arming',
       'code-policy',
       'response-style',
       'language-preference',


### PR DESCRIPTION
Consumer half of the agent-base 0.8.0 release, which fixes super-admin tool arming.

## Why

Arming shipped inert in 0.7.0. "arm shell" recorded the window and the acknowledgement came back, but the turn that followed RESUMED the session the unarmed message had opened seconds earlier, and a resumed Agent SDK session keeps the configuration it was started with. The armed tool list never reached the model, so Dave correctly answered that he had no shell.

Confirmed on the box rather than inferred: one session row, turn_count 2, same claude_session_id, with a "starting fresh" log line for the unarmed turn and none for the armed one.

agent-base 0.8.0 makes arming visible to the prompt fingerprint -- an armed turn renders a shell-arming slot, so the bytes differ, the session is not resumed, and the fresh session carries the new tool surface.

## This side of it

- **The exact 0.8.0 pin**, written by npm install --save-exact rather than by hand. Hand-editing the version is what left agent-base own lockfile at 0.7.0 and cost two failed publish runs; letting npm write package.json and package-lock.json together is the entire point.
- **PROMPT_SLOT_ORDER gains shell-arming** between role-note and code-policy. This repo pins the slot list element-by-element, which is exactly why agent-base canary went red on its PR -- the pin did its job. It is updated rather than loosened: a version tolerating both lists would have dissolved the cross-repo sequencing friction by weakening a deliberate assertion, which is the pattern flagged in review earlier today as weakened rather than updated.

## Verification

Checked against the published artefact, not the version string -- the distinction that let me over-report the 0.7.0 deploy as verified:

- npm 0.8.0 carries gitHead b4415ed4, the main commit containing the fix.
- The installed dist contains both shell-arming and promptPolicyFor.
- Consumer suites: 99 pass, 0 fail across slot order, byte stability, prompt assembly, personas, agent options and dependency pins. systemPromptSlots was failing before this pin and is green now; dependencyPins confirms the pin is bare-exact, not a caret.
- An unarmed turn stays byte-identical to 0.7.0, so no existing conversation is restarted by the upgrade.
- Typecheck, Prettier and context:check clean.

Merging this also turns agent-base canary green, closing the mutual block: that job builds this repo against agent-base HEAD, and it could not pass until this slot pin landed, while this pin could not land until 0.8.0 was published.

## What this does NOT prove

That arming works. Every check above shows the bytes shipped and the fingerprint changes. Only a live arm shell followed by a real request shows Dave can run a command -- which is how the original bug was found, after my deploy verification reported success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULGfkzvZLCXrDRiz9CsMH7